### PR TITLE
fix: persist appgw subnet delegation in shared infra

### DIFF
--- a/.infra/modules/shared-infrastructure/README.md
+++ b/.infra/modules/shared-infrastructure/README.md
@@ -58,6 +58,7 @@ This module creates **ONE instance** of each resource, shared across all service
   - `aks-crud` - 10.0.8.0/24 (CRUD node pool)
   - `apim` - 10.0.9.0/24 (API Management)
   - `private-endpoints` - 10.0.10.0/24 (Private endpoints for PaaS services)
+  - `appgw` - 10.0.11.0/24 (Application Gateway subnet, delegated to `Microsoft.Network/applicationGateways`)
 - **Network Security Groups** - One per subnet
 - **Private Endpoints** - PaaS services are private by default; Azure AI Foundry is the intentional public-access exception
 

--- a/.infra/modules/shared-infrastructure/shared-infrastructure.bicep
+++ b/.infra/modules/shared-infrastructure/shared-infrastructure.bicep
@@ -239,6 +239,7 @@ module vnet 'br/public:avm/res/network/virtual-network:0.7.2' = {
       {
         name: 'appgw'
         addressPrefix: '10.0.11.0/24'
+        delegation: 'Microsoft.Network/applicationGateways'
         networkSecurityGroupResourceId: appGwNsg.outputs.resourceId
       }
       {


### PR DESCRIPTION
## Summary\n- add delegation: Microsoft.Network/applicationGateways to the ppgw subnet in shared infrastructure bicep\n- update shared infrastructure README networking section\n\n## Why\n- fixes recurring provision failures with ApplicationGatewayNetworkIsolationRequiresSubnetDelegation\n- makes subnet configuration deterministic across deployments