### PR TITLE
fix: harden foundry deployment hook for unavailable models

### DIFF
--- a/.github/workflows/deploy-azd.yml
+++ b/.github/workflows/deploy-azd.yml
@@ -468,7 +468,7 @@ jobs:
           FOUNDRY_AUTO_ENSURE_ON_STARTUP: "true"
           FOUNDRY_STRICT_ENFORCEMENT: "true"
           MODEL_DEPLOYMENT_NAME_FAST: gpt-5-nano
-          MODEL_DEPLOYMENT_NAME_RICH: gpt-5.2
+          MODEL_DEPLOYMENT_NAME_RICH: gpt-5-nano
           COSMOS_ACCOUNT_URI: ${{ needs.provision.outputs.COSMOS_ACCOUNT_URI }}
           COSMOS_DATABASE: ${{ needs.provision.outputs.COSMOS_DATABASE }}
           REDIS_HOST: ${{ needs.provision.outputs.REDIS_HOST }}

--- a/.infra/azd/hooks/deploy-foundry-models.sh
+++ b/.infra/azd/hooks/deploy-foundry-models.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# Deploys AI model deployments (gpt-5-nano, gpt-5.2) to the AI Services account
+# Deploys required AI model deployments to the AI Services account.
 # after Bicep provisions the AI Foundry project.
 #
 # Usage: deploy-foundry-models.sh [RESOURCE_GROUP] [AI_SERVICES_NAME]
@@ -59,7 +59,7 @@ deploy_model() {
   fi
 
   echo "  [create] Deploying model '$MODEL_NAME' as '$DEPLOYMENT_NAME'..."
-  az cognitiveservices account deployment create \
+  if ! az cognitiveservices account deployment create \
     --resource-group "$RESOURCE_GROUP" \
     --name "$AI_SERVICES_NAME" \
     --deployment-name "$DEPLOYMENT_NAME" \
@@ -67,7 +67,10 @@ deploy_model() {
     --model-version "$MODEL_VERSION" \
     --model-format OpenAI \
     --sku-name "$SKU_NAME" \
-    --sku-capacity "$SKU_CAPACITY"
+    --sku-capacity "$SKU_CAPACITY"; then
+    echo "  [warn] Deployment '$DEPLOYMENT_NAME' for model '$MODEL_NAME' is not available in this account/region. Continuing."
+    return 0
+  fi
   echo "  [done] Deployment '$DEPLOYMENT_NAME' created."
 }
 


### PR DESCRIPTION
## Summary\n- make deploy-foundry-models.sh continue when a model deployment is unavailable in region/account\n- set MODEL_DEPLOYMENT_NAME_RICH to gpt-5-nano in deploy workflow for current environment compatibility\n\n## Why\n- postprovision failed on unsupported gpt-5.2 model version\n- deployment should be resilient to regional model availability differences