### PR TITLE
fix: set AKS cluster env in deploy workflow

### DIFF
--- a/.github/workflows/deploy-azd.yml
+++ b/.github/workflows/deploy-azd.yml
@@ -188,6 +188,8 @@ jobs:
           azd env set AZURE_ENV_NAME "${{ inputs.environment }}" -e "${{ inputs.environment }}"
           azd env set AZURE_RESOURCE_GROUP "${{ inputs.projectName }}-${{ inputs.environment }}-rg" -e "${{ inputs.environment }}"
           azd env set resourceGroupName "${{ inputs.projectName }}-${{ inputs.environment }}-rg" -e "${{ inputs.environment }}"
+          azd env set AZURE_AKS_CLUSTER_NAME "${{ inputs.projectName }}-${{ inputs.environment }}-aks" -e "${{ inputs.environment }}"
+          azd env set AKS_CLUSTER_NAME "${{ inputs.projectName }}-${{ inputs.environment }}-aks" -e "${{ inputs.environment }}"
 
           azd env set deployShared true -e "${{ inputs.environment }}"
           azd env set deployStatic "${{ inputs.deployStatic }}" -e "${{ inputs.environment }}"


### PR DESCRIPTION
## Summary\n- set AZURE_AKS_CLUSTER_NAME and AKS_CLUSTER_NAME in Configure azd environment\n\n## Why\n- provision postprovision hook fails when AKS cluster name cannot be inferred\n- explicit values make the hook deterministic