### PR TITLE
hotfix(#126): lowercase GHCR tag path in CI build-push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,11 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Build images
         run: |
+          registry=$(echo "$REGISTRY" | tr '[:upper:]' '[:lower:]')
           for d in apps/*; do
             [ -d "$d" ] || continue
             image_name=$(basename "$d")
-            docker build -t "$REGISTRY/$image_name:latest" -f "$d/src/Dockerfile" "$d"
+            docker build -t "$registry/$image_name:latest" -f "$d/src/Dockerfile" "$d"
           done
 
   push:
@@ -42,9 +43,10 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push images
         run: |
+          registry=$(echo "$REGISTRY" | tr '[:upper:]' '[:lower:]')
           for d in apps/*; do
             [ -d "$d" ] || continue
             image_name=$(basename "$d")
-            docker build -t "$REGISTRY/$image_name:latest" -f "$d/src/Dockerfile" "$d"
-            docker push "$REGISTRY/$image_name:latest"
+            docker build -t "$registry/$image_name:latest" -f "$d/src/Dockerfile" "$d"
+            docker push "$registry/$image_name:latest"
           done


### PR DESCRIPTION
## Summary
- Fix Docker tag generation in .github/workflows/ci.yml by normalizing REGISTRY to lowercase before build/push.
- Prevents invalid tag ... repository name must be lowercase failures in uild-push.

## Validation
- Verified diff is limited to workflow logic in ci.yml.
- Change is non-functional for app code; impacts CI tagging only.

## Context
- Follow-up to merged PR #126 where post-merge uild-push failed due to uppercase owner in GHCR path.