### PR TITLE
hotfix(ci): fix build-push Docker context for app images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,9 @@ jobs:
           registry=$(echo "$REGISTRY" | tr '[:upper:]' '[:lower:]')
           for d in apps/*; do
             [ -d "$d" ] || continue
+            [ -f "$d/src/Dockerfile" ] || continue
             image_name=$(basename "$d")
-            docker build -t "$registry/$image_name:latest" -f "$d/src/Dockerfile" "$d"
+            docker build -t "$registry/$image_name:latest" -f "$d/src/Dockerfile" "$d/src"
           done
 
   push:
@@ -46,7 +47,8 @@ jobs:
           registry=$(echo "$REGISTRY" | tr '[:upper:]' '[:lower:]')
           for d in apps/*; do
             [ -d "$d" ] || continue
+            [ -f "$d/src/Dockerfile" ] || continue
             image_name=$(basename "$d")
-            docker build -t "$registry/$image_name:latest" -f "$d/src/Dockerfile" "$d"
+            docker build -t "$registry/$image_name:latest" -f "$d/src/Dockerfile" "$d/src"
             docker push "$registry/$image_name:latest"
           done


### PR DESCRIPTION
## Summary
- Use pps/<service>/src as Docker build context in .github/workflows/ci.yml.
- Skip directories that do not have src/Dockerfile.
- Keep the prior lowercase GHCR registry normalization.

## Why
uild-push still failed after tag casing fix because Dockerfiles copy pyproject.toml from context root, and context was pps/<service> while file is in pps/<service>/src.

## Expected outcome
- uild-push no longer fails with /pyproject.toml: not found.
