### PR TITLE
Complete UI proxy diagnostics parity and resolver drift cleanup

### DIFF
--- a/apps/ui/INTEGRATION.md
+++ b/apps/ui/INTEGRATION.md
@@ -55,7 +55,7 @@ Shared resolver module: `app/api/_shared/base-url-resolver.ts`
 - CRUD env precedence: `NEXT_PUBLIC_CRUD_API_URL` → `NEXT_PUBLIC_API_URL` → `NEXT_PUBLIC_API_BASE_URL` → `CRUD_API_URL`
 - Agent env precedence: `NEXT_PUBLIC_AGENT_API_URL` → `AGENT_API_URL` → CRUD aliases above with `/agents` suffix
 - Browser runtime:
-  - CRUD client (`lib/api/client.ts`) uses relative URL (`''`) and calls `/api/*` via Next.js route
+  - CRUD client (`lib/api/client.ts`) uses configured public cloud URL when set; otherwise falls back to relative URL (`''`) via `/api/*` route
   - Agent client (`lib/api/agentClient.ts`) uses `/agent-api/*`
 - Server runtime:
   - CRUD and Agent API routes/clients resolve from env precedence above

--- a/apps/ui/app/agent-api/[...path]/route.ts
+++ b/apps/ui/app/agent-api/[...path]/route.ts
@@ -9,19 +9,36 @@ type TargetResolution = {
   upstreamPath: string;
 };
 
+type ProxyFailureKind = 'config' | 'network' | 'upstream';
+
+type ProxyErrorPayload = {
+  error: string;
+  proxy: {
+    failureKind: ProxyFailureKind;
+    sourceKey: string | null;
+    baseUrl: string | null;
+    attemptedPath: string;
+    method: string;
+    upstreamStatus?: number;
+    upstreamStatusText?: string;
+    upstreamError?: string | null;
+    upstreamRequestId?: string | null;
+    remediation: string[];
+  };
+};
+
 function buildTargetUrl(request: NextRequest, pathSegments: string[]): TargetResolution {
+  const joinedPath = pathSegments.filter(Boolean).join('/');
+  const upstreamPath = joinedPath ? `/agents/${joinedPath}` : '/agents';
   const { baseUrl, sourceKey } = resolveAgentApiBaseUrl();
   if (!baseUrl) {
     return {
       targetUrl: null,
       baseUrl: null,
       sourceKey,
-      upstreamPath: '/agents',
+      upstreamPath,
     };
   }
-
-  const joinedPath = pathSegments.filter(Boolean).join('/');
-  const upstreamPath = joinedPath ? `/agents/${joinedPath}` : '/agents';
   const query = request.nextUrl.search;
 
   return {
@@ -32,24 +49,140 @@ function buildTargetUrl(request: NextRequest, pathSegments: string[]): TargetRes
   };
 }
 
