### PR TITLE
Harden APIM reconciliation around ingress-first CRUD routing and unstable backend detection

### DIFF
--- a/.github/workflows/deploy-azd.yml
+++ b/.github/workflows/deploy-azd.yml
@@ -1519,6 +1519,78 @@ jobs:
           tenant-id: ${{ env.AZURE_TENANT_ID }}
           subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
 
+      - name: Validate CRUD APIM backend stability
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          RG_NAME="${{ inputs.projectName }}-${{ inputs.environment }}-rg"
+          APIM_NAME="${{ inputs.projectName }}-${{ inputs.environment }}-apim"
+          AKS_NAME="${{ inputs.projectName }}-${{ inputs.environment }}-aks"
+          K8S_NAMESPACE="holiday-peak"
+
+          fetch_crud_endpoint_ips() {
+            local logs
+            logs=$(az aks command invoke \
+              --resource-group "$RG_NAME" \
+              --name "$AKS_NAME" \
+              --command "kubectl get endpoints crud-service -n $K8S_NAMESPACE -o jsonpath='{.subsets[*].addresses[*].ip}'" \
+              --query logs -o tsv)
+
+            printf '%s' "$logs" | awk 'NF{line=$0} END{print line}'
+          }
+
+          resolve_crud_api_id() {
+            if az apim api show --resource-group "$RG_NAME" --service-name "$APIM_NAME" --api-id "crud-service" --only-show-errors >/dev/null 2>&1; then
+              printf 'crud-service'
+              return 0
+            fi
+
+            if az apim api show --resource-group "$RG_NAME" --service-name "$APIM_NAME" --api-id "crud" --only-show-errors >/dev/null 2>&1; then
+              printf 'crud'
+              return 0
+            fi
+
+            echo "Neither APIM API id 'crud-service' nor 'crud' exists in '$APIM_NAME'." >&2
+            return 1
+          }
+
+          extract_host() {
+            local url="$1"
+            python3 -c "from urllib.parse import urlparse; import sys; print(urlparse(sys.argv[1]).hostname or '')" "$url"
+          }
+
+          CRUD_ENDPOINT_IPS_RAW="$(fetch_crud_endpoint_ips)"
+          CRUD_ENDPOINT_IPS="$(printf '%s\n' "$CRUD_ENDPOINT_IPS_RAW" | tr ' ' '\n' | sed '/^[[:space:]]*$/d' | sort -u)"
+
+          if [ -z "$CRUD_ENDPOINT_IPS" ]; then
+            echo "Failed to resolve current endpoint IPs for crud-service in namespace '$K8S_NAMESPACE'." >&2
+            exit 1
+          fi
+
+          API_ID="$(resolve_crud_api_id)"
+          SERVICE_URL="$(az apim api show --resource-group "$RG_NAME" --service-name "$APIM_NAME" --api-id "$API_ID" --query serviceUrl -o tsv --only-show-errors)"
+          SERVICE_URL="$(printf '%s' "$SERVICE_URL" | xargs)"
+
+          if [ -z "$SERVICE_URL" ]; then
+            echo "APIM CRUD API '$API_ID' has an empty serviceUrl." >&2
+            exit 1
+          fi
+
+          SERVICE_HOST="$(extract_host "$SERVICE_URL")"
+          if [ -z "$SERVICE_HOST" ]; then
+            echo "Unable to parse host from APIM CRUD serviceUrl '$SERVICE_URL'." >&2
+            exit 1
+          fi
+
+          if printf '%s\n' "$CRUD_ENDPOINT_IPS" | grep -Fxq "$SERVICE_HOST"; then
+            echo "Unstable APIM backend detected: API '$API_ID' serviceUrl '$SERVICE_URL' points to current crud-service endpoint IP '$SERVICE_HOST'." >&2
+            echo "Current crud-service endpoint IPs: $(printf '%s\n' "$CRUD_ENDPOINT_IPS" | paste -sd ',' -)" >&2
+            exit 1
+          fi
+
+          echo "Validated APIM CRUD backend stability: API '$API_ID' serviceUrl host '$SERVICE_HOST' is not a current crud-service endpoint IP."
+
       - name: Resolve APIM gateway URL
         id: apim
         shell: bash

--- a/.infra/azd/hooks/sync-apim-agents.ps1
+++ b/.infra/azd/hooks/sync-apim-agents.ps1
@@ -544,6 +544,62 @@ function Resolve-ServiceBackendUrl {
     return "http://$Service-$Service.$Namespace.svc.cluster.local:$servicePort"
 }
 
