### PR TITLE
chore: include truth-ingestion in deploy-azd agent matrix

### DIFF
--- a/.github/workflows/deploy-azd.yml
+++ b/.github/workflows/deploy-azd.yml
@@ -95,6 +95,7 @@ jobs:
           product-management-assortment-optimization
           product-management-consistency-validation
           product-management-normalization-classification
+          truth-ingestion
           EOF
 
           SHARED_CHANGED=false

--- a/docs/implementation/truth-layer-api.md
+++ b/docs/implementation/truth-layer-api.md
@@ -10,6 +10,7 @@ This document describes currently available truth-layer endpoints and planned se
   - `ecommerce-product-detail-enrichment` (enrichment via `/invoke`)
   - `product-management-acp-transformation` (ACP export via `/invoke`)
   - `crud-service` (transactional APIs, including review endpoints used as interim review flow)
+- Deployment behavior: `truth-ingestion` is included in the same `deploy-azd` agent service matrix path as other agent services.
 - Planned but not yet delivered as standalone services in this repository:
   - dedicated Truth HITL service
   - dedicated Truth Export service for protocol variants beyond ACP


### PR DESCRIPTION
## Summary\n- add 	ruth-ingestion to the deploy-azd AGENT_SERVICES matrix\n- document that 	ruth-ingestion follows the standard agent deployment path\n\n## Why\n- ensures truth-ingestion is deployed as a regular agent service in workflow-dispatched and changed-service agent deployments\n\n## Validation\n- APIM sync and health checks already verified in dev during incident recovery