### PR TITLE
fix: install kubelogin in deploy workflow

### DIFF
--- a/.github/workflows/deploy-azd.yml
+++ b/.github/workflows/deploy-azd.yml
@@ -181,6 +181,9 @@ jobs:
             --federated-credential-provider github \
             --no-prompt
 
+      - name: Install kubelogin
+        run: az aks install-cli --kubelogin-version latest
+
       - name: Configure azd environment
         run: |
           azd env set AZURE_SUBSCRIPTION_ID "${AZURE_SUBSCRIPTION_ID}" -e "${{ inputs.environment }}"


### PR DESCRIPTION
## Summary\n- install kubelogin before zd provision in deploy workflow\n\n## Why\n- provision postprovision hook requires kubelogin when resolving AKS credentials\n- GitHub runner does not include it by default