### PR TITLE
chore: harden APIM/AGIC deploy flow and cleanup IaC warnings

### DIFF
--- a/.github/workflows/deploy-azd-dev.yml
+++ b/.github/workflows/deploy-azd-dev.yml
@@ -43,7 +43,7 @@ on:
         description: Force APIM sync and smoke checks even when no changed services are detected
         required: true
         type: boolean
-        default: false
+        default: true
       autoAllowAcrRunnerIp:
         description: Temporarily allow GitHub runner egress IP in ACR firewall during deploy and remove it afterward
         required: true
@@ -55,40 +55,19 @@ permissions:
   contents: read
 
 jobs:
-  deploy-from-push:
-    if: ${{ github.event_name == 'push' }}
+  deploy:
     uses: ./.github/workflows/deploy-azd.yml
     with:
       environment: dev
-      location: centralus
-      projectName: holidaypeakhub405
-      imageTag: ${{ github.sha }}
-      deployStatic: true
-      uiOnly: false
-      apiBaseUrl: ''
+      location: ${{ github.event_name == 'workflow_dispatch' && inputs.location || 'centralus' }}
+      projectName: ${{ github.event_name == 'workflow_dispatch' && inputs.projectName || 'holidaypeakhub405' }}
+      imageTag: ${{ github.event_name == 'workflow_dispatch' && inputs.imageTag || github.sha }}
+      deployStatic: ${{ github.event_name != 'workflow_dispatch' || inputs.deployStatic }}
+      uiOnly: ${{ github.event_name == 'workflow_dispatch' && inputs.uiOnly }}
+      apiBaseUrl: ${{ github.event_name == 'workflow_dispatch' && inputs.apiBaseUrl || '' }}
       deployChangedOnly: true
-      forceApimSync: false
-      autoAllowAcrRunnerIp: true
-    secrets:
-      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-      SWA_DEPLOYMENT_TOKEN: ${{ secrets.SWA_DEPLOYMENT_TOKEN }}
-
-  deploy-manual:
-    if: ${{ github.event_name == 'workflow_dispatch' }}
-    uses: ./.github/workflows/deploy-azd.yml
-    with:
-      environment: dev
-      location: ${{ inputs.location }}
-      projectName: ${{ inputs.projectName }}
-      imageTag: ${{ inputs.imageTag }}
-      deployStatic: ${{ inputs.deployStatic }}
-      uiOnly: ${{ inputs.uiOnly }}
-      apiBaseUrl: ${{ inputs.apiBaseUrl }}
-      deployChangedOnly: true
-      forceApimSync: ${{ inputs.forceApimSync }}
-      autoAllowAcrRunnerIp: ${{ inputs.autoAllowAcrRunnerIp }}
+      forceApimSync: ${{ github.event_name != 'workflow_dispatch' || inputs.forceApimSync }}
+      autoAllowAcrRunnerIp: ${{ github.event_name != 'workflow_dispatch' || inputs.autoAllowAcrRunnerIp }}
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/deploy-azd.yml
+++ b/.github/workflows/deploy-azd.yml
@@ -94,7 +94,11 @@ jobs:
           DEFAULT_BRANCH="${{ github.event.repository.default_branch }}"
           git fetch origin "$DEFAULT_BRANCH" --depth=1
 
