### PR TITLE
Fix for Explicit returns mixed with implicit (fall through) returns

### DIFF
--- a/lib/src/holiday_peak_lib/utils/retry.py
+++ b/lib/src/holiday_peak_lib/utils/retry.py
@@ -15,5 +15,9 @@ def async_retry(times: int = 3, delay_seconds: float = 0.1) -> Callable:
                     await asyncio.sleep(delay_seconds)
             if last_error:
                 raise last_error
+            raise RuntimeError(
+                "async_retry wrapper could not obtain a result; "
+                "ensure 'times' is greater than 0 and the wrapped function is callable."
+            )
         return wrapper
     return decorator


### PR DESCRIPTION
In general, to fix mixed implicit/explicit returns, ensure every control-flow path either returns a value of the intended type or raises, and avoid falling off the end of the function body.

Here, the best fix without altering intended functionality is to add an explicit `raise` after the `if last_error:` block. This handles the case where `times <= 0` or all iterations complete without setting `last_error`, preventing an implicit `None` return. A reasonable choice is to raise a `RuntimeError` explaining that no attempt was made or no result was obtained, because the wrapper cannot return a meaningful value in that scenario. We should place this new `raise` directly after the `if last_error:` block in `async_retry`’s inner `wrapper` function, within `lib/src/holiday_peak_lib/utils/retry.py`. No new imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._