### PR TITLE
chore(ci): apply deploy hooks only to changed services

### DIFF
--- a/.github/workflows/deploy-azd.yml
+++ b/.github/workflows/deploy-azd.yml
@@ -57,6 +57,8 @@ jobs:
       ui_changed: ${{ steps.detect.outputs.ui_changed }}
       agents_changed: ${{ steps.detect.outputs.agents_changed }}
       changed_agents_matrix: ${{ steps.detect.outputs.changed_agents_matrix }}
+      changed_agent_services_csv: ${{ steps.detect.outputs.changed_agent_services_csv }}
+      changed_aks_services_csv: ${{ steps.detect.outputs.changed_aks_services_csv }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -115,12 +117,13 @@ jobs:
 
           AGENTS_CHANGED=false
           MATRIX='[]'
+          CHANGED_AGENTS=()
 
           if [ "$SHARED_CHANGED" = true ]; then
             AGENTS_CHANGED=true
+            CHANGED_AGENTS=("${AGENT_SERVICES[@]}")
             MATRIX=$(printf '%s\n' "${AGENT_SERVICES[@]}" | jq -R . | jq -s 'map({service: .})')
           else
-            CHANGED_AGENTS=()
             for service in "${AGENT_SERVICES[@]}"; do
               if echo "$CHANGED_FILES" | grep -Eq "^apps/$service/"; then
                 CHANGED_AGENTS+=("$service")
@@ -133,10 +136,26 @@ jobs:
             fi
           fi
 
+          CHANGED_AGENT_SERVICES_CSV=""
+          if [ ${#CHANGED_AGENTS[@]} -gt 0 ]; then
+            CHANGED_AGENT_SERVICES_CSV=$(IFS=,; echo "${CHANGED_AGENTS[*]}")
+          fi
+
+          CHANGED_AKS_SERVICES_CSV="$CHANGED_AGENT_SERVICES_CSV"
+          if [ "$CRUD_CHANGED" = true ]; then
+            if [ -n "$CHANGED_AKS_SERVICES_CSV" ]; then
+              CHANGED_AKS_SERVICES_CSV="crud-service,$CHANGED_AKS_SERVICES_CSV"
+            else
+              CHANGED_AKS_SERVICES_CSV="crud-service"
+            fi
+          fi
+
           echo "crud_changed=$CRUD_CHANGED" >> "$GITHUB_OUTPUT"
           echo "ui_changed=$UI_CHANGED" >> "$GITHUB_OUTPUT"
           echo "agents_changed=$AGENTS_CHANGED" >> "$GITHUB_OUTPUT"
           echo "changed_agents_matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+          echo "changed_agent_services_csv=$CHANGED_AGENT_SERVICES_CSV" >> "$GITHUB_OUTPUT"
+          echo "changed_aks_services_csv=$CHANGED_AKS_SERVICES_CSV" >> "$GITHUB_OUTPUT"
 
   provision:
     if: ${{ !inputs.uiOnly }}
@@ -347,7 +366,9 @@ jobs:
 
   deploy-crud:
     runs-on: ubuntu-latest
-    needs: provision
+    needs:
+      - provision
+      - detect-changes
     if: ${{ !inputs.uiOnly && (!inputs.deployChangedOnly || needs.detect-changes.outputs.crud_changed == 'true') }}
     environment: ${{ inputs.environment }}
     env:
@@ -454,7 +475,9 @@ jobs:
   deploy-ui:
     runs-on: ubuntu-latest
     if: ${{ inputs.deployStatic && !inputs.uiOnly && (!inputs.deployChangedOnly || needs.detect-changes.outputs.ui_changed == 'true') }}
-    needs: provision
+    needs:
+      - provision
+      - detect-changes
     environment: ${{ inputs.environment }}
     env:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
@@ -574,6 +597,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !inputs.uiOnly && (!inputs.deployChangedOnly || needs.detect-changes.outputs.agents_changed == 'true') }}
     needs:
+      - provision
       - deploy-crud
       - deploy-foundry-models
       - detect-changes
@@ -645,12 +669,17 @@ jobs:
 
   sync-apim:
     runs-on: ubuntu-latest
-    needs: deploy-agents
+    if: ${{ !inputs.uiOnly && (!inputs.deployChangedOnly || needs.detect-changes.outputs.agents_changed == 'true' || needs.detect-changes.outputs.crud_changed == 'true') && (needs.deploy-crud.result == 'success' || needs.deploy-crud.result == 'skipped') && (needs.deploy-agents.result == 'success' || needs.deploy-agents.result == 'skipped') }}
+    needs:
+      - deploy-crud
+      - deploy-agents
+      - detect-changes
     environment: ${{ inputs.environment }}
     env:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      CHANGED_SERVICES: ${{ inputs.deployChangedOnly && needs.detect-changes.outputs.changed_aks_services_csv || '' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -677,12 +706,16 @@ jobs:
 
   ensure-foundry-agents:
     runs-on: ubuntu-latest
-    needs: deploy-agents
+    if: ${{ !inputs.uiOnly && (!inputs.deployChangedOnly || needs.detect-changes.outputs.agents_changed == 'true') && (needs.deploy-agents.result == 'success' || needs.deploy-agents.result == 'skipped') }}
+    needs:
+      - deploy-agents
+      - detect-changes
     environment: ${{ inputs.environment }}
     env:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      CHANGED_SERVICES: ${{ inputs.deployChangedOnly && needs.detect-changes.outputs.changed_agent_services_csv || '' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -713,27 +746,31 @@ jobs:
 
       - name: Verify Foundry readiness across services
         run: |
-          SERVICES=$(python3 -c "
-          import re
-          with open('azure.yaml') as f: lines = f.readlines()
-          s, cs, ch = False, None, None
-          svcs = []
-          for l in lines:
-            l = l.rstrip()
-            if not s:
-              if re.match(r'^services:\s*$', l): s = True
-              continue
-            if re.match(r'^[^\s]', l): break
-            m = re.match(r'^  ([a-z0-9\-]+):\s*$', l)
-            if m:
-              if cs and ch == 'aks' and cs != 'crud-service': svcs.append(cs)
-              cs, ch = m.group(1), None
-              continue
-            h = re.match(r'^    host:\s*(\S+)', l)
-            if h: ch = h.group(1)
-          if cs and ch == 'aks' and cs != 'crud-service': svcs.append(cs)
-          print('\n'.join(svcs))
-          ")
+          if [ -n "${CHANGED_SERVICES}" ]; then
+            SERVICES=$(printf '%s' "${CHANGED_SERVICES}" | tr ',' '\n' | sed '/^crud-service$/d' | sed '/^$/d')
+          else
+            SERVICES=$(python3 -c "
+            import re
+            with open('azure.yaml') as f: lines = f.readlines()
+            s, cs, ch = False, None, None
+            svcs = []
+            for l in lines:
+              l = l.rstrip()
+              if not s:
+                if re.match(r'^services:\s*$', l): s = True
+                continue
+              if re.match(r'^[^\s]', l): break
+              m = re.match(r'^  ([a-z0-9\-]+):\s*$', l)
+              if m:
+                if cs and ch == 'aks' and cs != 'crud-service': svcs.append(cs)
+                cs, ch = m.group(1), None
+                continue
+              h = re.match(r'^    host:\s*(\S+)', l)
+              if h: ch = h.group(1)
+            if cs and ch == 'aks' and cs != 'crud-service': svcs.append(cs)
+            print('\\n'.join(svcs))
+            ")
+          fi
 
           FAILED=0
           echo "$SERVICES" | while IFS= read -r SVC; do

--- a/.infra/azd/hooks/ensure-foundry-agents.ps1
+++ b/.infra/azd/hooks/ensure-foundry-agents.ps1
@@ -33,6 +33,7 @@ param(
     [switch]$UsePortForward,
     [string]$BaseUrl,
     [string]$AzureYamlPath,
+    [string]$ChangedServices = $env:CHANGED_SERVICES,
     [int]$MaxRetries = 3,
     [bool]$FailOnError = $false
 )
@@ -140,6 +141,17 @@ function Resolve-K8sServiceEndpoint {
 
 # ---- Main ----
 $services = Get-AgentServices -Path $AzureYamlPath
+
+if ($ChangedServices) {
+    $changedServiceSet = $ChangedServices.Split(',') | ForEach-Object { $_.Trim() } | Where-Object { $_ }
+    $services = @($services | Where-Object { $changedServiceSet -contains $_ })
+}
+
+if (-not $services -or $services.Count -eq 0) {
+    Write-Host 'No matching changed agent services to ensure.'
+    exit 0
+}
+
 Write-Host "Found $($services.Count) agent services to ensure."
 
 $failed = @()

--- a/.infra/azd/hooks/ensure-foundry-agents.sh
+++ b/.infra/azd/hooks/ensure-foundry-agents.sh
@@ -15,6 +15,7 @@ MAX_RETRIES="${MAX_RETRIES:-3}"
 USE_PORT_FORWARD=false
 BASE_URL=""
 FAIL_ON_ERROR="${FAIL_ON_ERROR:-false}"
+CHANGED_SERVICES="${CHANGED_SERVICES:-}"
 
 # ---- Parse arguments ----
 while [ $# -gt 0 ]; do
@@ -65,6 +66,23 @@ PY
 
 if [ -z "$SERVICES" ]; then
   echo "No agent services found in azure.yaml."
+  exit 0
+fi
+
+if [ -n "$CHANGED_SERVICES" ]; then
+  FILTER_FILE="$(mktemp)"
+  printf '%s' "$CHANGED_SERVICES" | tr ',' '\n' | sed '/^[[:space:]]*$/d' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' > "$FILTER_FILE"
+  SERVICES="$(printf '%s\n' "$SERVICES" | while IFS= read -r SVC; do
+    [ -z "$SVC" ] && continue
+    if grep -Fxq "$SVC" "$FILTER_FILE"; then
+      printf '%s\n' "$SVC"
+    fi
+  done)"
+  rm -f "$FILTER_FILE"
+fi
+
+if [ -z "$SERVICES" ]; then
+  echo "No matching changed agent services to ensure."
   exit 0
 fi
 

--- a/.infra/azd/hooks/sync-apim-agents.ps1
+++ b/.infra/azd/hooks/sync-apim-agents.ps1
@@ -3,6 +3,7 @@ param(
     [string]$ApimName = $env:APIM_NAME,
     [string]$Namespace = $(if ($env:K8S_NAMESPACE) { $env:K8S_NAMESPACE } else { 'holiday-peak' }),
     [string]$AzureYamlPath,
+    [string]$ChangedServices = $env:CHANGED_SERVICES,
     [string]$ApiPathPrefix = 'agents',
     [bool]$IncludeCrudService = $true,
     [bool]$RequireLoadBalancer = $true,
@@ -522,8 +523,14 @@ $script:resolvedAksClusterName = Get-AksClusterName -Rg $resolvedResourceGroup -
 Ensure-AksCredentials -Rg $resolvedResourceGroup -RepoRoot $repoRoot -SkipForPreview:$Preview
 
 $agentServices = Get-AksServicesFromAzureYaml -Path $AzureYamlPath -IncludeCrud:$IncludeCrudService
+
+if ($ChangedServices) {
+    $changedServiceSet = $ChangedServices.Split(',') | ForEach-Object { $_.Trim() } | Where-Object { $_ }
+    $agentServices = @($agentServices | Where-Object { $changedServiceSet -contains $_ })
+}
+
 if (-not $agentServices -or $agentServices.Count -eq 0) {
-    Write-Host 'No AKS agent services were found in azure.yaml. Nothing to sync.'
+    Write-Host 'No matching changed AKS services to sync.'
     exit 0
 }
 

--- a/.infra/azd/hooks/sync-apim-agents.sh
+++ b/.infra/azd/hooks/sync-apim-agents.sh
@@ -6,6 +6,7 @@ REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
 AZURE_YAML_PATH="${AZURE_YAML_PATH:-$REPO_ROOT/azure.yaml}"
 NAMESPACE="${K8S_NAMESPACE:-holiday-peak}"
 API_PATH_PREFIX="${API_PATH_PREFIX:-agents}"
+CHANGED_SERVICES="${CHANGED_SERVICES:-}"
 RESOURCE_GROUP="${AZURE_RESOURCE_GROUP:-${RESOURCE_GROUP:-}}"
 APIM_NAME="${APIM_NAME:-}"
 AKS_CLUSTER_NAME="${AKS_CLUSTER_NAME:-}"
@@ -166,6 +167,23 @@ PY
 
 if [ -z "$SERVICES" ]; then
   echo "No AKS agent services were found in azure.yaml. Nothing to sync."
+  exit 0
+fi
+
+if [ -n "$CHANGED_SERVICES" ]; then
+  FILTER_FILE="$(mktemp)"
+  printf '%s' "$CHANGED_SERVICES" | tr ',' '\n' | sed '/^[[:space:]]*$/d' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' > "$FILTER_FILE"
+  SERVICES="$(printf '%s\n' "$SERVICES" | while IFS= read -r SERVICE; do
+    [ -z "$SERVICE" ] && continue
+    if grep -Fxq "$SERVICE" "$FILTER_FILE"; then
+      printf '%s\n' "$SERVICE"
+    fi
+  done)"
+  rm -f "$FILTER_FILE"
+fi
+
+if [ -z "$SERVICES" ]; then
+  echo "No matching changed AKS services to sync."
   exit 0
 fi
 

--- a/docs/implementation/README.md
+++ b/docs/implementation/README.md
@@ -149,6 +149,14 @@ Target: **100%**
 
 ---
 
+## Deployment Optimization
+
+- `deploy-azd` changed-service detection now publishes changed agent and AKS service lists.
+- Post-deploy hooks (`sync-apim-agents` and `ensure-foundry-agents`) consume these lists through `CHANGED_SERVICES` and run only for changed services when `deployChangedOnly=true`.
+- Foundry readiness verification in deployment workflow is scoped to changed agent services under changed-only mode.
+
+---
+
 ## Related Documentation
 
 - [Architecture Overview](../architecture/architecture.md)


### PR DESCRIPTION
## Summary
- Add changed-service outputs in detect-changes (changed_agent_services_csv, changed_aks_services_csv).
- Scope sync-apim and nsure-foundry-agents jobs to changed services when deployChangedOnly=true.
- Add CHANGED_SERVICES filtering support to both shell and PowerShell hooks:
  - .infra/azd/hooks/sync-apim-agents.(sh|ps1)
  - .infra/azd/hooks/ensure-foundry-agents.(sh|ps1)
- Scope Foundry readiness verification loop in workflow to changed agent services.
- Fix workflow 
eeds references where detect-changes/provision contexts are used.
- Update implementation docs with changed-service hook behavior.

## Why
Post-deploy hooks were still applying to all services even in changed-only deployments, increasing runtime and causing unnecessary APIM/Foundry operations.

## Validation
- Workflow and hook files validated for syntax via editor diagnostics.
- No runtime behavior change when deployChangedOnly=false (hooks continue to run across all services).
