### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Azure-Samples/holiday-peak-hub/security/code-scanning/5](https://github.com/Azure-Samples/holiday-peak-hub/security/code-scanning/5)

In general, the fix is to declare an explicit `permissions` block in the workflow so that the `GITHUB_TOKEN` has only the scopes required. For this workflow, both jobs check out code (`contents: read`), and the `push` job logs into GHCR and pushes container images, which requires `packages: write`. No steps modify repository contents or issues/PRs, so broader write permissions are unnecessary.

The single best fix is to add a top-level `permissions` block (applies to all jobs) near the top of `.github/workflows/ci.yml`, after the `name` (or `on`) section. This block should set `contents: read` and `packages: write`. This keeps functionality intact: checkout continues to work with read access, and pushing images to GHCR continues to work with package write access. No imports or additional methods are needed because this is purely a YAML configuration change inside the workflow file.

Concretely:
- Edit `.github/workflows/ci.yml`.
- Insert:

  ```yaml
  permissions:
    contents: read
    packages: write
  ```

  between the `on:` block and the `jobs:` block (for clarity and standard layout).  
- No other lines need to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
