### PR TITLE
chore(ui): enforce local proxy path + SWA push contract gate

### DIFF
--- a/.github/workflows/ui-contract-gate.yml
+++ b/.github/workflows/ui-contract-gate.yml
@@ -1,0 +1,67 @@
+name: ui-contract-gate
+
+on:
+  push:
+    paths:
+      - apps/ui/**
+      - .github/workflows/deploy-ui-swa.yml
+      - .github/workflows/deploy-azd.yml
+      - .github/workflows/ui-contract-gate.yml
+      - scripts/ci/validate_swa_hybrid_contract.py
+  pull_request:
+    branches:
+      - main
+    paths:
+      - apps/ui/**
+      - .github/workflows/deploy-ui-swa.yml
+      - .github/workflows/deploy-azd.yml
+      - .github/workflows/ui-contract-gate.yml
+      - scripts/ci/validate_swa_hybrid_contract.py
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ui-contract-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Validate SWA hybrid runtime contract
+        run: python scripts/ci/validate_swa_hybrid_contract.py
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: yarn
+          cache-dependency-path: apps/ui/yarn.lock
+
+      - name: Install UI dependencies
+        working-directory: apps/ui
+        run: yarn install --frozen-lockfile --prefer-offline
+
+      - name: Run focused UI contract tests
+        working-directory: apps/ui
+        env:
+          CI: true
+        run: >-
+          yarn test
+          tests/unit/staticWebAppConfigParity.test.ts
+          tests/unit/baseUrlResolverContract.test.ts
+          tests/unit/apiProxyRouteEnv.test.ts
+          tests/unit/agentApiProxyRouteEnv.test.ts
+          --runInBand
+          --ci

--- a/apps/ui/INTEGRATION.md
+++ b/apps/ui/INTEGRATION.md
@@ -55,7 +55,7 @@ Shared resolver module: `app/api/_shared/base-url-resolver.ts`
 - CRUD env precedence: `NEXT_PUBLIC_CRUD_API_URL` → `NEXT_PUBLIC_API_URL` → `NEXT_PUBLIC_API_BASE_URL` → `CRUD_API_URL`
 - Agent env precedence: `NEXT_PUBLIC_AGENT_API_URL` → `AGENT_API_URL` → CRUD aliases above with `/agents` suffix
 - Browser runtime:
-  - CRUD client (`lib/api/client.ts`) uses configured public cloud URL when set; otherwise falls back to relative URL (`''`) via `/api/*` route
+  - CRUD client (`lib/api/client.ts`) always uses `/api/*` proxy route
   - Agent client (`lib/api/agentClient.ts`) uses `/agent-api/*`
 - Server runtime:
   - CRUD and Agent API routes/clients resolve from env precedence above
@@ -64,6 +64,22 @@ Shared resolver module: `app/api/_shared/base-url-resolver.ts`
   - Agent client derives from resolved CRUD base + `/agents` (fallback `/agents`)
 
 This contract is validated by unit tests in `tests/unit/baseUrlResolverContract.test.ts`.
+
+## Runtime Hosting Mode (Azure Static Web Apps + Next.js)
+
+This UI is deployed on **Azure Static Web Apps with Next.js server runtime enabled** (hybrid mode), not as static-only export.
+
+- Production evidence includes `X-Powered-By: Next.js`.
+- `/api/*` requests are handled by Next Route Handlers and proxied upstream with `x-holiday-peak-proxy: next-app-api`.
+- `next.config.js` uses `output: 'standalone'`, which is compatible with server-side runtime deployment.
+
+### Avoid confusion: Static-only vs Hybrid Next.js on SWA
+
+- **Static-only SWA (no Node runtime)**
+  Uses Next static export (`output: 'export'`), serves prebuilt assets only, and does not execute Next Route Handlers/SSR at request time.
+
+- **SWA + Next server runtime (current model)**
+  Supports SSR/Server Components/Route Handlers and returns runtime signals such as `X-Powered-By: Next.js` and proxy headers from server handlers.
 
 ## Architecture
 

--- a/apps/ui/app/api/_shared/base-url-resolver.ts
+++ b/apps/ui/app/api/_shared/base-url-resolver.ts
@@ -121,29 +121,6 @@ function inferRuntimeKind(env: EnvMap = process.env): RuntimeKind {
   return typeof window === 'undefined' ? 'server' : 'browser';
 }
 
-function resolveCrudBrowserPublicBaseUrlFromProcessEnv(): ResolutionResult {
-  const directPublicCandidates: Array<[string, string | undefined]> = [
-    ['NEXT_PUBLIC_CRUD_API_URL', process.env.NEXT_PUBLIC_CRUD_API_URL],
-    ['NEXT_PUBLIC_API_URL', process.env.NEXT_PUBLIC_API_URL],
-    ['NEXT_PUBLIC_API_BASE_URL', process.env.NEXT_PUBLIC_API_BASE_URL],
-  ];
-
-  for (const [key, value] of directPublicCandidates) {
-    const normalized = normalizeBaseUrl(value);
-    if (normalized) {
-      return {
-        baseUrl: normalized,
-        sourceKey: key,
-      };
-    }
-  }
-
-  return {
-    baseUrl: null,
-    sourceKey: null,
-  };
-}
-
 export function resolveCrudApiClientBaseUrl(params?: {
   env?: EnvMap;
   runtime?: RuntimeKind;
@@ -152,19 +129,9 @@ export function resolveCrudApiClientBaseUrl(params?: {
   const runtime = params?.runtime ?? inferRuntimeKind(env);
 
   if (runtime === 'browser') {
-    const resolved = params?.env
-      ? resolveCrudApiBaseUrl(env)
-      : resolveCrudBrowserPublicBaseUrlFromProcessEnv();
-    if (resolved.baseUrl) {
-      return {
-        ...resolved,
-        runtime,
-      };
-    }
-
     return {
-      baseUrl: '',
-      sourceKey: null,
+      baseUrl: '/api',
+      sourceKey: 'BROWSER_PROXY_ROUTE',
       runtime,
     };
   }

--- a/apps/ui/tests/unit/apiClientMockAuth.test.ts
+++ b/apps/ui/tests/unit/apiClientMockAuth.test.ts
@@ -30,20 +30,20 @@ describe('api client dev mock auth headers', () => {
     return clientModule.apiClient.defaults.baseURL;
   }
 
-  it('uses configured cloud CRUD base URL in browser runtime', async () => {
+  it('uses browser CRUD proxy base URL in browser runtime', async () => {
     process.env.NODE_ENV = 'development';
     process.env.NEXT_PUBLIC_CRUD_API_URL = 'https://apim.example.azure-api.net/';
 
-    await expect(getApiClientBaseUrl()).resolves.toBe('https://apim.example.azure-api.net');
+    await expect(getApiClientBaseUrl()).resolves.toBe('/api');
   });
 
-  it('falls back to relative browser base URL when no public CRUD URL is configured', async () => {
+  it('keeps browser CRUD proxy base URL when no public CRUD URL is configured', async () => {
     process.env.NODE_ENV = 'development';
     delete process.env.NEXT_PUBLIC_CRUD_API_URL;
     delete process.env.NEXT_PUBLIC_API_URL;
     delete process.env.NEXT_PUBLIC_API_BASE_URL;
 
-    await expect(getApiClientBaseUrl()).resolves.toBe('');
+    await expect(getApiClientBaseUrl()).resolves.toBe('/api');
   });
 
   it('adds bearer authorization when auth token exists', async () => {

--- a/apps/ui/tests/unit/baseUrlResolverContract.test.ts
+++ b/apps/ui/tests/unit/baseUrlResolverContract.test.ts
@@ -57,14 +57,14 @@ describe('base URL resolver contract', () => {
   });
 
   describe('resolveCrudApiClientBaseUrl', () => {
-    it('uses direct NEXT_PUBLIC vars in browser runtime when env param is omitted', () => {
+    it('uses browser proxy route in browser runtime when env param is omitted', () => {
       process.env.NEXT_PUBLIC_CRUD_API_URL = 'https://browser-direct.example.net/';
 
       const browser = resolveCrudApiClientBaseUrl({ runtime: 'browser' });
 
       expect(browser).toEqual({
-        baseUrl: 'https://browser-direct.example.net',
-        sourceKey: 'NEXT_PUBLIC_CRUD_API_URL',
+        baseUrl: '/api',
+        sourceKey: 'BROWSER_PROXY_ROUTE',
         runtime: 'browser',
       });
     });
@@ -77,15 +77,15 @@ describe('base URL resolver contract', () => {
         } as NodeJS.ProcessEnv,
       });
       expect(browser).toEqual({
-        baseUrl: 'https://browser.example.net',
-        sourceKey: 'NEXT_PUBLIC_CRUD_API_URL',
+        baseUrl: '/api',
+        sourceKey: 'BROWSER_PROXY_ROUTE',
         runtime: 'browser',
       });
 
       const browserFallback = resolveCrudApiClientBaseUrl({ runtime: 'browser', env: {} as NodeJS.ProcessEnv });
       expect(browserFallback).toEqual({
-        baseUrl: '',
-        sourceKey: null,
+        baseUrl: '/api',
+        sourceKey: 'BROWSER_PROXY_ROUTE',
         runtime: 'browser',
       });
 

--- a/docs/implementation/single-rg-deployment-runbook.md
+++ b/docs/implementation/single-rg-deployment-runbook.md
@@ -59,6 +59,29 @@ This deletes `holidaypeakhub405-dev-rg` asynchronously.
   - `POSTGRES_AUTH_MODE=password`
   - `POSTGRES_AUTH_MODE=entra`
 
+## UI Runtime Clarification (SWA)
+
+The production UI on Azure Static Web Apps runs with **Next.js server runtime (hybrid)**, not static export-only hosting.
+
+- Expected production signals:
+  - `X-Powered-By: Next.js` on UI responses.
+  - `x-holiday-peak-proxy: next-app-api` on `/api/*` responses served via Next Route Handlers.
+- Operational implication: `/api/*` availability depends on Next server runtime health and upstream API reachability.
+
+### How to verify
+
+```bash
+curl -s -D - -o /dev/null https://blue-meadow-00fcb8810.4.azurestaticapps.net/
+curl -s -D - -o /dev/null https://blue-meadow-00fcb8810.4.azurestaticapps.net/api/health
+curl -s -D - -o /dev/null "https://blue-meadow-00fcb8810.4.azurestaticapps.net/api/products?limit=1"
+```
+
+Expected results:
+
+- HTTP status `200` for all three requests.
+- `X-Powered-By: Next.js` present in at least UI/runtime-served responses.
+- `x-holiday-peak-proxy: next-app-api` present on `/api/health` and `/api/products`.
+
 ## Required Governance Action
 
 An external principal (`MCAPSGov-AutomationApp`) is stopping services on a daily cadence. Restrict or exclude this environment from that automation; otherwise, connectivity will continue to break regardless of deployment script quality.

--- a/scripts/ci/validate_swa_hybrid_contract.py
+++ b/scripts/ci/validate_swa_hybrid_contract.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Validate SWA + Next.js hybrid runtime contract.
+
+This guard prevents accidental drift to static-export-only mode that would
+break Next Route Handlers used by `/api/*` and `/agent-api/*` proxy routes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+
+def read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise RuntimeError(f"Unable to read {path}: {exc}") from exc
+
+
+def assert_contains(content: str, needle: str, error: str, failures: list[str]) -> None:
+    if needle not in content:
+        failures.append(error)
+
+
+def validate(repo_root: Path) -> list[str]:
+    failures: list[str] = []
+
+    next_config_path = repo_root / "apps" / "ui" / "next.config.js"
+    deploy_ui_swa_path = repo_root / ".github" / "workflows" / "deploy-ui-swa.yml"
+    deploy_azd_path = repo_root / ".github" / "workflows" / "deploy-azd.yml"
+    api_proxy_path = repo_root / "apps" / "ui" / "app" / "api" / "[...path]" / "route.ts"
+    agent_proxy_path = repo_root / "apps" / "ui" / "app" / "agent-api" / "[...path]" / "route.ts"
+
+    for required in [
+        next_config_path,
+        deploy_ui_swa_path,
+        deploy_azd_path,
+        api_proxy_path,
+        agent_proxy_path,
+    ]:
+        if not required.exists():
+            failures.append(f"Missing required contract file: {required.relative_to(repo_root)}")
+
+    if failures:
+        return failures
+
+    next_config = read_text(next_config_path)
+    deploy_ui_swa = read_text(deploy_ui_swa_path)
+    deploy_azd = read_text(deploy_azd_path)
+    api_proxy = read_text(api_proxy_path)
+    agent_proxy = read_text(agent_proxy_path)
+
+    # Next runtime mode guard
+    assert_contains(
+        next_config,
+        "output: 'standalone'",
+        "apps/ui/next.config.js must keep output: 'standalone' for SWA hybrid runtime.",
+        failures,
+    )
+    if "output: 'export'" in next_config or 'output: "export"' in next_config:
+        failures.append("apps/ui/next.config.js must not use output: 'export' (static-only mode).")
+
+    # Proxy handlers and identity headers guard
+    assert_contains(
+        api_proxy,
+        "next-app-api",
+        "apps/ui/app/api/[...path]/route.ts must preserve next-app-api proxy header contract.",
+        failures,
+    )
+    assert_contains(
+        agent_proxy,
+        "next-app-agent-api",
+        "apps/ui/app/agent-api/[...path]/route.ts must preserve next-app-agent-api proxy header contract.",
+        failures,
+    )
+
+    # SWA deploy contract guard
+    for workflow_name, content in [
+        (".github/workflows/deploy-ui-swa.yml", deploy_ui_swa),
+        (".github/workflows/deploy-azd.yml", deploy_azd),
+    ]:
+        assert_contains(
+            content,
+            "Azure/static-web-apps-deploy@v1",
+            f"{workflow_name} must deploy UI via Azure/static-web-apps-deploy@v1.",
+            failures,
+        )
+        assert_contains(
+            content,
+            "app_location: apps/ui",
+            f"{workflow_name} must keep app_location: apps/ui.",
+            failures,
+        )
+        assert_contains(
+            content,
+            "output_location: ''",
+            f"{workflow_name} must keep output_location: '' for Next runtime handling.",
+            failures,
+        )
+
+    if "next export" in deploy_ui_swa or "next export" in deploy_azd:
+        failures.append("SWA deployment workflow must not use next export for UI build.")
+
+    return failures
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[2]
+    failures = validate(repo_root)
+
+    if failures:
+        print("SWA hybrid runtime contract: FAILED")
+        for failure in failures:
+            print(f"- {failure}")
+        return 2
+
+    print("SWA hybrid runtime contract: PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- force browser CRUD client to use Next `/api` proxy route
- keep APIM upstream routing on server-side handlers
- add push/PR CI contract gate for SWA hybrid runtime (`ui-contract-gate`)
- add deterministic contract validator script (`scripts/ci/validate_swa_hybrid_contract.py`)
- document SWA hybrid runtime vs static-only mode and verification steps

## Validation
- python scripts/ci/validate_swa_hybrid_contract.py
- yarn test tests/unit/staticWebAppConfigParity.test.ts tests/unit/baseUrlResolverContract.test.ts tests/unit/apiProxyRouteEnv.test.ts tests/unit/agentApiProxyRouteEnv.test.ts --runInBand

## Specialist input
- AzureStaticWebAppsSpecialist: SWA runtime contract assertions and docs framing
- PlatformEngineer: push-gate workflow design and deterministic CI setup
