### PR TITLE
fix: set azd resource group env for postprovision hooks

### DIFF
--- a/.github/workflows/deploy-azd.yml
+++ b/.github/workflows/deploy-azd.yml
@@ -186,6 +186,8 @@ jobs:
           azd env set AZURE_SUBSCRIPTION_ID "${AZURE_SUBSCRIPTION_ID}" -e "${{ inputs.environment }}"
           azd env set AZURE_LOCATION "${{ inputs.location }}" -e "${{ inputs.environment }}"
           azd env set AZURE_ENV_NAME "${{ inputs.environment }}" -e "${{ inputs.environment }}"
+          azd env set AZURE_RESOURCE_GROUP "${{ inputs.projectName }}-${{ inputs.environment }}-rg" -e "${{ inputs.environment }}"
+          azd env set resourceGroupName "${{ inputs.projectName }}-${{ inputs.environment }}-rg" -e "${{ inputs.environment }}"
 
           azd env set deployShared true -e "${{ inputs.environment }}"
           azd env set deployStatic "${{ inputs.deployStatic }}" -e "${{ inputs.environment }}"


### PR DESCRIPTION
## Summary\n- set AZURE_RESOURCE_GROUP and esourceGroupName during Configure azd environment\n\n## Why\n- postprovision hook resolution failed with 