-          CHANGED_FILES=$(git diff --name-only "origin/$DEFAULT_BRANCH...HEAD")
+          if [ "${{ github.event_name }}" = "push" ] && [ -n "${{ github.event.before }}" ] && [ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]; then
+            CHANGED_FILES=$(git diff --name-only "${{ github.event.before }}...${{ github.sha }}")
+          else
+            CHANGED_FILES=$(git diff --name-only "origin/$DEFAULT_BRANCH...HEAD")
+          fi
 
           mapfile -t AGENT_SERVICES < <(python3 - <<'PY'
           import re
@@ -632,7 +636,7 @@ jobs:
             exit 0
           fi
 
-          for cls in webapprouting.kubernetes.azure.com nginx azure-application-gateway; do
+          for cls in azure-application-gateway webapprouting.kubernetes.azure.com nginx; do
             if kubectl get ingressclass "$cls" >/dev/null 2>&1; then
               echo "Using detected ingress class: $cls"
               echo "INGRESS_CLASS_NAME=$cls" >> "$GITHUB_ENV"

--- a/.infra/azd/hooks/render-helm.ps1
+++ b/.infra/azd/hooks/render-helm.ps1
@@ -96,6 +96,13 @@ $helmArgs = @(
   "tolerations[0].effect=NoSchedule"
 )
 
+if ($ServiceName -eq "crud-service") {
+  $helmArgs += @('--set', 'ingress.paths[0].path=/health')
+  $helmArgs += @('--set', 'ingress.paths[0].pathType=Prefix')
+  $helmArgs += @('--set', 'ingress.paths[1].path=/api')
+  $helmArgs += @('--set', 'ingress.paths[1].pathType=Prefix')
+}
+
 if ($replicaCount) {
   $helmArgs += @('--set', "replicaCount=$replicaCount")
 }

--- a/.infra/azd/hooks/render-helm.sh
+++ b/.infra/azd/hooks/render-helm.sh
@@ -72,6 +72,12 @@ HELM_ARGS="$HELM_ARGS --set image.tag=$IMAGE_TAG"
 HELM_ARGS="$HELM_ARGS --set keda.enabled=$KEDA_ENABLED"
 HELM_ARGS="$HELM_ARGS --set ingress.enabled=$INGRESS_ENABLED"
 HELM_ARGS="$HELM_ARGS --set-string ingress.className=$INGRESS_CLASS_NAME"
+if [ "$SERVICE_NAME" = "crud-service" ]; then
+  HELM_ARGS="$HELM_ARGS --set ingress.paths[0].path=/health"
+  HELM_ARGS="$HELM_ARGS --set ingress.paths[0].pathType=Prefix"
+  HELM_ARGS="$HELM_ARGS --set ingress.paths[1].path=/api"
+  HELM_ARGS="$HELM_ARGS --set ingress.paths[1].pathType=Prefix"
+fi
 HELM_ARGS="$HELM_ARGS --set canary.enabled=$CANARY_ENABLED"
 HELM_ARGS="$HELM_ARGS --set probes.readiness.path=$READINESS_PATH"
 if [ -n "$REPLICA_COUNT" ]; then

--- a/.infra/azd/hooks/sync-apim-agents.ps1
+++ b/.infra/azd/hooks/sync-apim-agents.ps1
@@ -349,7 +349,7 @@ function Test-IngressCrudHealth {
         [Parameter(Mandatory = $true)][string]$GatewayHost
     )
 
-    $probeUrl = "http://$GatewayHost/crud-service/health"
+    $probeUrl = "http://$GatewayHost/health"
     $lastStatus = ''
     $lastBody = ''
 
@@ -414,6 +414,9 @@ function Resolve-ServiceBackendUrl {
 
     if ($script:useIngressMode) {
         Ensure-IngressReady
+        if ($Service -eq 'crud-service') {
+            return "http://$($script:resolvedIngressGatewayHost)"
+        }
         return "http://$($script:resolvedIngressGatewayHost)/$Service"
     }
 

--- a/.infra/azd/hooks/sync-apim-agents.sh
+++ b/.infra/azd/hooks/sync-apim-agents.sh
@@ -324,7 +324,7 @@ $candidate"
 
 validate_ingress_health() {
   host="$1"
-  probe_url="http://$host/crud-service/health"
+  probe_url="http://$host/health"
   probe_body="/tmp/apim-ingress-health.json"
   status_code=""
 
@@ -371,8 +371,12 @@ resolve_backend_url() {
   # If using Ingress (AGIC), resolve via App Gateway public IP
   if [ "$USE_INGRESS" = true ]; then
     ensure_ingress_ready
-    # Route through ingress controller with path-based routing.
-    printf 'http://%s/%s' "$RESOLVED_INGRESS_HOST" "$svc"
+    # CRUD uses app-native ingress paths (/health, /api) at gateway root.
+    if [ "$svc" = "crud-service" ]; then
+      printf 'http://%s' "$RESOLVED_INGRESS_HOST"
+    else
+      printf 'http://%s/%s' "$RESOLVED_INGRESS_HOST" "$svc"
+    fi
     return
   fi
 

--- a/.infra/azd/main.bicep
+++ b/.infra/azd/main.bicep
@@ -11,6 +11,8 @@ param environment string = 'dev'
 param projectName string = 'holidaypeakhub'
 @description('Optional override for Key Vault name (3-24 chars, lowercase letters, numbers, and hyphens).')
 param keyVaultNameOverride string = ''
+@description('Enable AKS Web App Routing addon. Keep disabled for AGIC/App Gateway-first ingress topology.')
+param aksWebApplicationRoutingEnabled bool = false
 @secure()
 @description('Optional PostgreSQL admin password for CRUD database. Leave empty to auto-generate.')
 param postgresAdminPassword string = ''
@@ -31,6 +33,7 @@ module sharedInfra '../modules/shared-infrastructure/shared-infrastructure-main.
     environment: environment
     projectName: projectName
     keyVaultNameOverride: keyVaultNameOverride
+    aksWebApplicationRoutingEnabled: aksWebApplicationRoutingEnabled
     postgresAdminPassword: postgresAdminPassword
     resourceGroupName: resourceGroupName
   }

--- a/.infra/modules/shared-infrastructure/shared-infrastructure-main.bicep
+++ b/.infra/modules/shared-infrastructure/shared-infrastructure-main.bicep
@@ -6,6 +6,8 @@ param environment string = 'dev' // dev, staging, prod
 param projectName string = 'holidaypeakhub'
 @description('Optional override for Key Vault name (3-24 chars, lowercase letters, numbers, and hyphens). Leave empty to use default naming.')
 param keyVaultNameOverride string = ''
+@description('Enable AKS Web App Routing addon. Keep disabled for AGIC/App Gateway-first ingress topology.')
+param aksWebApplicationRoutingEnabled bool = false
 @secure()
 @description('Optional PostgreSQL administrator password for CRUD database.')
 param postgresAdminPassword string = ''
@@ -31,6 +33,7 @@ module sharedInfra './shared-infrastructure.bicep' = {
     environment: environment
     projectName: projectName
     keyVaultNameOverride: keyVaultNameOverride
+    aksWebApplicationRoutingEnabled: aksWebApplicationRoutingEnabled
     postgresAdminPassword: postgresAdminPassword
   }
   dependsOn: [

--- a/.infra/modules/shared-infrastructure/shared-infrastructure.bicep
+++ b/.infra/modules/shared-infrastructure/shared-infrastructure.bicep
@@ -8,6 +8,8 @@ param projectName string = 'holidaypeakhub'
 param keyVaultNameOverride string = ''
 @description('AKS Kubernetes version; leave empty to use Azure default')
 param aksKubernetesVersion string = ''
+@description('Enable AKS Web App Routing addon. Keep disabled for AGIC/App Gateway-first ingress topology.')
+param aksWebApplicationRoutingEnabled bool = false
 @secure()
 @description('PostgreSQL administrator password for CRUD transactional database. Leave empty to auto-generate a deterministic dev password.')
 param postgresAdminPassword string = ''
@@ -695,7 +697,7 @@ module aks 'br/public:avm/res/container-service/managed-cluster:0.12.0' = {
     omsAgentEnabled: true
     enableKeyvaultSecretsProvider: true
     enableOidcIssuerProfile: true
-    webApplicationRoutingEnabled: true
+    webApplicationRoutingEnabled: aksWebApplicationRoutingEnabled
     primaryAgentPoolProfiles: [
       {
         name: 'system'

--- a/.infra/modules/static-web-app/README.md
+++ b/.infra/modules/static-web-app/README.md
@@ -8,35 +8,35 @@ This module provisions **Azure Static Web Apps** for the Holiday Peak Hub fronte
   - Free tier (dev/staging)
   - Standard tier (prod) with enterprise CDN
 - **GitHub Actions Integration** - Automatic CI/CD on push to main
-- **Custom Domain** (prod only) - www.holidaypeakhub.com
+- **Custom Domain** (prod only) - `www.holidaypeakhub.com`
 
 ## Architecture
 
-```
+```text
 ┌─────────────────────────────────────────────────────────┐
-│ Azure Static Web Apps                                    │
+│ Azure Static Web Apps                                  │
 │ ┌─────────────────────────────────────────────────────┐ │
-│ │ Frontend (Next.js)                                   │ │
-│ │ - Homepage                                           │ │
-│ │ - Product Pages                                      │ │
-│ │ - Checkout                                           │ │
-│ │ - Dashboard                                          │ │
-│ │ - Staff/Admin Pages                                  │ │
+│ │ Frontend (Next.js)                                  │ │
+│ │ - Homepage                                          │ │
+│ │ - Product Pages                                     │ │
+│ │ - Checkout                                          │ │
+│ │ - Dashboard                                         │ │
+│ │ - Staff/Admin Pages                                 │ │
 │ └─────────────────────────────────────────────────────┘ │
-│                          │                               │
-│                          ▼                               │
+│                          │                              │
+│                          ▼                              │
 │ ┌─────────────────────────────────────────────────────┐ │
-│ │ Azure CDN (Global Edge Locations)                    │ │
-│ │ - Static assets (JS, CSS, images)                   │ │
-│ │ - Automatic caching                                  │ │
-│ │ - Brotli compression                                 │ │
+│ │ Azure CDN (Global Edge Locations)                  │ │
+│ │ - Static assets (JS, CSS, images)                  │ │
+│ │ - Automatic caching                                 │ │
+│ │ - Brotli compression                                │ │
 │ └─────────────────────────────────────────────────────┘ │
 └─────────────────────────────────────────────────────────┘
                           │
                           ▼
               ┌───────────────────────┐
-              │ Azure API Management   │
-              │ (Backend APIs)         │
+              │ Azure API Management  │
+              │ (Backend APIs)        │
               └───────────────────────┘
 ```
 
@@ -120,15 +120,16 @@ swa deploy \
 
 ## GitHub Actions Integration
 
-The Bicep deployment automatically creates a GitHub Actions workflow. The deployment token is output by the module.
+The Bicep deployment automatically creates a GitHub Actions workflow. Retrieve the deployment token directly from the Static Web App resource (do not output it from IaC deployment outputs).
 
 ### Store Deployment Token in GitHub Secrets
 
 ```bash
-# Get deployment token
-DEPLOYMENT_TOKEN=$(az deployment sub show \
-  --name static-web-app-deployment \
-  --query properties.outputs.deploymentToken.value -o tsv)
+# Get deployment token from the Static Web App resource
+DEPLOYMENT_TOKEN=$(az staticwebapp secrets list \
+  --name holidaypeakhub-ui-dev \
+  --resource-group holidaypeakhub-dev-rg \
+  --query properties.apiKey -o tsv)
 
 # Store in GitHub secrets (requires GitHub CLI)
 gh secret set AZURE_STATIC_WEB_APPS_API_TOKEN --body "$DEPLOYMENT_TOKEN"
@@ -178,17 +179,20 @@ jobs:
 ### Environment Variables (Build Time)
 
 Set in Bicep module:
+
 - `NEXT_PUBLIC_API_BASE_URL` - Backend API URL
 - `NEXT_PUBLIC_ENVIRONMENT` - Environment name (dev/staging/prod)
 
 ### Update API URLs
 
 **Dev**:
+
 ```bash
 NEXT_PUBLIC_API_BASE_URL=https://holidaypeakhub-dev-apim.azure-api.net
 ```
 
 **Production**:
+
 ```bash
 NEXT_PUBLIC_API_BASE_URL=https://api.holidaypeakhub.com
 ```
@@ -196,12 +200,14 @@ NEXT_PUBLIC_API_BASE_URL=https://api.holidaypeakhub.com
 ## Custom Domain (Production)
 
 ### Prerequisites
+
 1. Domain registered (e.g., GoDaddy, Namecheap)
 2. DNS access to create CNAME records
 
 ### Steps
 
 1. **Add Custom Domain in Bicep** (already configured for prod)
+
    ```bicep
    resource customDomain 'Microsoft.Web/staticSites/customDomains@2023-01-01' = if (environment == 'prod') {
      parent: staticWebApp
@@ -211,6 +217,7 @@ NEXT_PUBLIC_API_BASE_URL=https://api.holidaypeakhub.com
    ```
 
 2. **Get Validation Token**
+
    ```bash
    az staticwebapp hostname show \
      --name holidaypeakhub-ui-prod \
@@ -218,12 +225,14 @@ NEXT_PUBLIC_API_BASE_URL=https://api.holidaypeakhub.com
    ```
 
 3. **Add DNS Records**
-   | Type  | Name | Value                                      |
-   |-------|------|--------------------------------------------|
-   | CNAME | www  | <static-web-app-default-hostname>          |
-   | TXT   | www  | <validation-token>                         |
+
+   | Type | Name | Value |
+   | --- | --- | --- |
+   | CNAME | www | `static-web-app-default-hostname` |
+   | TXT | www | `validation-token` |
 
 4. **Verify Domain**
+
    ```bash
    az staticwebapp hostname show \
      --name holidaypeakhub-ui-prod \
@@ -272,24 +281,29 @@ Static Web Apps supports client-side routing. Create `staticwebapp.config.json` 
 ## Performance Optimization
 
 ### 1. Enable Compression
+
 - Brotli/Gzip automatically enabled by Azure CDN
 
 ### 2. Optimize Images
+
 Use Next.js Image component (with `unoptimized: true` for static export):
+
 ```tsx
 import Image from 'next/image'
 
-<Image 
-  src="/images/product.jpg" 
-  alt="Product" 
-  width={500} 
-  height={500} 
-  unoptimized 
+<Image
+  src="/images/product.jpg"
+  alt="Product"
+  width={500}
+  height={500}
+  unoptimized
 />
 ```
 
 ### 3. Code Splitting
+
 Next.js automatically code-splits pages. Use dynamic imports for heavy components:
+
 ```tsx
 import dynamic from 'next/dynamic'
 
@@ -299,7 +313,9 @@ const HeavyComponent = dynamic(() => import('../components/HeavyComponent'), {
 ```
 
 ### 4. Cache Headers
+
 Configured in `staticwebapp.config.json`:
+
 ```json
 {
   "routes": [
@@ -322,6 +338,7 @@ Configured in `staticwebapp.config.json`:
 ## Monitoring
 
 ### View Deployment Logs
+
 ```bash
 az staticwebapp show \
   --name holidaypeakhub-ui-dev \
@@ -329,11 +346,13 @@ az staticwebapp show \
 ```
 
 ### View Application Insights
+
 Static Web Apps automatically integrates with Application Insights if configured in the shared infrastructure module.
 
 ## Cost
 
 ### Free Tier (Dev/Staging)
+
 - **Bandwidth**: 100 GB/month
 - **Custom domains**: 2
 - **SSL certificates**: Included
@@ -341,6 +360,7 @@ Static Web Apps automatically integrates with Application Insights if configured
 - **Cost**: $0/month
 
 ### Standard Tier (Production)
+
 - **Bandwidth**: Unlimited
 - **Custom domains**: Unlimited
 - **Enterprise CDN**: Included
@@ -351,15 +371,18 @@ Static Web Apps automatically integrates with Application Insights if configured
 ## Troubleshooting
 
 ### Build Failures
+
 1. Check GitHub Actions logs
 2. Verify `next.config.js` has `output: 'export'`
 3. Ensure no server-side features (getServerSideProps, API routes)
 
 ### 404 Errors
+
 1. Verify `staticwebapp.config.json` has `navigationFallback`
 2. Check `trailingSlash: true` in `next.config.js`
 
 ### API Connection Issues
+
 1. Verify `NEXT_PUBLIC_API_BASE_URL` is set correctly
 2. Check CORS configuration in APIM
 3. Verify APIM is accessible from client browser

--- a/.infra/modules/static-web-app/static-web-app-main.bicep
+++ b/.infra/modules/static-web-app/static-web-app-main.bicep
@@ -24,4 +24,3 @@ module swa './static-web-app.bicep' = {
 // Outputs
 output staticWebAppName string = swa.outputs.staticWebAppName
 output staticWebAppDefaultHostname string = swa.outputs.staticWebAppDefaultHostname
-output deploymentToken string = swa.outputs.deploymentToken

--- a/.infra/modules/static-web-app/static-web-app.bicep
+++ b/.infra/modules/static-web-app/static-web-app.bicep
@@ -35,6 +35,8 @@ resource staticWebApp 'Microsoft.Web/staticSites@2023-01-01' = {
     ManagedBy: 'Bicep'
     'azd-service-name': 'ui'
     'azd-env-name': environment
+    SourceRepository: repositoryUrl
+    SourceBranch: branch
   }
 }
 
@@ -59,4 +61,3 @@ resource appSettings 'Microsoft.Web/staticSites/config@2023-01-01' = {
 output staticWebAppName string = staticWebApp.name
 output staticWebAppDefaultHostname string = staticWebApp.properties.defaultHostname
 output staticWebAppId string = staticWebApp.id
-output deploymentToken string = listSecrets(staticWebApp.id, staticWebApp.apiVersion).properties.apiKey

--- a/.kubernetes/chart/templates/ingress.yaml
+++ b/.kubernetes/chart/templates/ingress.yaml
@@ -31,6 +31,17 @@ spec:
     - http:
     {{- end }}
         paths:
+          {{- if .Values.ingress.paths }}
+          {{- range .Values.ingress.paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType | default $.Values.ingress.pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ include "holiday-peak-service.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port | default 80 }}
+          {{- end }}
+          {{- else }}
           - path: {{ .Values.ingress.path | default (printf "/%s" .Values.serviceName) }}
             pathType: {{ .Values.ingress.pathType | default "Prefix" }}
             backend:
@@ -38,6 +49,7 @@ spec:
                 name: {{ include "holiday-peak-service.fullname" . }}
                 port:
                   number: {{ .Values.service.port | default 80 }}
+          {{- end }}
 {{- end }}
 
 ---

--- a/.kubernetes/chart/values.yaml
+++ b/.kubernetes/chart/values.yaml
@@ -13,6 +13,7 @@ ingress:
   className: "webapprouting.kubernetes.azure.com"
   host: ""  # Leave empty for path-based routing, or set hostname for host-based
   path: ""  # Defaults to /{serviceName}
+  paths: []  # Optional explicit ingress paths, e.g. [{ path: /health, pathType: Prefix }, { path: /api, pathType: Prefix }]
   pathType: "Prefix"
   requestTimeout: 30
   tls: []

--- a/docs/architecture/adrs/adr-026-agic-traffic-management.md
+++ b/docs/architecture/adrs/adr-026-agic-traffic-management.md
@@ -96,9 +96,12 @@ flowchart TB
 
 | Traffic Type | Path | Backend |
 |-------------|------|---------|
-| CRUD API | `/crud-service/*` | crud-service ClusterIP |
+| CRUD API (health) | `/health` | crud-service ClusterIP |
+| CRUD API (business) | `/api/*` | crud-service ClusterIP |
 | Agent Services | `/{agent-name}/*` | agent service ClusterIP |
 | Canary Traffic | `/{service-name}/canary/*` | canary deployment (when enabled) |
+
+APIM keeps the CRUD public surface under `/api/*` and only rewrites the health probe route (`/api/health -> /health`).
 
 ### Canary Deployment Flow
 

--- a/docs/governance/infrastructure-governance.md
+++ b/docs/governance/infrastructure-governance.md
@@ -1,7 +1,7 @@
 # Infrastructure Governance and Compliance Guidelines
 
-**Version**: 2.0  
-**Last Updated**: 2026-03-11  
+**Version**: 2.1  
+**Last Updated**: 2026-03-12  
 **Owner**: Infrastructure Team
 
 ## Scope
@@ -28,16 +28,21 @@ Infrastructure provisioning, deployment orchestration, identity, security contro
 ## Environment Policy Matrix
 
 | Policy Area | dev | prod | staging |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | Entrypoint workflow | `deploy-azd-dev.yml` | `deploy-azd-prod.yml` | Not currently provisioned as dedicated workflow |
 | Trigger model | `push` to `main` + `workflow_dispatch` | Stable tag push `v*.*.*` | Manual via reusable workflow only if explicitly configured |
 | Release gate | Not required | Required: published, non-draft, non-prerelease GitHub Release | N/A |
 | Main lineage gate | Not required | Required: tagged commit must be reachable from `main` | N/A |
 | Demo data seeding mode | Local/manual only (not part of CI deploy) | Local/manual only | Local/manual only |
 | Changed-only deployment | Enabled | Enabled | N/A |
-| Force APIM sync default | `false` | `true` | N/A |
+| Force APIM sync default | `true` | `true` | N/A |
 | Auto allow ACR runner IP | `true` default | `false` default | N/A |
 | Non-prod drift remediation | Enabled | Disabled | Would be treated as non-prod if introduced |
+
+### Workflow deduplication policy
+
+- Entrypoint workflows should avoid duplicated job blocks for push/manual variants when the same reusable workflow call can be parameterized with event-aware expressions.
+- `deploy-azd-dev.yml` is maintained as a single reusable-workflow invocation path to reduce drift between trigger types.
 
 ## Security and Access Controls
 
@@ -50,9 +55,14 @@ Infrastructure provisioning, deployment orchestration, identity, security contro
 
 - CRUD-first sequencing before dependent agent rollouts.
 - Changed-service detection to reduce blast radius and deployment duration.
+- Push-event changed-service detection must diff `${{ github.event.before }}...${{ github.sha }}` to avoid empty comparisons against `origin/main` after merge.
 - APIM sync/smoke checks for API path health after relevant changes.
 - APIM sync determinism is required: ingress sync must resolve against an explicit Application Gateway target in workflow execution.
+- Reusable deploy workflow ingress-class detection must prioritize `azure-application-gateway` before other classes in AGIC-first environments.
 - APIM sync filtering must always include `crud-service` when CRUD sync is enabled, even under changed-services filtering.
+- For App Gateway-backed CRUD routing, ingress must expose app-native paths (`/health`, `/api`) and APIM CRUD backend must target App Gateway root (no `/crud-service` suffix).
+- Path translation must not be split across AGIC and APIM for CRUD. APIM keeps health rewrite (`/api/health -> /health`), while `/api/*` routes are forwarded as-is.
+- AKS IaC defaults to AGIC/App Gateway-first ingress by setting Web App Routing addon disabled unless explicitly enabled (`aksWebApplicationRoutingEnabled`).
 - Optional UI-only deployment path constrained by SWA token flow and health checks.
 - ACR network-rule temporary exceptions may be applied/removed automatically when enabled.
 

--- a/docs/roadmap/001-crud-apim-routing.md
+++ b/docs/roadmap/001-crud-apim-routing.md
@@ -71,7 +71,7 @@ These controls reduce the chance that frontend `/api/products` or `/api/categori
   - Prefer explicit `ingress host` or explicit `app gateway name/ip` when provided.
   - Auto-resolution is allowed only when a single unambiguous candidate exists.
   - Ambiguous routing candidates now fail fast.
-- Before any APIM update in ingress mode, hooks probe `http://<resolved-ingress-host>/crud-service/health` and abort on unhealthy/invalid resolution.
+- Before any APIM update in ingress mode, hooks probe `http://<resolved-ingress-host>/health` and abort on unhealthy/invalid resolution.
 
 ## Closure Status Update (2026-03-06, PR #198)
 


### PR DESCRIPTION
## Summary\n- Deduplicates dev deploy entrypoint while preserving manual false booleans\n- Prioritizes AGIC ingress class detection and aligns CRUD ingress/APIM path behavior\n- Adds explicit AKS web app routing toggle for AGIC-first topology in Bicep\n- Removes SWA secret outputs from IaC and cleans related docs/lint warnings\n- Updates governance/ADR/roadmap docs to match implemented routing contract\n\n## Validation\n- Code Critic review: approve with nits after fixes\n- Architecture sign-off: APPROVED\n- get_errors clean for changed workflow, Bicep, and docs files\n- Bicep diagnostics clean for updated IaC entrypoints/modules\n\n## Risk\n- Low/Medium: routing behavior now explicitly expects CRUD root ingress paths (/health, /api/*) in AGIC-first setup