### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: test
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Azure-Samples/holiday-peak-hub/security/code-scanning/3](https://github.com/Azure-Samples/holiday-peak-hub/security/code-scanning/3)

In general, the fix is to add an explicit `permissions` block that grants only the minimal scopes needed by the workflow. Here, the workflow only checks out repository contents and runs tests; it doesn’t need to write to the repository, manage issues, or modify pull requests. The minimal safe configuration is `contents: read`, which mirrors a read-only default. This can be added at the workflow root (applies to all jobs) or under the `test` job. Adding it at the root keeps the file concise and covers any future jobs unless they explicitly override it.

Concretely, in `.github/workflows/test.yml`, insert a `permissions:` section near the top of the file (after `name: test` and before `on:`) with `contents: read`. No additional imports or dependencies are required, as this is purely a YAML configuration change. Existing functionality remains unchanged: the checkout action and tests will still work because they only require read access to the repository contents.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