+function Get-ServiceEndpointIps {
+    param(
+        [Parameter(Mandatory = $true)][string]$Service,
+        [Parameter(Mandatory = $true)][string]$Namespace
+    )
+
+    $endpointIps = @()
+
+    if (Get-Command kubectl -ErrorAction SilentlyContinue) {
+        $ipsFromKubectl = kubectl get endpoints $Service -n $Namespace -o jsonpath="{.subsets[*].addresses[*].ip}" 2>$null
+        if ($LASTEXITCODE -eq 0 -and $ipsFromKubectl) {
+            $endpointIps += @($ipsFromKubectl -split '\s+' | Where-Object { $_ })
+        }
+    }
+
+    if (($endpointIps.Count -eq 0) -and $script:resolvedAksClusterName -and $script:resolvedResourceGroup) {
+        $ipsFromAksCommand = Invoke-AksKubectlJsonPath -Rg $script:resolvedResourceGroup -ClusterName $script:resolvedAksClusterName -KubectlArgs "get endpoints $Service -n $Namespace -o jsonpath='{.subsets[*].addresses[*].ip}'"
+        if ($ipsFromAksCommand) {
+            $endpointIps += @($ipsFromAksCommand -split '\s+' | Where-Object { $_ })
+        }
+    }
+
+    return @($endpointIps | Sort-Object -Unique)
+}
+
+function Get-UrlHost {
+    param([Parameter(Mandatory = $true)][string]$Url)
+
+    try {
+        return ([uri]$Url).Host
+    }
+    catch {
+        return ''
+    }
+}
+
+function Assert-StableCrudBackendTarget {
+    param(
+        [Parameter(Mandatory = $true)][string]$BackendUrl,
+        [Parameter(Mandatory = $true)][string]$Namespace
+    )
+
+    $backendHost = Get-UrlHost -Url $BackendUrl
+    if (-not $backendHost) {
+        throw "Unable to parse host from CRUD APIM backend URL '$BackendUrl'."
+    }
+
+    $endpointIps = Get-ServiceEndpointIps -Service 'crud-service' -Namespace $Namespace
+    if ($endpointIps -contains $backendHost) {
+        $joinedIps = $endpointIps -join ', '
+        throw "Refusing to set unstable CRUD APIM backend '$BackendUrl': host '$backendHost' matches current crud-service endpoint IP(s): $joinedIps"
+    }
+
+    Write-Host "Validated stable CRUD APIM backend host '$backendHost'."
+}
+
 function Ensure-AgentApi {
     param(
         [Parameter(Mandatory = $true)][string]$Rg,
@@ -628,6 +684,7 @@ function Update-CrudApi {
     }
 
     $backend = Resolve-ServiceBackendUrl -Service $service -Namespace $Ns -RequireLb:$RequireLoadBalancer -Retries $BackendResolveRetries -DelaySeconds $BackendResolveDelaySeconds
+    Assert-StableCrudBackendTarget -BackendUrl $backend -Namespace $Ns
 
     $apiExists = $false
     az apim api show --resource-group $Rg --service-name $Apim --api-id 'crud-service' --only-show-errors *> $null

--- a/.infra/azd/hooks/sync-apim-agents.sh
+++ b/.infra/azd/hooks/sync-apim-agents.sh
@@ -430,6 +430,60 @@ resolve_backend_url() {
   printf 'http://%s-%s.%s.svc.cluster.local:80' "$svc" "$svc" "$NAMESPACE"
 }
 
+get_service_endpoint_ips() {
+  svc="$1"
+  ns="$2"
+  endpoint_ips=""
+
+  if command -v kubectl >/dev/null 2>&1; then
+    endpoint_ips="$(kubectl get endpoints "$svc" -n "$ns" -o jsonpath='{.subsets[*].addresses[*].ip}' 2>/dev/null || true)"
+  fi
+
+  if [ -z "$endpoint_ips" ] && [ -n "$AKS_CLUSTER_NAME" ] && [ -n "$RESOURCE_GROUP" ]; then
+    aks_logs="$(az aks command invoke \
+      --resource-group "$RESOURCE_GROUP" \
+      --name "$AKS_CLUSTER_NAME" \
+      --command "kubectl get endpoints $svc -n $ns -o jsonpath='{.subsets[*].addresses[*].ip}'" \
+      --query logs -o tsv 2>/dev/null || true)"
+
+    endpoint_ips="$(printf '%s' "$aks_logs" | awk 'NF{line=$0} END{print line}')"
+  fi
+
+  printf '%s' "$endpoint_ips"
+}
+
+get_url_host() {
+  url="$1"
+
+  python3 - "$url" <<'PY'
+import sys
+from urllib.parse import urlparse
+
+value = sys.argv[1]
+parsed = urlparse(value)
+print(parsed.hostname or "")
+PY
+}
+
+assert_stable_crud_backend_target() {
+  backend_url="$1"
+  backend_host="$(get_url_host "$backend_url")"
+
+  if [ -z "$backend_host" ]; then
+    echo "Unable to parse host from CRUD APIM backend URL '$backend_url'." >&2
+    return 1
+  fi
+
+  endpoint_ips="$(get_service_endpoint_ips crud-service "$NAMESPACE")"
+  if [ -n "$endpoint_ips" ] && printf '%s\n' "$endpoint_ips" | tr ' ' '\n' | sed '/^[[:space:]]*$/d' | grep -Fxq "$backend_host"; then
+    endpoint_list="$(printf '%s\n' "$endpoint_ips" | tr ' ' '\n' | sed '/^[[:space:]]*$/d' | paste -sd ',' -)"
+    echo "Refusing to set unstable CRUD APIM backend '$backend_url': host '$backend_host' matches current crud-service endpoint IP(s): $endpoint_list" >&2
+    return 1
+  fi
+
+  echo "Validated stable CRUD APIM backend host '$backend_host'."
+}
+
 ensure_crud_api() {
   API_ID="crud"
   DISPLAY_NAME="CRUD Service"
@@ -441,6 +495,7 @@ ensure_crud_api() {
   fi
 
   BACKEND_URL="$(resolve_backend_url crud-service)"
+  assert_stable_crud_backend_target "$BACKEND_URL"
 
   if az apim api show --resource-group "$RESOURCE_GROUP" --service-name "$APIM_NAME" --api-id "crud-service" >/dev/null 2>&1; then
     API_ID="crud-service"

--- a/azure.yaml
+++ b/azure.yaml
@@ -510,12 +510,12 @@ hooks:
     windows:
       shell: pwsh
       run: |
-        ./.infra/azd/hooks/sync-apim-agents.ps1 -Namespace holiday-peak -ApiPathPrefix agents -IncludeCrudService:$true -RequireLoadBalancer:$true
+        ./.infra/azd/hooks/sync-apim-agents.ps1 -Namespace holiday-peak -ApiPathPrefix agents -UseIngress -IncludeCrudService:$true
         ./.infra/azd/hooks/ensure-foundry-agents.ps1 -UsePortForward -FailOnError:$false
       interactive: false
     posix:
       shell: sh
       run: |
-        ./.infra/azd/hooks/sync-apim-agents.sh --namespace holiday-peak --api-path-prefix agents --require-load-balancer
+        ./.infra/azd/hooks/sync-apim-agents.sh --namespace holiday-peak --api-path-prefix agents --use-ingress
         ./.infra/azd/hooks/ensure-foundry-agents.sh --port-forward --non-blocking
       interactive: false

--- a/docs/roadmap/001-crud-apim-routing.md
+++ b/docs/roadmap/001-crud-apim-routing.md
@@ -41,14 +41,15 @@ The `sync-apim-agents` deployment job was designed for agent services only. The 
   - `/api` and `/api/{*path}`
   - `/acp/{*path}`
 - This enables frontend calls proxied as `/api/*` to resolve through APIM to the CRUD backend.
-- `azure.yaml` postdeploy now enforces CRUD inclusion explicitly in APIM sync for `azd up`.
+- `.github/workflows/deploy-azd.yml` is the official APIM reconciliation source of truth and runs ingress/App Gateway-first sync.
+- `azure.yaml` postdeploy now mirrors that same ingress/App Gateway-first APIM sync model for `azd up`, while still forcing CRUD inclusion.
 - `.infra/azd/main.bicep` now exports `APIM_NAME` and `AKS_CLUSTER_NAME` to strengthen hook resolution in fresh environments.
 
 ## Validation Snapshot (2026-02-28, env: `dev` / `405`)
 
 - `GET https://holidaypeakhub405-dev-apim.azure-api.net/api/health` returns `200`.
 - `GET https://holidaypeakhub405-dev-apim.azure-api.net/api/products?limit=1` reaches CRUD auth flow (returns `401` when unauthenticated), confirming APIM route-to-backend correctness.
-- CRUD remains included in strict postdeploy APIM sync (`-IncludeCrudService:$true -RequireLoadBalancer:$true`) and stays healthy in full 22-service sweep.
+- CRUD remains included in strict postdeploy APIM sync (`-UseIngress -IncludeCrudService:$true`) and stays healthy in full 22-service sweep.
 
 ## Recurrence Hardening (Mar 2026)
 
@@ -72,6 +73,9 @@ These controls reduce the chance that frontend `/api/products` or `/api/categori
   - Auto-resolution is allowed only when a single unambiguous candidate exists.
   - Ambiguous routing candidates now fail fast.
 - Before any APIM update in ingress mode, hooks probe `http://<resolved-ingress-host>/health` and abort on unhealthy/invalid resolution.
+- APIM sync hooks now include a CRUD backend stability guard that fails if resolved CRUD `serviceUrl` host matches a current `crud-service` endpoint IP.
+- Reusable deploy workflow now validates APIM CRUD `serviceUrl` (`crud-service` fallback `crud`) against live `crud-service` endpoint IPs via `az aks command invoke`, and fails before smoke tests on unstable target detection.
+- Demo recovery now explicitly re-runs ingress/App Gateway-first APIM reconciliation before validating APIM CRUD endpoints or reseeding demo data.
 
 ## Closure Status Update (2026-03-06, PR #198)
 

--- a/scripts/ops/demo-recover-and-seed.ps1
+++ b/scripts/ops/demo-recover-and-seed.ps1
@@ -12,6 +12,7 @@ $aksName = "$ProjectName-$Environment-aks"
 $appGwName = "$ProjectName-$Environment-appgw"
 $postgresName = "$ProjectName-$Environment-postgres"
 $apimBase = "https://$ProjectName-$Environment-apim.azure-api.net"
+$apimName = "$ProjectName-$Environment-apim"
 
 Write-Host "Starting AKS, Application Gateway, and PostgreSQL in '$resourceGroup'..."
 az aks start -g "$resourceGroup" -n "$aksName" | Out-Null
@@ -24,6 +25,9 @@ for ($i = 0; $i -lt 30; $i++) {
     if ($state -eq "Running") { break }
     Start-Sleep -Seconds 20
 }
+
+Write-Host "Re-running APIM reconciliation through App Gateway before validation..."
+.\.infra\azd\hooks\sync-apim-agents.ps1 -ResourceGroup $resourceGroup -ApimName $apimName -Namespace $Namespace -ApiPathPrefix agents -UseIngress -AppGatewayName $appGwName -IncludeCrudService:$true
 
 Write-Host "Validating APIM CRUD endpoints..."
 $paths = @("/api/health", "/api/products?limit=1", "/api/categories")


### PR DESCRIPTION
## Summary
This PR is limited to repository automation hardening. It aligns APIM reconciliation and demo recovery flows to prefer ingress/App Gateway-backed routing for CRUD, adds guards to prevent APIM from being pointed at ephemeral pod endpoint IPs, and documents the hardened deployment behavior.

This PR does not remediate the current live Azure runtime drift. That remains separate tracked operational work.

## Key Changes
- Add a reusable deploy workflow guard in `.github/workflows/deploy-azd.yml` that fails validation if the APIM CRUD `serviceUrl` resolves to a current `crud-service` endpoint IP.
- Update both APIM sync hooks in `.infra/azd/hooks/sync-apim-agents.ps1` and `.infra/azd/hooks/sync-apim-agents.sh` to inspect live `crud-service` endpoint IPs and refuse to program APIM with an unstable CRUD backend target.
- Change `azure.yaml` postdeploy hooks to use ingress mode for APIM sync while still explicitly including CRUD in reconciliation.
- Update `scripts/ops/demo-recover-and-seed.ps1` so recovery re-runs APIM reconciliation through App Gateway before validating CRUD endpoints or reseeding demo data.
- Refresh `docs/roadmap/001-crud-apim-routing.md` to record the new source of truth, stability guardrails, and recovery sequencing.

## Validation
- `python -m pytest`
- Targeted UI routing/contract coverage already passed earlier in this workspace:
  - `tests/unit/baseUrlResolverContract.test.ts`
  - `tests/unit/apiClientMockAuth.test.ts`
  - `tests/unit/apiProxyRouteEnv.test.ts`
  - `tests/unit/agentApiProxyRouteEnv.test.ts`
  - `tests/unit/SearchPage.test.tsx`
- Local file validation passed for the newly changed recovery/deploy config surfaces:
  - PowerShell parse validation for `scripts/ops/demo-recover-and-seed.ps1`
  - `git diff --check -- azure.yaml scripts/ops/demo-recover-and-seed.ps1 docs/roadmap/001-crud-apim-routing.md`

## Residual Operational Risk
This PR does not fix the already-drifted live environment.

Current observed runtime drift remains:
- APIM CRUD still points directly to live pod IP `10.0.8.20`
- App Gateway still carries stale backend `10.0.8.27`
- Live Azure remediation is still required before the environment can be considered reconciled end to end

This PR reduces the chance of reintroducing the same misconfiguration through deploy/recovery automation, but it should not be represented as a live-environment fix.

## Linked Issues
- Closes or advances: `#278`
- Closes or advances: `#279`
- Parent tracking: `#280`

## Scope Boundary
Repository automation hardening only. Live Azure reconciliation and App Gateway runtime repair remain separate operational execution under the linked issues.
