### PR TITLE
Use /health readiness probe for crud-service

### DIFF
--- a/.infra/azd/hooks/render-helm.ps1
+++ b/.infra/azd/hooks/render-helm.ps1
@@ -7,6 +7,11 @@ $namespace = if ($env:K8S_NAMESPACE) { $env:K8S_NAMESPACE } else { "holiday-peak
 $imagePrefix = if ($env:IMAGE_PREFIX) { $env:IMAGE_PREFIX } else { "ghcr.io/azure-samples" }
 $imageTag = if ($env:IMAGE_TAG) { $env:IMAGE_TAG } else { "latest" }
 $kedaEnabled = if ($env:KEDA_ENABLED) { $env:KEDA_ENABLED } else { "false" }
+$readinessPath = "/ready"
+
+if ($ServiceName -eq "crud-service") {
+  $readinessPath = "/health"
+}
 
 $serviceImageVarName = "SERVICE_$($ServiceName.ToUpper().Replace('-', '_'))_IMAGE_NAME"
 $serviceImage = [Environment]::GetEnvironmentVariable($serviceImageVarName)
@@ -44,6 +49,8 @@ $helmArgs = @(
   "image.tag=$imageTag",
   '--set',
   "keda.enabled=$kedaEnabled"
+  '--set',
+  "probes.readiness.path=$readinessPath"
 )
 
 $envMappings = @{

--- a/.infra/azd/hooks/render-helm.sh
+++ b/.infra/azd/hooks/render-helm.sh
@@ -9,11 +9,13 @@ IMAGE_TAG="${IMAGE_TAG:-latest}"
 KEDA_ENABLED="${KEDA_ENABLED:-false}"
 INGRESS_ENABLED="${INGRESS_ENABLED:-true}"
 CANARY_ENABLED="${CANARY_ENABLED:-false}"
+READINESS_PATH="/ready"
 
 # Determine workload type (crud-service goes to crud pool, others to agents pool)
 if [ "$SERVICE_NAME" = "crud-service" ]; then
   NODE_POOL="crud"
   WORKLOAD_TYPE="crud"
+  READINESS_PATH="/health"
 else
   NODE_POOL="agents"
   WORKLOAD_TYPE="agents"
@@ -47,6 +49,7 @@ HELM_ARGS="$HELM_ARGS --set image.tag=$IMAGE_TAG"
 HELM_ARGS="$HELM_ARGS --set keda.enabled=$KEDA_ENABLED"
 HELM_ARGS="$HELM_ARGS --set ingress.enabled=$INGRESS_ENABLED"
 HELM_ARGS="$HELM_ARGS --set canary.enabled=$CANARY_ENABLED"
+HELM_ARGS="$HELM_ARGS --set probes.readiness.path=$READINESS_PATH"
 
 # Node pool targeting
 HELM_ARGS="$HELM_ARGS --set nodeSelector.agentpool=$NODE_POOL"


### PR DESCRIPTION
## Summary
- override CRUD readiness probe path to /health in render hooks

## Why
- CRUD rollout repeatedly exceeded progress deadline due /ready probe timeouts on new pods
- /health reflects startup success for rollout gating while preserving liveness checks
