### PR TITLE
fix: set execute permission for azd hook scripts

### DIFF
--- a/.github/workflows/deploy-azd.yml
+++ b/.github/workflows/deploy-azd.yml
@@ -184,6 +184,9 @@ jobs:
       - name: Install kubelogin
         run: az aks install-cli --kubelogin-version latest
 
+      - name: Ensure hook scripts executable
+        run: chmod +x ./.infra/azd/hooks/*.sh
+
       - name: Configure azd environment
         run: |
           azd env set AZURE_SUBSCRIPTION_ID "${AZURE_SUBSCRIPTION_ID}" -e "${{ inputs.environment }}"


### PR DESCRIPTION
## Summary\n- add chmod +x ./.infra/azd/hooks/*.sh before zd provision in deploy workflow\n\n## Why\n- postprovision failed with Permission denied on hook scripts in GitHub Linux runner