### PR TITLE
Fix deploy workflow location and kubelogin/hook setup

### DIFF
--- a/.github/workflows/deploy-azd.yml
+++ b/.github/workflows/deploy-azd.yml
@@ -10,7 +10,7 @@ on:
       location:
         description: Azure location
         required: true
-        default: eastus2
+        default: centralus
       projectName:
         description: Project prefix used by naming convention
         required: true
@@ -198,6 +198,12 @@ jobs:
       - name: Ensure hook scripts executable
         run: chmod +x ./.infra/azd/hooks/*.sh
 
+      - name: Install kubelogin
+        run: az aks install-cli --kubelogin-version latest
+
+      - name: Ensure hook scripts executable
+        run: chmod +x ./.infra/azd/hooks/*.sh
+
       - name: Configure azd environment
         run: |
           azd env set AZURE_SUBSCRIPTION_ID "${AZURE_SUBSCRIPTION_ID}" -e "${{ inputs.environment }}"
@@ -298,6 +304,23 @@ jobs:
             --tenant-id "${AZURE_TENANT_ID}" \
             --federated-credential-provider github \
             --no-prompt
+
+      - name: Configure azd environment context
+        run: |
+          azd env set AZURE_SUBSCRIPTION_ID "${AZURE_SUBSCRIPTION_ID}" -e "${{ inputs.environment }}"
+          azd env set AZURE_LOCATION "${{ inputs.location }}" -e "${{ inputs.environment }}"
+          azd env set AZURE_ENV_NAME "${{ inputs.environment }}" -e "${{ inputs.environment }}"
+          azd env set AZURE_RESOURCE_GROUP "${{ inputs.projectName }}-${{ inputs.environment }}-rg" -e "${{ inputs.environment }}"
+          azd env set resourceGroupName "${{ inputs.projectName }}-${{ inputs.environment }}-rg" -e "${{ inputs.environment }}"
+          azd env set AZURE_AKS_CLUSTER_NAME "${{ inputs.projectName }}-${{ inputs.environment }}-aks" -e "${{ inputs.environment }}"
+          azd env set AKS_CLUSTER_NAME "${{ inputs.projectName }}-${{ inputs.environment }}-aks" -e "${{ inputs.environment }}"
+          azd env set AZURE_CONTAINER_REGISTRY_ENDPOINT "${{ inputs.projectName }}${{ inputs.environment }}acr.azurecr.io" -e "${{ inputs.environment }}"
+
+      - name: Install kubelogin
+        run: az aks install-cli --kubelogin-version latest
+
+      - name: Ensure hook scripts executable
+        run: chmod +x ./.infra/azd/hooks/*.sh
 
       - name: Configure azd environment context
         run: |


### PR DESCRIPTION
## Summary
- set deploy workflow default location to centralus to match existing deployment location
- install kubelogin in deploy-crud and deploy-agents jobs
- ensure azd hook scripts are executable in deploy-crud and deploy-agents jobs

## Why
- prevent InvalidDeploymentLocation conflicts in provision
- prevent predeploy hook failures (permission denied + missing kubelogin) during service deploys
