### PR TITLE
Fix for Empty except

### DIFF
--- a/lib/src/holiday_peak_lib/agents/foundry.py
+++ b/lib/src/holiday_peak_lib/agents/foundry.py
@@ -177,6 +177,8 @@ class FoundryInvoker:
                 or 0,
             )
         except TypeError:
+            # Some history entries may not be comparable / lack a usable created_at;
+            # if sorting fails, fall back to the original order.
             pass
         telemetry = {
             "endpoint": self.config.endpoint,


### PR DESCRIPTION
General fix: avoid bare `except ...: pass` without explanation by either handling the error meaningfully (e.g., logging, fallback) or adding a clear comment explaining why it is safe to ignore. We should not change the external behavior: on `TypeError` the code should still continue with unsorted `history`.

Best fix here: keep the same behavior (continue with `history` unsorted) but add an explanatory comment in the `except` block so tools and readers understand the intent. To keep dependencies minimal and avoid changing imports, we can rely on a simple inline comment without introducing logging or new packages. Concretely, in `lib/src/holiday_peak_lib/agents/foundry.py`, around lines 172–180, replace the bare `except TypeError: pass` with an `except TypeError:` that contains a short comment saying that sorting is best‑effort and failures are ignored, then a `pass`. This satisfies CodeQL and documents the intended semantics.

No new methods or imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._