### PR TITLE
bug: switch from AGIC to AKS Web Application Routing to fix crud-service deploy (#191)

### DIFF
--- a/.infra/modules/shared-infrastructure/shared-infrastructure.bicep
+++ b/.infra/modules/shared-infrastructure/shared-infrastructure.bicep
@@ -35,7 +35,6 @@ var keyVaultName = empty(keyVaultNameOverride)
   ? take('${projectName}${envSuffix}-kv', 24)
   : toLower(keyVaultNameOverride)
 var apimName = '${projectName}${envSuffix}-apim'
-var appGwName = '${projectName}${envSuffix}-appgw'
 var appInsightsName = '${projectName}${envSuffix}-insights'
 var logAnalyticsName = '${projectName}${envSuffix}-logs'
 var vnetName = '${projectName}${envSuffix}-vnet'
@@ -95,69 +94,7 @@ module aksCrudNsg 'br/public:avm/res/network/network-security-group:0.5.2' = {
   }
 }
 
-// Application Gateway NSG for AGIC (required for ingress traffic)
-module appGwNsg 'br/public:avm/res/network/network-security-group:0.5.2' = {
-  name: 'nsg-appgw'
-  params: {
-    name: 'appgw-nsg'
-    location: location
-    securityRules: [
-      {
-        name: 'AllowGatewayManager'
-        properties: {
-          protocol: 'Tcp'
-          sourcePortRange: '*'
-          destinationPortRange: '65200-65535'
-          sourceAddressPrefix: 'GatewayManager'
-          destinationAddressPrefix: '*'
-          access: 'Allow'
-          priority: 100
-          direction: 'Inbound'
-        }
-      }
-      {
-        name: 'AllowHTTP'
-        properties: {
-          protocol: 'Tcp'
-          sourcePortRange: '*'
-          destinationPortRange: '80'
-          sourceAddressPrefix: 'Internet'
-          destinationAddressPrefix: '*'
-          access: 'Allow'
-          priority: 110
-          direction: 'Inbound'
-        }
-      }
-      {
-        name: 'AllowHTTPS'
-        properties: {
-          protocol: 'Tcp'
-          sourcePortRange: '*'
-          destinationPortRange: '443'
-          sourceAddressPrefix: 'Internet'
-          destinationAddressPrefix: '*'
-          access: 'Allow'
-          priority: 120
-          direction: 'Inbound'
-        }
-      }
-      {
-        name: 'AllowAzureLoadBalancer'
-        properties: {
-          protocol: '*'
-          sourcePortRange: '*'
-          destinationPortRange: '*'
-          sourceAddressPrefix: 'AzureLoadBalancer'
-          destinationAddressPrefix: '*'
-          access: 'Allow'
-          priority: 130
-          direction: 'Inbound'
-        }
-      }
-    ]
-    tags: tags
-  }
-}
+
 
 module apimNsg 'br/public:avm/res/network/network-security-group:0.5.2' = {
   name: 'nsg-apim'
@@ -237,12 +174,6 @@ module vnet 'br/public:avm/res/network/virtual-network:0.7.2' = {
         networkSecurityGroupResourceId: apimNsg.outputs.resourceId
       }
       {
-        name: 'appgw'
-        addressPrefix: '10.0.11.0/24'
-        delegation: 'Microsoft.Network/applicationGateways'
-        networkSecurityGroupResourceId: appGwNsg.outputs.resourceId
-      }
-      {
         name: 'private-endpoints'
         addressPrefix: '10.0.10.0/24'
         networkSecurityGroupResourceId: privateEndpointsNsg.outputs.resourceId
@@ -258,8 +189,7 @@ var aksSystemSubnetId = subnetResourceIds[0]
 var aksAgentsSubnetId = subnetResourceIds[1]
 var aksCrudSubnetId = subnetResourceIds[2]
 var apimSubnetId = subnetResourceIds[3]
-var appGwSubnetId = subnetResourceIds[4]
-var peSubnetId = subnetResourceIds[5]
+var peSubnetId = subnetResourceIds[4]
 
 // Private DNS Zones (AVM) — required for private endpoints
 module acrPrivateDnsZone 'br/public:avm/res/network/private-dns-zone:0.8.0' = {
@@ -738,141 +668,6 @@ module aiFoundry 'br/public:avm/ptn/ai-ml/ai-foundry:0.6.0' = {
   }
 }
 
-// Application Gateway for AGIC (Ingress Controller)
-var appGwSkuName = environment == 'prod' ? 'WAF_v2' : 'Standard_v2'
-var appGwCapacity = environment == 'prod' ? 2 : 1
-var appGwPublicIpName = '${appGwName}-pip'
-
-resource appGwPublicIp 'Microsoft.Network/publicIPAddresses@2023-09-01' = {
-  name: appGwPublicIpName
-  location: location
-  sku: {
-    name: 'Standard'
-    tier: 'Regional'
-  }
-  properties: {
-    publicIPAllocationMethod: 'Static'
-    publicIPAddressVersion: 'IPv4'
-  }
-  tags: tags
-}
-
-resource appGateway 'Microsoft.Network/applicationGateways@2023-09-01' = {
-  name: appGwName
-  location: location
-  properties: {
-    sku: {
-      name: appGwSkuName
-      tier: appGwSkuName
-      capacity: appGwCapacity
-    }
-    gatewayIPConfigurations: [
-      {
-        name: 'appGatewayIpConfig'
-        properties: {
-          subnet: {
-            id: appGwSubnetId
-          }
-        }
-      }
-    ]
-    frontendIPConfigurations: [
-      {
-        name: 'appGwPublicFrontendIp'
-        properties: {
-          publicIPAddress: {
-            id: appGwPublicIp.id
-          }
-        }
-      }
-    ]
-    frontendPorts: [
-      {
-        name: 'port_80'
-        properties: {
-          port: 80
-        }
-      }
-      {
-        name: 'port_443'
-        properties: {
-          port: 443
-        }
-      }
-    ]
-    backendAddressPools: [
-      {
-        name: 'defaultAddressPool'
-        properties: {
-          backendAddresses: []
-        }
-      }
-    ]
-    backendHttpSettingsCollection: [
-      {
-        name: 'defaultHttpSettings'
-        properties: {
-          port: 80
-          protocol: 'Http'
-          cookieBasedAffinity: 'Disabled'
-          requestTimeout: 30
-          pickHostNameFromBackendAddress: true
-          probe: {
-            id: resourceId('Microsoft.Network/applicationGateways/probes', appGwName, 'defaultProbe')
-          }
-        }
-      }
-    ]
-    probes: [
-      {
-        name: 'defaultProbe'
-        properties: {
-          protocol: 'Http'
-          path: '/health'
-          interval: 30
-          timeout: 30
-          unhealthyThreshold: 3
-          pickHostNameFromBackendHttpSettings: true
-          minServers: 0
-        }
-      }
-    ]
-    httpListeners: [
-      {
-        name: 'httpListener'
-        properties: {
-          frontendIPConfiguration: {
-            id: resourceId('Microsoft.Network/applicationGateways/frontendIPConfigurations', appGwName, 'appGwPublicFrontendIp')
-          }
-          frontendPort: {
-            id: resourceId('Microsoft.Network/applicationGateways/frontendPorts', appGwName, 'port_80')
-          }
-          protocol: 'Http'
-        }
-      }
-    ]
-    requestRoutingRules: [
-      {
-        name: 'defaultRule'
-        properties: {
-          ruleType: 'Basic'
-          priority: 100
-          httpListener: {
-            id: resourceId('Microsoft.Network/applicationGateways/httpListeners', appGwName, 'httpListener')
-          }
-          backendAddressPool: {
-            id: resourceId('Microsoft.Network/applicationGateways/backendAddressPools', appGwName, 'defaultAddressPool')
-          }
-          backendHttpSettings: {
-            id: resourceId('Microsoft.Network/applicationGateways/backendHttpSettingsCollection', appGwName, 'defaultHttpSettings')
-          }
-        }
-      }
-    ]
-  }
-  tags: tags
-}
-
 // Azure Kubernetes Service (AVM)
 module aks 'br/public:avm/res/container-service/managed-cluster:0.12.0' = {
   name: 'aks'
@@ -898,8 +693,7 @@ module aks 'br/public:avm/res/container-service/managed-cluster:0.12.0' = {
     omsAgentEnabled: true
     enableKeyvaultSecretsProvider: true
     enableOidcIssuerProfile: true
-    ingressApplicationGatewayEnabled: true
-    appGatewayResourceId: appGateway.id
+    webApplicationRoutingEnabled: true
     primaryAgentPoolProfiles: [
       {
         name: 'system'
@@ -1111,6 +905,3 @@ output appInsightsConnectionString string = appInsights.outputs.connectionString
 output appInsightsInstrumentationKey string = appInsights.outputs.instrumentationKey
 output vnetId string = vnet.outputs.resourceId
 output vnetName string = vnet.outputs.name
-output appGwName string = appGateway.name
-output appGwPublicIp string = appGwPublicIp.properties.ipAddress
-output appGwResourceId string = appGateway.id

--- a/.kubernetes/chart/templates/ingress.yaml
+++ b/.kubernetes/chart/templates/ingress.yaml
@@ -5,22 +5,12 @@ metadata:
   name: {{ include "holiday-peak-service.fullname" . }}
   labels:
     app: {{ .Values.serviceName }}
+  {{- with .Values.ingress.annotations }}
   annotations:
-    kubernetes.io/ingress.class: azure/application-gateway
-    {{- if .Values.ingress.ssl.enabled }}
-    appgw.ingress.kubernetes.io/ssl-redirect: "true"
-    {{- end }}
-    {{- if .Values.ingress.healthProbe.path }}
-    appgw.ingress.kubernetes.io/health-probe-path: "{{ .Values.ingress.healthProbe.path }}"
-    {{- end }}
-    appgw.ingress.kubernetes.io/backend-protocol: "http"
-    appgw.ingress.kubernetes.io/request-timeout: "{{ .Values.ingress.requestTimeout | default 30 }}"
-    appgw.ingress.kubernetes.io/connection-draining: "true"
-    appgw.ingress.kubernetes.io/connection-draining-timeout: "30"
-    {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
-    {{- end }}
+  {{- end }}
 spec:
+  ingressClassName: webapprouting.kubernetes.azure.com
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}
@@ -58,18 +48,12 @@ metadata:
   labels:
     app: {{ .Values.serviceName }}
     canary: "true"
+  {{- with .Values.canary.ingress.annotations }}
   annotations:
-    kubernetes.io/ingress.class: azure/application-gateway
-    # AGIC doesn't support weight-based canary natively, but we can use header-based routing
-    # For true weight-based canary, use Azure Front Door or Traffic Manager in front of App Gateway
-    appgw.ingress.kubernetes.io/backend-path-prefix: "/"
-    {{- if .Values.canary.headerRouting.enabled }}
-    appgw.ingress.kubernetes.io/rewrite-rule-set: "canary-{{ .Values.serviceName }}"
-    {{- end }}
-    {{- with .Values.canary.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
-    {{- end }}
+  {{- end }}
 spec:
+  ingressClassName: webapprouting.kubernetes.azure.com
   rules:
     {{- if .Values.ingress.host }}
     - host: {{ .Values.ingress.host | quote }}

--- a/.kubernetes/chart/values.yaml
+++ b/.kubernetes/chart/values.yaml
@@ -7,17 +7,13 @@ service:
   targetPort: 8000
   annotations: {}
 
-# Ingress configuration for AGIC (Application Gateway Ingress Controller)
+# Ingress configuration for AKS Web Application Routing (NGINX-based add-on)
 ingress:
   enabled: true
   host: ""  # Leave empty for path-based routing, or set hostname for host-based
   path: ""  # Defaults to /{serviceName}
   pathType: "Prefix"
   requestTimeout: 30
-  ssl:
-    enabled: false
-  healthProbe:
-    path: "/health"
   tls: []
   annotations: {}
 


### PR DESCRIPTION
## Problem

Closes #191

The \deploy-azd\ workflow has been failing on every push to \main\ for 5+ consecutive runs. The \deploy-crud\ job always fails with:

\\\
failed deploying service 'crud-service': failed retrieving ingress endpoints,
failed waiting for resource, resource 'ing' is not ready, resource is not ready
\\\

## Root Cause

The Helm ingress template used \kubernetes.io/ingress.class: azure/application-gateway\ (AGIC). The AKS-managed AGIC add-on does **not reliably populate** the Kubernetes Ingress \.status.loadBalancer.ingress\ field. This is the field \zd deploy\ polls to detect the endpoint when deploying to an AKS service — so it always times out after the full 10-minute wait window (even with a 60 s retry).

The infrastructure provisions successfully (Application Gateway is created, AGIC add-on is enabled) but AGIC lacks the managed identity Contributor assignment to the App Gateway that is necessary for it to configure backends and write the IP back to the Ingress status.

## Fix

Replace AGIC with the **AKS Web Application Routing (WAR) add-on** — the Microsoft-recommended NGINX-based successor to AGIC. WAR:
- Correctly populates \Ingress.status.loadBalancer.ingress\ (azd can detect the endpoint)
- Is a first-class AKS managed add-on (no separate App Gateway required)
- Requires zero changes to the \zd deploy\ command or workflow

## Changes

### \.infra/modules/shared-infrastructure/shared-infrastructure.bicep\
- Remove \Application Gateway\ resource and its public IP (\ppGwPublicIp\)
- Remove \ppGwNsg\ NSG module (only needed for AGIC subnet)
- Remove \ppgw\ subnet from VNet definition; fix \peSubnetId\ index (5 → 4)
- Remove \ppGwName\ variable and \ppGwName\ / \ppGwPublicIp\ / \ppGwResourceId\ outputs
- Replace \ingressApplicationGatewayEnabled: true\ + \ppGatewayResourceId\   with **\webApplicationRoutingEnabled: true\** on the AKS cluster module

### \.kubernetes/chart/templates/ingress.yaml\
- Replace \kubernetes.io/ingress.class: azure/application-gateway\ and all \ppgw.ingress.kubernetes.io/*\ annotations with \spec.ingressClassName: webapprouting.kubernetes.azure.com\
- Same change applied to the canary Ingress
- Annotations block now uses clean \{{- with .Values.ingress.annotations }}\

### \.kubernetes/chart/values.yaml\
- Remove AGIC-specific fields (\ssl\, \healthProbe\) from \ingress\ stanza
- Update comment to reflect WAR

## Test Plan

- [x] All 699 lib unit tests pass (\python -m pytest lib/tests\)
- [ ] \zd provision\ re-provisions AKS cluster with WAR add-on enabled (removes App GW)
- [ ] \zd deploy --service crud-service\ completes without ingress timeout

## Architecture Notes

The Application Gateway was exclusively used for AGIC. Removing it:
- Saves cost (Standard_v2 App GW is not cheap for dev)
- Simplifies the network topology (removes \ppgw\ subnet)
- Aligns with Microsoft's guidance to use WAR over AGIC for new deployments