### PR TITLE
chore: harden APIM/CRUD guardrails and networking docs

### DIFF
--- a/.github/workflows/deploy-azd.yml
+++ b/.github/workflows/deploy-azd.yml
@@ -419,6 +419,12 @@ jobs:
             --name "${{ inputs.projectName }}-${{ inputs.environment }}-aks" \
             --overwrite-existing
 
+      - name: Preflight ingress dependencies (App Gateway + AGIC)
+        run: |
+          bash .infra/azd/hooks/preflight-ingress-deps.sh \
+            "${{ inputs.projectName }}-${{ inputs.environment }}-rg" \
+            "${{ inputs.projectName }}-${{ inputs.environment }}-appgw"
+
       - name: Resolve AKS managed identity client ID
         run: |
           AKS_MI_CLIENT_ID=$(az aks show \
@@ -667,6 +673,12 @@ jobs:
             --resource-group "${{ inputs.projectName }}-${{ inputs.environment }}-rg" \
             --name "${{ inputs.projectName }}-${{ inputs.environment }}-aks" \
             --overwrite-existing
+
+      - name: Preflight ingress dependencies (App Gateway + AGIC)
+        run: |
+          bash .infra/azd/hooks/preflight-ingress-deps.sh \
+            "${{ inputs.projectName }}-${{ inputs.environment }}-rg" \
+            "${{ inputs.projectName }}-${{ inputs.environment }}-appgw"
 
       - name: Sync APIM agent APIs
         run: |

--- a/.infra/azd/hooks/preflight-ingress-deps.sh
+++ b/.infra/azd/hooks/preflight-ingress-deps.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 <resource-group> <app-gateway-name>"
+  exit 1
+fi
+
+RG="$1"
+APP_GW_NAME="$2"
+
+APP_GW_STATE=$(az network application-gateway show \
+  --resource-group "$RG" \
+  --name "$APP_GW_NAME" \
+  --query "operationalState" -o tsv 2>/dev/null || true)
+
+if [ "$APP_GW_STATE" != "Running" ]; then
+  echo "App Gateway '$APP_GW_NAME' is not running (state='$APP_GW_STATE')."
+  echo "Start it before deploying/syncing ingress-backed services."
+  echo "Example: az network application-gateway start --resource-group $RG --name $APP_GW_NAME"
+  exit 1
+fi
+
+AGIC_LABEL="app=ingress-appgw"
+AGIC_NAMESPACE="kube-system"
+
+if ! kubectl get pods -n "$AGIC_NAMESPACE" -l "$AGIC_LABEL" >/dev/null 2>&1; then
+  echo "AGIC pod not found in namespace '$AGIC_NAMESPACE' with label '$AGIC_LABEL'."
+  echo "Ingress-backed routing cannot be reconciled without AGIC."
+  exit 1
+fi
+
+READY="$(kubectl get pods -n "$AGIC_NAMESPACE" -l "$AGIC_LABEL" -o jsonpath='{.items[0].status.containerStatuses[0].ready}' 2>/dev/null || true)"
+RESTARTS="$(kubectl get pods -n "$AGIC_NAMESPACE" -l "$AGIC_LABEL" -o jsonpath='{.items[0].status.containerStatuses[0].restartCount}' 2>/dev/null || true)"
+
+if [ "$READY" != "true" ]; then
+  echo "AGIC is not ready (ready='$READY', restarts='$RESTARTS')."
+  echo "Common cause: missing RBAC on App Gateway for AGIC managed identity."
+  echo "Inspect with: kubectl logs -n $AGIC_NAMESPACE -l $AGIC_LABEL --tail=200"
+  exit 1
+fi
+
+echo "Ingress dependency preflight passed."

--- a/.infra/azd/hooks/render-helm.ps1
+++ b/.infra/azd/hooks/render-helm.ps1
@@ -13,6 +13,38 @@ if ($ServiceName -eq "crud-service") {
   $readinessPath = "/health"
 }
 
+if ($ServiceName -ne "crud-service") {
+  $requiredAgentVars = @(
+    'REDIS_URL',
+    'COSMOS_ACCOUNT_URI',
+    'COSMOS_DATABASE',
+    'COSMOS_CONTAINER',
+    'BLOB_ACCOUNT_URL',
+    'BLOB_CONTAINER',
+    'CRUD_SERVICE_URL'
+  )
+  $missingAgentVars = @($requiredAgentVars | Where-Object { -not [Environment]::GetEnvironmentVariable($_) })
+  if ($missingAgentVars.Count -gt 0) {
+    throw "Missing required environment variables for APIM/private-memory standard ($ServiceName): $($missingAgentVars -join ', ')"
+  }
+}
+
+if ($ServiceName -eq "crud-service" -and -not [Environment]::GetEnvironmentVariable('AGENT_APIM_BASE_URL')) {
+  throw "Missing required environment variable for APIM-only standard (crud-service): AGENT_APIM_BASE_URL"
+}
+
+if ($ServiceName -eq "crud-service") {
+  $postgresUser = [Environment]::GetEnvironmentVariable('POSTGRES_USER')
+  $postgresAuthMode = [Environment]::GetEnvironmentVariable('POSTGRES_AUTH_MODE')
+  if (-not $postgresAuthMode) {
+    $postgresAuthMode = 'password'
+  }
+
+  if ($postgresAuthMode -ne 'entra' -and $postgresUser -match '-aks-agentpool$') {
+    throw "Invalid POSTGRES_USER '$postgresUser' for POSTGRES_AUTH_MODE '$postgresAuthMode'. Use the PostgreSQL admin user (for example: crud_admin) for password auth mode."
+  }
+}
+
 $serviceImageVarName = "SERVICE_$($ServiceName.ToUpper().Replace('-', '_'))_IMAGE_NAME"
 $serviceImage = [Environment]::GetEnvironmentVariable($serviceImageVarName)
 
@@ -53,6 +85,15 @@ $helmArgs = @(
   "probes.readiness.path=$readinessPath"
 )
 
+if ($ServiceName -eq "crud-service") {
+  $helmArgs += @(
+    '--set',
+    'service.type=LoadBalancer',
+    '--set-string',
+    'service.annotations.service\.beta\.kubernetes\.io/azure-load-balancer-internal=true'
+  )
+}
+
 $envMappings = @{
   # Database
   POSTGRES_HOST = $env:POSTGRES_HOST
@@ -66,6 +107,8 @@ $envMappings = @{
   EVENT_HUB_NAMESPACE = $env:EVENT_HUB_NAMESPACE
   KEY_VAULT_URI = $env:KEY_VAULT_URI
   REDIS_HOST = $env:REDIS_HOST
+  CRUD_SERVICE_URL = $env:CRUD_SERVICE_URL
+  AGENT_APIM_BASE_URL = $env:AGENT_APIM_BASE_URL
   AZURE_CLIENT_ID = $env:AZURE_CLIENT_ID
   AZURE_TENANT_ID = $env:AZURE_TENANT_ID
 

--- a/.infra/azd/hooks/render-helm.sh
+++ b/.infra/azd/hooks/render-helm.sh
@@ -21,6 +21,34 @@ else
   WORKLOAD_TYPE="agents"
 fi
 
+require_env() {
+  key="$1"
+  value="$(printenv "$key" || true)"
+  if [ -z "$value" ]; then
+    echo "Missing required environment variable: $key" >&2
+    exit 1
+  fi
+}
+
+if [ "$SERVICE_NAME" = "crud-service" ]; then
+  require_env "AGENT_APIM_BASE_URL"
+
+  POSTGRES_USER_VALUE="${POSTGRES_USER:-}"
+  POSTGRES_AUTH_MODE_VALUE="${POSTGRES_AUTH_MODE:-password}"
+  if [ "$POSTGRES_AUTH_MODE_VALUE" != "entra" ] && printf '%s' "$POSTGRES_USER_VALUE" | grep -q -- '-aks-agentpool$'; then
+    echo "Invalid POSTGRES_USER '$POSTGRES_USER_VALUE' for POSTGRES_AUTH_MODE '$POSTGRES_AUTH_MODE_VALUE'. Use the PostgreSQL admin user (for example: crud_admin) for password auth mode." >&2
+    exit 1
+  fi
+else
+  require_env "REDIS_URL"
+  require_env "COSMOS_ACCOUNT_URI"
+  require_env "COSMOS_DATABASE"
+  require_env "COSMOS_CONTAINER"
+  require_env "BLOB_ACCOUNT_URL"
+  require_env "BLOB_CONTAINER"
+  require_env "CRUD_SERVICE_URL"
+fi
+
 SERVICE_IMAGE_VAR_NAME="SERVICE_$(printf '%s' "$SERVICE_NAME" | tr '[:lower:]-' '[:upper:]_')_IMAGE_NAME"
 SERVICE_IMAGE="$(printenv "$SERVICE_IMAGE_VAR_NAME" || true)"
 
@@ -51,6 +79,11 @@ HELM_ARGS="$HELM_ARGS --set ingress.enabled=$INGRESS_ENABLED"
 HELM_ARGS="$HELM_ARGS --set canary.enabled=$CANARY_ENABLED"
 HELM_ARGS="$HELM_ARGS --set probes.readiness.path=$READINESS_PATH"
 
+if [ "$SERVICE_NAME" = "crud-service" ]; then
+  HELM_ARGS="$HELM_ARGS --set service.type=LoadBalancer"
+  HELM_ARGS="$HELM_ARGS --set-string service.annotations.service\\.beta\\.kubernetes\\.io/azure-load-balancer-internal=true"
+fi
+
 # Node pool targeting
 HELM_ARGS="$HELM_ARGS --set nodeSelector.agentpool=$NODE_POOL"
 HELM_ARGS="$HELM_ARGS --set tolerations[0].key=workload"
@@ -78,6 +111,8 @@ add_env_arg "POSTGRES_SSL" "${POSTGRES_SSL:-}"
 add_env_arg "EVENT_HUB_NAMESPACE" "${EVENT_HUB_NAMESPACE:-}"
 add_env_arg "KEY_VAULT_URI" "${KEY_VAULT_URI:-}"
 add_env_arg "REDIS_HOST" "${REDIS_HOST:-}"
+add_env_arg "CRUD_SERVICE_URL" "${CRUD_SERVICE_URL:-}"
+add_env_arg "AGENT_APIM_BASE_URL" "${AGENT_APIM_BASE_URL:-}"
 add_env_arg "AZURE_CLIENT_ID" "${AZURE_CLIENT_ID:-}"
 add_env_arg "AZURE_TENANT_ID" "${AZURE_TENANT_ID:-}"
 

--- a/.infra/azd/hooks/sync-apim-agents.ps1
+++ b/.infra/azd/hooks/sync-apim-agents.ps1
@@ -399,7 +399,7 @@ function Update-CrudApi {
         return
     }
 
-    $backend = Resolve-ServiceBackendUrl -Service $service -Namespace $Ns -RequireLb:$RequireLoadBalancer -Retries $BackendResolveRetries -DelaySeconds $BackendResolveDelaySeconds
+    $backend = Resolve-ServiceBackendUrl -Service $service -Namespace $Ns -RequireLb:$true -Retries $BackendResolveRetries -DelaySeconds $BackendResolveDelaySeconds
 
     $apiExists = $false
     az apim api show --resource-group $Rg --service-name $Apim --api-id 'crud-service' --only-show-errors *> $null

--- a/.infra/azd/hooks/sync-apim-agents.sh
+++ b/.infra/azd/hooks/sync-apim-agents.sh
@@ -262,7 +262,13 @@ ensure_crud_api() {
     return
   fi
 
+  PREV_USE_INGRESS="$USE_INGRESS"
+  PREV_REQUIRE_LOAD_BALANCER="$REQUIRE_LOAD_BALANCER"
+  USE_INGRESS=false
+  REQUIRE_LOAD_BALANCER=true
   BACKEND_URL="$(resolve_backend_url crud-service)"
+  USE_INGRESS="$PREV_USE_INGRESS"
+  REQUIRE_LOAD_BALANCER="$PREV_REQUIRE_LOAD_BALANCER"
 
   if az apim api show --resource-group "$RESOURCE_GROUP" --service-name "$APIM_NAME" --api-id "crud-service" >/dev/null 2>&1; then
     API_ID="crud-service"

--- a/apps/crud-service/src/crud_service/integrations/agent_client.py
+++ b/apps/crud-service/src/crud_service/integrations/agent_client.py
@@ -25,15 +25,31 @@ class AgentClient:
         self.enable_fallback = settings.enable_agent_fallback
 
     def _resolve_agent_url(self, explicit_url: str | None, service_name: str) -> str | None:
-        """Resolve target agent URL using explicit override or APIM path convention."""
-        if explicit_url:
-            return explicit_url.rstrip("/")
-
-        apim_base = settings.agent_apim_base_url
+        """Resolve target agent URL using APIM-only routing."""
+        apim_base = str(settings.agent_apim_base_url or "")
         if not apim_base:
+            logger.warning(
+                "AGENT_APIM_BASE_URL is not configured; skipping agent call",
+                extra={"service_name": service_name},
+            )
             return None
 
-        return f"{apim_base.rstrip('/')}/agents/{service_name}"
+        apim_base = apim_base.rstrip("/")
+        apim_url = f"{apim_base}/agents/{service_name}"
+
+        if explicit_url:
+            normalized_explicit = explicit_url.rstrip("/")
+            if normalized_explicit.startswith(f"{apim_base}/agents/"):
+                return normalized_explicit
+            logger.warning(
+                "Ignoring non-APIM explicit agent URL; enforcing APIM-only routing",
+                extra={
+                    "service_name": service_name,
+                    "explicit_url": normalized_explicit,
+                    "apim_base": apim_base,
+                },
+            )
+        return apim_url
 
     @circuit(
         failure_threshold=settings.agent_circuit_failure_threshold,

--- a/apps/crud-service/tests/unit/test_agent_client_new_methods.py
+++ b/apps/crud-service/tests/unit/test_agent_client_new_methods.py
@@ -292,7 +292,7 @@ class TestGetPersonalization:
 class TestResolveAgentUrl:
     """Tests for AgentClient._resolve_agent_url with APIM fallback."""
 
-    def test_explicit_url_takes_precedence(self, monkeypatch):
+    def test_explicit_apim_url_takes_precedence(self, monkeypatch):
         monkeypatch.setattr(
             agent_client_module.settings,
             "agent_apim_base_url",
@@ -300,13 +300,23 @@ class TestResolveAgentUrl:
         )
 
         client = AgentClient()
-        assert client._resolve_agent_url("http://explicit", "svc") == "http://explicit"
+        assert (
+            client._resolve_agent_url("https://apim.example.com/agents/svc", "svc")
+            == "https://apim.example.com/agents/svc"
+        )
 
-    def test_strips_trailing_slash_from_explicit(self, monkeypatch):
-        monkeypatch.setattr(agent_client_module.settings, "agent_apim_base_url", None)
+    def test_non_apim_explicit_url_is_ignored(self, monkeypatch):
+        monkeypatch.setattr(
+            agent_client_module.settings,
+            "agent_apim_base_url",
+            "https://apim.example.com",
+        )
 
         client = AgentClient()
-        assert client._resolve_agent_url("http://explicit/", "svc") == "http://explicit"
+        assert (
+            client._resolve_agent_url("http://explicit/", "svc")
+            == "https://apim.example.com/agents/svc"
+        )
 
     def test_apim_fallback_when_explicit_is_none(self, monkeypatch):
         monkeypatch.setattr(

--- a/docs/README.md
+++ b/docs/README.md
@@ -67,7 +67,10 @@ gh workflow run deploy-azd.yml -f environment=dev -f location=eastus2 -f project
 
 - Keep `deployShared=true` for all shared-environment rollouts.
 - UI deployment intentionally uses the SWA GitHub Action path (not `azd deploy --service ui`) so App Router dynamic segments (`[id]`, `[slug]`) are built in the same mode as standard SWA workflows.
-- Frontend API calls must always use APIM via `NEXT_PUBLIC_API_URL` (no localhost fallback in UI runtime/build config).
+- Backend communication standard is **APIM-only** for externally reachable service APIs:
+  - Frontend → backend MUST use APIM (`NEXT_PUBLIC_API_URL` / `NEXT_PUBLIC_CRUD_API_URL` / `NEXT_PUBLIC_AGENT_API_URL`).
+  - CRUD synchronous calls → agent REST MUST use APIM (`AGENT_APIM_BASE_URL`), not direct service URLs.
+  - Direct browser/client calls to AKS services, App Gateway backends, pod IPs, or `*.svc.cluster.local` are not allowed.
 - Demo seeding uses a curated catalog of 10 categories and 100 products with realistic retail data. Re-runs are idempotent by item ID (`cat-*`, `prd-*`): existing seeded records are updated instead of duplicated.
 - Use environment approvals in GitHub Environments for `staging`/`prod`.
 - Keep image tags immutable for reproducible rollback.
@@ -224,6 +227,7 @@ az acr update -n <acrName> --public-network-enabled false
 - **[Business Summary](architecture/business-summary.md)** - Business requirements and use cases
 - **[Components Documentation](architecture/components.md)** - All framework and service components
 - **[ADRs (Architecture Decision Records)](architecture/ADRs.md)** - Index of all 20 ADRs
+- **[Backend Networking Standard](governance/backend-networking-standard.md)** - APIM-only routing + private data-plane requirements
 
 ---
 
@@ -254,6 +258,7 @@ az acr update -n <acrName> --public-network-enabled false
 **Networking posture**:
 - Non-prod environments run APIM in VNET `External` mode (public gateway, private backend reachability to AKS).
 - This supports the APIM-in-front pattern while keeping AKS services as `ClusterIP` behind private network paths.
+- Agent memory and CRUD data dependencies (Redis, Cosmos DB, Blob Storage, PostgreSQL) MUST stay private-network reachable from AKS and MUST NOT require direct public-path app access.
 
 ### Application Layer
 **Technology**: FastAPI (Python 3.13)  

--- a/docs/architecture/ADRs.md
+++ b/docs/architecture/ADRs.md
@@ -76,6 +76,11 @@ Each ADR follows a standard template:
 - SLM-first routing for cost optimization ([ADR-013](adrs/adr-013-model-routing.md))
 - Adapter boundaries and composition rules ([ADR-012](adrs/adr-012-adapter-boundaries.md))
 
+### Networking & Security
+- APIM as sole external API gateway, private data-plane dependencies ([ADR-027](adrs/adr-027-apim-only-backend-access.md))
+- AGIC for unified AKS ingress and canary traffic ([ADR-026](adrs/adr-026-agic-traffic-management.md))
+- JWT-based authentication with RBAC ([ADR-019](adrs/adr-019-authentication-rbac.md))
+
 ### Memory & State
 - Three-tier memory (Hot/Warm/Cold) ([ADR-008](adrs/adr-008-memory-tiers.md))
 - Memory partitioning and data placement ([ADR-014](adrs/adr-014-memory-partitioning.md))

--- a/docs/architecture/adrs/adr-027-apim-only-backend-access.md
+++ b/docs/architecture/adrs/adr-027-apim-only-backend-access.md
@@ -1,0 +1,242 @@
+````markdown
+# ADR-027: APIM-Only Backend Access and Private Data-Plane Connectivity
+
+**Status**: Accepted  
+**Date**: 2026-03  
+**Deciders**: Architecture Team, Ricardo Cataldi  
+**Tags**: networking, security, apim, aks, private-endpoints, data-plane
+
+## Context
+
+After implementing AGIC for unified AKS ingress (ADR-026), the architecture had a
+separate, unresolved gap: **who is the authoritative entry point for backend API
+traffic, and how must service dependencies (Redis, Cosmos DB, Blob Storage,
+PostgreSQL) be reached?**
+
+Several inconsistencies were found in the running system:
+
+1. **CRUD-to-agent routing** used explicit service URLs without enforcing that those
+   URLs were APIM-backed, allowing non-APIM paths to slip through silently.
+2. **Frontend environment variables** referenced agent services in some environments
+   via raw App Gateway or internal IPs instead of the APIM gateway URL.
+3. **Agent pods** were occasionally deployed without the required memory dependency
+   environment variables (`REDIS_URL`, `COSMOS_ACCOUNT_URI`, etc.), causing silent
+   degradation at runtime instead of an early deployment failure.
+4. **PostgreSQL** had its public network access enabled in the `dev` environment
+   during a troubleshooting window and was not automatically re-hardened.
+5. **No deployment guardrail** existed to fail fast when any of the required
+   APIM or private-memory environment values were absent.
+
+### Drivers
+
+- **Security posture**: Data services (Redis, Cosmos DB, Blob, Postgres) must not be
+  reachable from the public internet. Exposing them, even temporarily, violates the
+  intended private networking design.
+- **Auditability and observability**: Routing all client-visible API traffic through
+  APIM allows centralized rate limiting, tracing, subscription key management, and
+  policy enforcement. Bypassing APIM removes these controls.
+- **Operational predictability**: Services with missing dependency env vars are harder
+  to debug at runtime. A fail-fast guardrail at deploy time is preferable.
+- **Consistency**: The standard must apply uniformly to all environments (dev, staging,
+  prod) without exception. There should be no "it works differently in dev" carve-outs.
+
+## Decision
+
+**Adopt Azure API Management (APIM) as the sole externally-reachable entry point for
+all backend API traffic. Require all data-plane service dependencies (Redis, Cosmos DB,
+Blob Storage, PostgreSQL) to remain on private networks. Enforce both constraints at
+the deployment layer with fail-fast hooks.**
+
+### Architecture Overview
+
+```mermaid
+graph TD
+    Internet([Public Internet])
+    Internet -->|HTTPS| APIM
+
+    APIM["Azure API Management\n─ Policy enforcement\n─ Rate limiting / auth\n─ Observability & tracing"]
+
+    APIM -->|VNet-integrated backend| AKS
+
+    subgraph AKS["AKS — holiday-peak namespace"]
+        direction TB
+        Frontend["Frontend\n(Next.js)"]
+        CRUD["CRUD Service\n(PostgreSQL)"]
+        Agents["Agent Pods\n(22 services)"]
+        Frontend -->|APIM_BASE_URL| CRUD
+        CRUD -->|AGENT_APIM_BASE_URL /agents/*| Agents
+    end
+
+    Agents -->|private endpoint| Redis[(Redis)]
+    Agents -->|private endpoint| Cosmos[(Cosmos DB)]
+    Agents -->|private endpoint| Blob[(Blob Storage)]
+    CRUD -->|VNet-delegated subnet| Postgres[(PostgreSQL)]
+
+    Prohibited1["✕ Direct client → pod / IP / cluster.local"]
+    Prohibited2["✕ Direct client → App Gateway backend IP"]
+
+    style Prohibited1 fill:#ffcccc,stroke:#cc0000,color:#990000
+    style Prohibited2 fill:#ffcccc,stroke:#cc0000,color:#990000
+```
+
+### Rules
+
+#### Rule 1 — APIM is the only externally-reachable backend entry point
+
+- Frontend env vars (`NEXT_PUBLIC_API_URL`, `NEXT_PUBLIC_CRUD_API_URL`,
+  `NEXT_PUBLIC_AGENT_API_URL`) MUST all point to the APIM gateway URL.
+- CRUD synchronous calls to agent services MUST route via
+  `AGENT_APIM_BASE_URL/agents/{service-name}`.
+- Direct calls to pod IPs, AKS ClusterIP DNS names, App Gateway backend IPs, or
+  internal load balancer addresses from any client outside the cluster are prohibited.
+
+#### Rule 2 — CRUD-to-agent URL resolution is APIM-enforced in code
+
+`_resolve_agent_url()` in `apps/crud-service/src/crud_service/integrations/agent_client.py`
+enforces APIM-only semantics:
+
+- If `AGENT_APIM_BASE_URL` is absent → log warning, return `None` (call skipped).
+- If an explicit non-APIM URL is passed → log warning, ignore it. APIM URL is used.
+- If an APIM-origin explicit URL is passed → accepted (enables per-call path overrides
+  within the same APIM gateway).
+
+This prevents non-APIM routing paths from silently entering the call graph at runtime.
+
+#### Rule 3 — Data-plane dependencies must use private networking
+
+All four data-plane dependencies must be reachable **only** via private networks:
+
+| Dependency   | Private mechanism                    | Port  |
+|--------------|--------------------------------------|-------|
+| Redis        | Private Endpoint + Private DNS zone  | 6380  |
+| Cosmos DB    | Private Endpoint + Private DNS zone  | 443   |
+| Blob Storage | Private Endpoint + Private DNS zone  | 443   |
+| PostgreSQL   | VNet-delegated subnet + Private DNS  | 5432  |
+
+`publicNetworkAccess` MUST remain `Disabled` for all four dependencies.
+Break-glass maintenance windows that temporarily enable public access must
+be tracked as incidents and reversed immediately after.
+
+#### Rule 4 — Required environment variables enforced at deploy time
+
+Helm render hooks (`.infra/azd/hooks/render-helm.ps1` and `render-helm.sh`) fail
+the deployment if any required variable is absent.
+
+Agent services MUST have:
+
+```
+REDIS_URL             # rediss://<host>:<port>/0
+COSMOS_ACCOUNT_URI    # https://<account>.documents.azure.com:443/
+COSMOS_DATABASE
+COSMOS_CONTAINER
+BLOB_ACCOUNT_URL      # https://<account>.blob.core.windows.net
+BLOB_CONTAINER
+CRUD_SERVICE_URL      # must equal APIM gateway base URL
+```
+
+CRUD service MUST have:
+
+```
+AGENT_APIM_BASE_URL   # must equal APIM gateway base URL
+```
+
+Missing values cause the hook to exit non-zero, blocking `azd deploy` before any
+Kubernetes manifests are applied.
+
+### Verification Protocol
+
+After each deployment the following checks must pass:
+
+1. **APIM reachability**: `GET /api/health`, `GET /agents/{agent}/health` →  HTTP 200.
+2. **Env compliance audit** (PowerShell/shell script): all required vars present in every
+   running deployment → `ENV_COMPLIANCE=PASS`.
+3. **In-pod private connectivity probe** (representative agent pod): DNS resolves to
+   `10.x.x.x`, TCP connect succeeds on correct port for Redis/Cosmos/Blob.
+4. **CRUD pod private connectivity**: `POSTGRES_HOST` DNS + TCP connect succeeds from
+   within cluster.
+5. **Network posture check**: `az postgres flexible-server show` confirms
+   `publicNetworkAccess=Disabled`.
+
+## Consequences
+
+### Positive
+
+- **Consistent security boundary**: all external API traffic passes through a single
+  policy-enforcement point (APIM). No accidental bypass paths exist.
+- **Centralized observability**: rate limiting, tracing, and subscription management
+  apply uniformly to every backend API call.
+- **Reduced blast radius**: private-only data-plane dependencies cannot be reached
+  from the public internet, even if a pod is compromised or misconfigured.
+- **Fail-fast deployments**: missing required env vars cause deployment failure before
+  any pod is restarted, making configuration drift visible immediately.
+- **Enforced in code**: CRUD agent client rejects non-APIM routing at the code level,
+  not only at the infrastructure level.
+
+### Negative
+
+- **APIM is a critical path dependency**: if APIM is unavailable, all external backend
+  API access is unavailable. Mitigated by APIM Premium tier with availability zone
+  support.
+- **Deployment requires complete env setup**: developers cannot use `azd deploy` until
+  all required APIM and memory env vars are set. Mitigated by documented baseline env
+  setup in `.infra/azd/` and `docs/governance/backend-networking-standard.md`.
+- **Local development workaround needed**: local development (outside AKS) requires
+  either `azd env set` with real values or a local mock of the APIM URL. Port-forward
+  workflows still work for dev testing.
+
+### Neutral
+
+- **AGIC is the intra-cluster router; APIM is the external gateway**: both exist at
+  different layers. APIM routes to the App Gateway IP; App Gateway routes to ClusterIP
+  services via AGIC ingress rules. These are complementary, not competing.
+- **MCP tool traffic is agent-to-agent** and does not pass through APIM. MCP endpoints
+  are internal only (`/mcp/*` on ClusterIP services). This is by design (ADR-010).
+
+## Implementation Checklist
+
+- [x] `_resolve_agent_url()` rewritten to APIM-only semantics
+- [x] Unit tests updated for new URL resolution behavior (20 tests passing)
+- [x] `render-helm.ps1` fail-fast guardrails for required env vars
+- [x] `render-helm.sh` fail-fast guardrails for required env vars
+- [x] `AGENT_APIM_BASE_URL` and `CRUD_SERVICE_URL` propagated in render hooks
+- [x] All agentic deployments updated with required env vars
+- [x] `ENV_COMPLIANCE=PASS` validated across all deployments
+- [x] In-pod private connectivity validated (Redis/Cosmos/Blob via `10.x` IPs)
+- [x] PostgreSQL `publicNetworkAccess=Disabled`
+- [x] APIM smoke test: CRUD + representative agents returning HTTP 200
+- [x] `docs/governance/backend-networking-standard.md` created
+
+## Alternatives Considered
+
+### 1. Allow direct App Gateway access without APIM
+
+Rejected. Loses centralized policy enforcement (rate limiting, auth, observability).
+Also makes the API surface inconsistent between environments where App Gateway IP
+can change.
+
+### 2. Allow CRUD-to-agent calls via internal ClusterIP DNS
+
+Rejected. Although lower latency, this bypasses APIM policy for inter-service calls,
+creates a hidden dependency on internal DNS naming that differs from external routing,
+and makes tracing of agent invocations from CRUD invisible in APIM analytics.
+
+### 3. Soft enforcement (warn-only for missing env vars)
+
+Rejected. Silent degradation is worse than a failed deployment. A warn-only approach
+was the status quo that led to services running without memory dependencies set.
+
+### 4. Public endpoints for Redis/Cosmos/Blob with IP firewall rules
+
+Rejected. Firewall rules based on IPs are brittle in AKS (node pools can get new IPs
+on scaling events) and still expose the control plane to public internet scanning.
+Private endpoints are the correct model for production and dev parity.
+
+## References
+
+- [ADR-009: AKS Deployment Architecture](adr-009-aks-deployment.md)
+- [ADR-021: azd-First Deployment](adr-021-azd-first-deployment.md)
+- [ADR-026: AGIC Traffic Management](adr-026-agic-traffic-management.md)
+- [Backend Networking Standard](../../governance/backend-networking-standard.md)
+- [Azure APIM VNet Integration](https://learn.microsoft.com/azure/api-management/virtual-network-concepts)
+- [Azure Private Endpoints](https://learn.microsoft.com/azure/private-link/private-endpoint-overview)
+````

--- a/docs/governance/backend-networking-standard.md
+++ b/docs/governance/backend-networking-standard.md
@@ -1,0 +1,66 @@
+# Backend Networking Standard
+
+## Scope
+
+This standard applies to all environments and all backend services in this repository:
+
+- Frontend (`apps/ui`)
+- CRUD service (`apps/crud-service`)
+- Agentic services (`apps/*` on AKS)
+- Shared data dependencies (Redis, Cosmos DB, Blob Storage, PostgreSQL)
+
+## Mandatory Rules
+
+1. **APIM-only backend API access**
+   - All client-visible backend API traffic MUST go through Azure API Management (APIM).
+   - Frontend calls MUST target APIM URLs (`NEXT_PUBLIC_API_URL`, `NEXT_PUBLIC_CRUD_API_URL`, `NEXT_PUBLIC_AGENT_API_URL`).
+   - CRUD synchronous calls to agents MUST route via APIM (`AGENT_APIM_BASE_URL`).
+
+2. **No direct backend API access from clients**
+   - Direct client calls to AKS services, pod IPs, internal DNS names (`*.svc.cluster.local`), or App Gateway backend IPs are prohibited.
+
+3. **Private data-plane dependency connectivity**
+   - Redis, Cosmos DB, Blob Storage, and PostgreSQL MUST be reachable from AKS via private networking (Private Endpoint + private DNS / VNet-integrated path).
+   - Public network access for these dependencies should remain disabled unless an approved break-glass maintenance window is active.
+
+4. **Deployment guardrails**
+   - Helm render hooks MUST fail fast when required APIM/memory environment values are missing.
+   - CRUD service manifests MUST render the Kubernetes service as an internal load balancer (`service.type=LoadBalancer` with `service.beta.kubernetes.io/azure-load-balancer-internal=true`) so APIM can target a stable private backend.
+   - APIM CRUD backend sync MUST resolve to a load balancer endpoint and must not fall back to ClusterIP or `*.svc.cluster.local` targets.
+   - For agent services, required env values include:
+     - `REDIS_URL`
+     - `COSMOS_ACCOUNT_URI`
+     - `COSMOS_DATABASE`
+     - `COSMOS_CONTAINER`
+     - `BLOB_ACCOUNT_URL`
+     - `BLOB_CONTAINER`
+     - `CRUD_SERVICE_URL`
+   - For CRUD, required env value includes:
+     - `AGENT_APIM_BASE_URL`
+   - For CRUD in password auth mode, `POSTGRES_USER` MUST be the PostgreSQL admin/user principal (for example `crud_admin`) and not a managed identity-style AKS principal value.
+
+## Baseline Environment Values
+
+At minimum, each deployed environment must define:
+
+- `APIM_GATEWAY_URL` / `NEXT_PUBLIC_API_URL`
+- `AGENT_APIM_BASE_URL`
+- `REDIS_URL`
+- `COSMOS_ACCOUNT_URI`
+- `COSMOS_DATABASE`
+- `COSMOS_CONTAINER`
+- `BLOB_ACCOUNT_URL`
+- `BLOB_CONTAINER`
+- `CRUD_SERVICE_URL` (APIM-routed CRUD base)
+
+## Verification Checklist
+
+- APIM routes respond for CRUD (`/api/*`) and agents (`/agents/*`).
+- Agent pods have memory env variables populated.
+- CRUD has `AGENT_APIM_BASE_URL` populated.
+- AKS pod DNS/TCP checks for Cosmos/Blob/Postgres/Redis succeed against private endpoints.
+- Resource network posture confirms private endpoint usage and no accidental public exposure.
+
+## Enforcement Notes
+
+This repository enforces the standard through deployment hooks and runtime URL resolution logic. If required values are missing, deployment should fail early instead of silently degrading to non-standard routing.


### PR DESCRIPTION
## Summary\n- enforce APIM/CRUD backend guardrails in deploy hooks\n- force CRUD APIM backend resolution to LB-only\n- add ingress preflight hook and governance ADR/docs updates\n- update CRUD agent client APIM-only URL behavior tests\n\n## Verification\n- APIM smoke checks: CRUD + representative agents all 200\n- pytest apps/crud-service/tests/unit/test_agent_client_new_methods.py (20 passed)