### PR TITLE
Fix for Variable defined multiple times

### DIFF
--- a/lib/src/holiday_peak_lib/agents/base_agent.py
+++ b/lib/src/holiday_peak_lib/agents/base_agent.py
@@ -270,7 +270,6 @@ class BaseRetailAgent(BaseAgent, ABC):
                 )
 
             if evaluation_text.strip().lower() == "upgrade":
-                upgraded_messages = messages
                 if isinstance(messages, list):
                     upgraded_messages = [
                         {


### PR DESCRIPTION
Generally, to fix this kind of issue you remove the redundant assignment so that each variable is only assigned when its value will actually be used. This prevents confusion about which value is in effect and avoids dead stores.

Here, the best fix is to delete the initial `upgraded_messages = messages` assignment at line 273, leaving only the three branches that set `upgraded_messages` based on the type of `messages`. Because the `if/elif/else` chain is exhaustive, `upgraded_messages` is always set before it is passed to `self.__invoke_target`, so no other structural change is required. No imports or new methods are needed, and the rest of the logic, including the call to the LLM with `upgraded_messages`, remains unchanged.

Concretely, in `lib/src/holiday_peak_lib/agents/base_agent.py`, within `BaseRetailAgent.invoke_model`, remove the line `upgraded_messages = messages` (line 273 in the snippet). All other lines stay as they are.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._