### PR TITLE
Retry CRUD deploy once on transient failure

### DIFF
--- a/.github/workflows/deploy-azd.yml
+++ b/.github/workflows/deploy-azd.yml
@@ -428,7 +428,12 @@ jobs:
           echo "WORKLOAD_AZURE_CLIENT_ID=${AKS_MI_CLIENT_ID}" >> "$GITHUB_ENV"
 
       - name: Deploy CRUD service
-        run: azd deploy --service crud-service --no-prompt -e "${{ inputs.environment }}"
+        run: |
+          if ! azd deploy --service crud-service --no-prompt -e "${{ inputs.environment }}"; then
+            echo "Initial CRUD deploy failed; retrying once after short wait..."
+            sleep 60
+            azd deploy --service crud-service --no-prompt -e "${{ inputs.environment }}"
+          fi
         env:
           AZURE_CLIENT_ID: ${{ env.WORKLOAD_AZURE_CLIENT_ID }}
           AZURE_TENANT_ID: ${{ env.AZURE_TENANT_ID }}


### PR DESCRIPTION
## Summary
- add a single retry for zd deploy --service crud-service in deploy workflow

## Why
- CRUD rollout can continue converging after an initial timeout; one retry reduces false-negative pipeline failures and allows downstream agent deployment stages to execute
