### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: build-push
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Azure-Samples/holiday-peak-hub/security/code-scanning/6](https://github.com/Azure-Samples/holiday-peak-hub/security/code-scanning/6)

In general, the fix is to explicitly declare a minimal `permissions` block for the workflow or for each job that uses `GITHUB_TOKEN`, usually with `contents: read` unless broader write scopes are clearly needed. This ensures that the token cannot be used by this workflow to perform unintended write actions on the repository, regardless of organization-level defaults.

For this specific workflow, neither `build` nor `push` jobs require repository write access. They only need to read the source code (via `actions/checkout`) and use `secrets.GITHUB_TOKEN` as a password for GHCR. The best fix without changing existing functionality is to add a workflow-level `permissions` block immediately after `name: build-push` setting `contents: read`. This applies to all jobs, keeps the YAML compact, and satisfies CodeQL’s recommendation. No additional imports or actions are required.

Concretely, in `.github/workflows/ci.yml`, insert:

```yaml
permissions:
  contents: read
```

between line 1 (`name: build-push`) and line 3 (`on:`). No other lines need to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