+function extractFirstMessage(payload: unknown): string | null {
+  const extract = (value: unknown, depth = 0): string | null => {
+    if (depth > 4 || value === null || value === undefined) {
+      return null;
+    }
+
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      return trimmed.length > 0 ? trimmed : null;
+    }
+
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        const message = extract(item, depth + 1);
+        if (message) {
+          return message;
+        }
+      }
+      return null;
+    }
+
+    if (typeof value === 'object') {
+      const record = value as Record<string, unknown>;
+      for (const key of ['error', 'message', 'detail', 'title', 'msg']) {
+        const message = extract(record[key], depth + 1);
+        if (message) {
+          return message;
+        }
+      }
+    }
+
+    return null;
+  };
+
+  return extract(payload);
+}
+
+async function readUpstreamErrorPayload(response: Response): Promise<string | null> {
+  const contentType = response.headers.get('content-type') || '';
+
+  if (contentType.includes('application/json')) {
+    try {
+      const jsonPayload = await response.json();
+      return extractFirstMessage(jsonPayload);
+    } catch {
+      return null;
+    }
+  }
+
+  try {
+    const text = (await response.text()).trim();
+    if (!text) {
+      return null;
+    }
+
+    return text.slice(0, 240);
+  } catch {
+    return null;
+  }
+}
+
+function buildProxyErrorPayload(params: {
+  failureKind: ProxyFailureKind;
+  sourceKey: string | null;
+  baseUrl: string | null;
+  attemptedPath: string;
+  method: string;
+  upstreamStatus?: number;
+  upstreamStatusText?: string;
+  upstreamError?: string | null;
+  upstreamRequestId?: string | null;
+}): ProxyErrorPayload {
+  const remediationByKind: Record<ProxyFailureKind, string[]> = {
+    config: [
+      'Set NEXT_PUBLIC_AGENT_API_URL or AGENT_API_URL to a reachable backend URL.',
+      'Redeploy or restart the UI host after updating environment variables.',
+    ],
+    network: [
+      'Verify DNS, firewall rules, and outbound network access from the UI host to the agent backend URL.',
+      'Check agent backend availability and retry the request.',
+    ],
+    upstream: [
+      'Inspect upstream agent service logs for request failures and dependency outages.',
+      'Retry after backend recovery or fail over to a healthy upstream instance.',
+    ],
+  };
+
+  const errorByKind: Record<ProxyFailureKind, string> = {
+    config: 'Agent API proxy is not configured for backend routing.',
+    network: 'Agent API proxy could not reach upstream service.',
+    upstream: 'Agent API proxy received a bad gateway response from upstream.',
+  };
+
+  return {
+    error: errorByKind[params.failureKind],
+    proxy: {
+      failureKind: params.failureKind,
+      sourceKey: params.sourceKey,
+      baseUrl: params.baseUrl,
+      attemptedPath: params.attemptedPath,
+      method: params.method,
+      upstreamStatus: params.upstreamStatus,
+      upstreamStatusText: params.upstreamStatusText,
+      upstreamError: params.upstreamError ?? null,
+      upstreamRequestId: params.upstreamRequestId ?? null,
+      remediation: remediationByKind[params.failureKind],
+    },
+  };
+}
+
 async function proxyRequest(
   request: NextRequest,
   context: { params: Promise<{ path: string[] }> },
 ): Promise<NextResponse> {
   const params = await context.params;
   const { targetUrl, baseUrl, sourceKey, upstreamPath } = buildTargetUrl(request, params.path);
+  const method = request.method.toUpperCase();
 
   if (!targetUrl) {
     return NextResponse.json(
+      buildProxyErrorPayload({
+        failureKind: 'config',
+        sourceKey,
+        baseUrl,
+        attemptedPath: upstreamPath,
+        method,
+      }),
       {
-        error:
-          'Agent API proxy is not configured. Set NEXT_PUBLIC_AGENT_API_URL or AGENT_API_URL (fallbacks: NEXT_PUBLIC_CRUD_API_URL, NEXT_PUBLIC_API_URL, CRUD_API_URL).',
-        proxy: {
-          sourceKey,
-          attemptedPath: upstreamPath,
+        status: 502,
+        headers: {
+          'x-holiday-peak-proxy': 'next-app-agent-api',
+          'x-holiday-peak-proxy-failure-kind': 'config',
         },
       },
-      { status: 500 },
     );
   }
 
@@ -57,7 +190,6 @@ async function proxyRequest(
   requestHeaders.delete('host');
   requestHeaders.delete('content-length');
 
-  const method = request.method.toUpperCase();
   const body = method === 'GET' || method === 'HEAD' ? undefined : await request.arrayBuffer();
 
   let upstream: Response;
@@ -79,15 +211,50 @@ async function proxyRequest(
       });
     }
     return NextResponse.json(
+      buildProxyErrorPayload({
+        failureKind: 'network',
+        sourceKey,
+        baseUrl,
+        attemptedPath: upstreamPath,
+        method,
+        upstreamError: error instanceof Error ? error.message : null,
+      }),
       {
-        error: 'Agent API proxy could not reach upstream service.',
-        proxy: {
-          sourceKey,
-          baseUrl,
-          attemptedPath: upstreamPath,
+        status: 502,
+        headers: {
+          'x-holiday-peak-proxy': 'next-app-agent-api',
+          'x-holiday-peak-proxy-source': sourceKey ?? '',
+          'x-holiday-peak-proxy-failure-kind': 'network',
         },
       },
-      { status: 502 },
+    );
+  }
+
+  if (upstream.status === 502) {
+    const upstreamError = await readUpstreamErrorPayload(upstream);
+    const upstreamRequestId =
+      upstream.headers.get('x-request-id') || upstream.headers.get('x-ms-request-id');
+
+    return NextResponse.json(
+      buildProxyErrorPayload({
+        failureKind: 'upstream',
+        sourceKey,
+        baseUrl,
+        attemptedPath: upstreamPath,
+        method,
+        upstreamStatus: upstream.status,
+        upstreamStatusText: upstream.statusText,
+        upstreamError,
+        upstreamRequestId,
+      }),
+      {
+        status: 502,
+        headers: {
+          'x-holiday-peak-proxy': 'next-app-agent-api',
+          'x-holiday-peak-proxy-source': sourceKey ?? '',
+          'x-holiday-peak-proxy-failure-kind': 'upstream',
+        },
+      },
     );
   }
 

--- a/apps/ui/lib/services/semanticSearchService.ts
+++ b/apps/ui/lib/services/semanticSearchService.ts
@@ -5,6 +5,7 @@
  */
 
 import agentApiClient from '../api/agentClient';
+import { resolveAgentApiClientBaseUrl } from '@/app/api/_shared/base-url-resolver';
 import { productService } from './productService';
 import {
   mapAcpProductsToUi,
@@ -13,7 +14,7 @@ import {
 } from '../utils/productMappers';
 import type { Product as UiProduct } from '../../components/types';
 
-const AGENT_API_BASE_URL = process.env.NEXT_PUBLIC_AGENT_API_URL || '';
+const AGENT_API_BASE_URL = resolveAgentApiClientBaseUrl().baseUrl || '';
 
 export interface SemanticSearchRequest {
   query: string;

--- a/apps/ui/tests/unit/agentApiProxyRouteEnv.test.ts
+++ b/apps/ui/tests/unit/agentApiProxyRouteEnv.test.ts
@@ -51,6 +51,27 @@ describe('/agent-api proxy route env handling', () => {
     } as unknown as NextRequest;
   }
 
+  it('returns explicit 502 config diagnostics when no agent proxy base URL is configured', async () => {
+    const route = await import('../../app/agent-api/[...path]/route');
+    const response = await route.GET(makeRequest('http://localhost/agent-api/ecommerce-catalog-search/invoke'), {
+      params: Promise.resolve({ path: ['ecommerce-catalog-search', 'invoke'] }),
+    });
+
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({
+        error: 'Agent API proxy is not configured for backend routing.',
+        proxy: expect.objectContaining({
+          failureKind: 'config',
+          attemptedPath: '/agents/ecommerce-catalog-search/invoke',
+          method: 'GET',
+          remediation: expect.any(Array),
+        }),
+      }),
+    );
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
   it('returns 502 with sanitized diagnostics when upstream agent fetch throws', async () => {
     process.env.NEXT_PUBLIC_AGENT_API_URL = 'https://apim.example.azure-api.net/agents';
     (global.fetch as jest.Mock).mockRejectedValue(new Error('connect ETIMEDOUT'));
@@ -65,8 +86,49 @@ describe('/agent-api proxy route env handling', () => {
       expect.objectContaining({
         error: 'Agent API proxy could not reach upstream service.',
         proxy: expect.objectContaining({
+          failureKind: 'network',
           sourceKey: 'NEXT_PUBLIC_AGENT_API_URL',
           attemptedPath: '/agents/ecommerce-product-detail-enrichment/invoke',
+          method: 'GET',
+          upstreamError: 'connect ETIMEDOUT',
+        }),
+      }),
+    );
+  });
+
+  it('returns 502 upstream diagnostics when upstream responds with 502', async () => {
+    process.env.NEXT_PUBLIC_AGENT_API_URL = 'https://apim.example.azure-api.net/agents';
+    (global.fetch as jest.Mock).mockResolvedValue({
+      body: null,
+      status: 502,
+      statusText: 'Bad Gateway',
+      headers: new Headers({
+        'content-type': 'application/json',
+        'x-request-id': 'agent-upstream-req-123',
+      }),
+      json: jest.fn(async () => ({
+        error: 'Agent dependency timeout',
+      })),
+      text: jest.fn(async () => ''),
+    });
+
+    const route = await import('../../app/agent-api/[...path]/route');
+    const response = await route.GET(makeRequest('http://localhost/agent-api/ecommerce-catalog-search/invoke'), {
+      params: Promise.resolve({ path: ['ecommerce-catalog-search', 'invoke'] }),
+    });
+
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({
+        error: 'Agent API proxy received a bad gateway response from upstream.',
+        proxy: expect.objectContaining({
+          failureKind: 'upstream',
+          attemptedPath: '/agents/ecommerce-catalog-search/invoke',
+          method: 'GET',
+          upstreamStatus: 502,
+          upstreamStatusText: 'Bad Gateway',
+          upstreamError: 'Agent dependency timeout',
+          upstreamRequestId: 'agent-upstream-req-123',
         }),
       }),
     );


### PR DESCRIPTION
## Summary
- Align agent proxy error contract with CRUD proxy diagnostics (config/network/upstream)
- Add upstream 502 metadata extraction for agent proxy responses
- Remove resolver drift in semantic search service by using shared runtime resolver
- Correct integration contract docs for browser CRUD behavior with cloud URL precedence

## Issues
- Closes #269
- Closes #270
- Refs #268

## Validation
- yarn test tests/unit/agentApiProxyRouteEnv.test.ts tests/unit/apiProxyRouteEnv.test.ts tests/unit/baseUrlResolverContract.test.ts tests/unit/apiClientMockAuth.test.ts tests/unit/SearchPage.test.tsx --runInBand