### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,8 @@
 name: lint
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Azure-Samples/holiday-peak-hub/security/code-scanning/4](https://github.com/Azure-Samples/holiday-peak-hub/security/code-scanning/4)

In general, fix this by explicitly specifying a least‑privilege `permissions` block either at the workflow root (to apply to all jobs) or at the job level (for more granular control). For a linting workflow that only checks out code and runs local tooling, `contents: read` is typically sufficient.

For this specific file, add a `permissions` block at the top level, alongside `name` and `on`, so it applies to the `lint` job. The block should minimally grant `contents: read`, which allows `actions/checkout` to function while denying unnecessary write permissions. No changes to steps, commands, or additional imports are required, and existing behavior will remain unchanged aside from tightening the token’s permissions.

Concretely: in `.github/workflows/lint.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `name: lint` and the `on:` sections (or immediately before `jobs:` as an alternative, but root‑level is more conventional here). No other files need modification.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
