### PR TITLE
Stabilize primary deployment selector for upgrades

### DIFF
--- a/.kubernetes/chart/templates/deployment.yaml
+++ b/.kubernetes/chart/templates/deployment.yaml
@@ -9,9 +9,6 @@ spec:
   selector:
     matchLabels:
       app: {{ .Values.serviceName }}
-      {{- if not .Values.canary.enabled }}
-      canary: "false"
-      {{- end }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
## Summary
- remove canary label from primary Deployment selector matchLabels in shared Helm chart

## Why
- avoid immutable selector upgrade failure for existing deployments created with previous selector shape
