### PR TITLE
Increase Kubernetes probe timeout defaults

### DIFF
--- a/.kubernetes/chart/templates/deployment.yaml
+++ b/.kubernetes/chart/templates/deployment.yaml
@@ -42,6 +42,7 @@ spec:
               port: 8000
             initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds | default 5 }}
             periodSeconds: {{ .Values.probes.startup.periodSeconds | default 10 }}
+            timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds | default 5 }}
             failureThreshold: {{ .Values.probes.startup.failureThreshold | default 30 }}
           {{- end }}
           readinessProbe:
@@ -50,12 +51,14 @@ spec:
               port: 8000
             initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
             periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds | default 5 }}
           livenessProbe:
             httpGet:
               path: {{ .Values.probes.liveness.path }}
               port: 8000
             initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
             periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds | default 5 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
 
@@ -108,6 +111,7 @@ spec:
               port: 8000
             initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds | default 5 }}
             periodSeconds: {{ .Values.probes.startup.periodSeconds | default 10 }}
+            timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds | default 5 }}
             failureThreshold: {{ .Values.probes.startup.failureThreshold | default 30 }}
           {{- end }}
           readinessProbe:
@@ -116,12 +120,14 @@ spec:
               port: 8000
             initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
             periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds | default 5 }}
           livenessProbe:
             httpGet:
               path: {{ .Values.probes.liveness.path }}
               port: 8000
             initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
             periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds | default 5 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
 {{- end }}

--- a/.kubernetes/chart/values.yaml
+++ b/.kubernetes/chart/values.yaml
@@ -43,15 +43,18 @@ probes:
     path: /health
     initialDelaySeconds: 5
     periodSeconds: 10
+    timeoutSeconds: 5
     failureThreshold: 30
   liveness:
     path: /health
     initialDelaySeconds: 10
     periodSeconds: 10
+    timeoutSeconds: 5
   readiness:
     path: /ready
     initialDelaySeconds: 5
     periodSeconds: 10
+    timeoutSeconds: 5
 
 # Node selector for targeting specific node pools
 # For agents: agentpool: agents


### PR DESCRIPTION
## Summary
- add 	imeoutSeconds support to startup/readiness/liveness probes in shared chart template
- set default probe timeout to 5s in chart values

## Why
- deployment rollouts were timing out while /ready exceeded the implicit 1s probe timeout
