### PR TITLE
infra: enable AGC shared infrastructure support

### DIFF
--- a/.infra/DEPLOYMENT.md
+++ b/.infra/DEPLOYMENT.md
@@ -124,7 +124,15 @@ azd provision -e dev
 | 13 | AI Foundry Project | `avm/ptn/ai-ml/ai-foundry:0.6.0` | AI/ML models |
 | 14 | AKS (3 pools) | `avm/res/container-service/managed-cluster:0.12.0` | Compute |
 | 15 | APIM | `avm/res/api-management/service:0.14.0` | API gateway |
-| — | 6 RBAC assignments | Native | Identity permissions |
+| 16 | AGC controller identity | Native | ALB controller workload identity |
+| — | 6-9 RBAC assignments | Native | Identity permissions |
+
+If `agcSupportEnabled` is enabled for the environment, the shared stack also provisions:
+- a delegated `agc` subnet sized for AGC association capacity,
+- workload identity federation for `azure-alb-system/alb-controller-sa`,
+- RBAC for AGC controller access to the AKS node resource group and delegated subnet.
+
+During `azd provision`, the `postprovision` hook installs the ALB controller Helm chart and validates that GatewayClass `azure-alb-external` is present. No `ApplicationLoadBalancer` or workload route is created in this step.
 
 **Private endpoints** are created for: ACR, Cosmos DB, Redis, Storage, Event Hubs, Key Vault, AI Services.
 
@@ -184,6 +192,10 @@ Key outputs:
 - `apimGatewayUrl` — APIM gateway URL
 - `appInsightsConnectionString` — App Insights connection string
 - `aiProjectName` — AI Foundry project name
+- `agcSubnetId` — Delegated subnet reserved for AGC associations
+- `agcControllerDeploymentMode` — Controller installation mode for downstream automation
+- `agcGatewayClass` — GatewayClass to target in later Kubernetes routing issues
+- `agcFrontendReference` — Equivalent frontend reference exported before any real AGC frontend exists
 
 ---
 

--- a/.infra/README.md
+++ b/.infra/README.md
@@ -77,6 +77,7 @@ All resources use AVM (Azure Verified Modules) and deploy to **eastus2** by defa
 | Resource | AVM Module | Purpose |
 |----------|-----------|---------|
 | AKS (3 node pools) | `avm/res/container-service/managed-cluster:0.12.0` | Compute for all services |
+| AGC controller identity | Native | Workload identity principal for the ALB controller |
 | ACR (Premium) | `avm/res/container-registry/registry:0.9.3` | Container image registry |
 | PostgreSQL Flexible Server | `avm/res/db-for-postgre-sql/flexible-server:0.15.0` | CRUD transactional operations |
 | Cosmos DB | `avm/res/document-db/database-account:0.18.0` | Agent warm memory |
@@ -86,8 +87,8 @@ All resources use AVM (Azure Verified Modules) and deploy to **eastus2** by defa
 | Key Vault (Premium) | `avm/res/key-vault/vault:0.13.3` | Secrets + certificates |
 | API Management | `avm/res/api-management/service:0.14.0` | API gateway |
 | AI Foundry Project | `avm/ptn/ai-ml/ai-foundry:0.6.0` | AI/ML model management (pinned to `westus3`, public network enabled) |
-| VNet (5 subnets) | `avm/res/network/virtual-network:0.7.2` | Network isolation |
-| 5 NSGs | `avm/res/network/network-security-group:0.5.2` | Subnet-level security |
+| VNet (5-6 subnets) | `avm/res/network/virtual-network:0.7.2` | Network isolation |
+| 5-6 NSGs | `avm/res/network/network-security-group:0.5.2` | Subnet-level security |
 | 8 Private DNS Zones | `avm/res/network/private-dns-zone:0.8.0` | Private endpoint DNS resolution |
 | Log Analytics | `avm/res/operational-insights/workspace:0.15.0` | Centralized logging |
 | App Insights | `avm/res/insights/component:0.7.1` | Application monitoring |
@@ -118,6 +119,7 @@ All resources use AVM (Azure Verified Modules) and deploy to **eastus2** by defa
 | `aks-crud` | `10.0.8.0/24` | AKS CRUD node pool |
 | `apim` | `10.0.9.0/24` | API Management (prod: Internal VNet) |
 | `private-endpoints` | `10.0.10.0/24` | Private endpoint NICs |
+| `agc` | `10.0.11.0/24` by default | Delegated subnet for Application Gateway for Containers |
 
 ### RBAC Assignments (6)
 
@@ -155,6 +157,8 @@ az deployment sub create \
 ```
 
 **What this creates**: AKS cluster (3 pools), ACR, PostgreSQL (CRUD), Cosmos DB (agent warm memory), Event Hubs (5 topics), Redis, Storage, Key Vault, APIM, AI Foundry Project, VNet (5 subnets + 5 NSGs), 8 Private DNS Zones with Private Endpoints, App Insights, Log Analytics, 6 RBAC assignments
+
+When `agcSupportEnabled` is on, shared infrastructure also creates the delegated AGC subnet, the ALB controller workload identity, and the RBAC required for later AGC route publication. The `azd` postprovision flow then installs the ALB controller into AKS without cutting over any workloads.
 
 **Duration**: ~25 minutes | **Cost**: see [Cost Estimates](#-cost-estimates)
 

--- a/.infra/azd/hooks/ensure-agc-controller.ps1
+++ b/.infra/azd/hooks/ensure-agc-controller.ps1
@@ -1,0 +1,140 @@
+#!/usr/bin/env pwsh
+param(
+    [string]$ResourceGroup = $env:AZURE_RESOURCE_GROUP,
+    [string]$AksClusterName = $env:AKS_CLUSTER_NAME,
+    [string]$AgcSupportEnabled = $env:AGC_SUPPORT_ENABLED,
+    [string]$ControllerIdentityClientId = $env:AGC_CONTROLLER_IDENTITY_CLIENT_ID,
+    [string]$ControllerIdentityPrincipalId = $env:AGC_CONTROLLER_IDENTITY_PRINCIPAL_ID,
+    [string]$AgcSubnetId = $env:AGC_SUBNET_ID,
+    [string]$AksNodeResourceGroup = $env:AKS_NODE_RESOURCE_GROUP
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Resolve-Path "$PSScriptRoot\..\..\.."
+
+function Get-EnvValueFromFile {
+    param([string]$FilePath, [string]$Key)
+    if (-not (Test-Path $FilePath)) { return '' }
+    foreach ($line in Get-Content $FilePath) {
+        if ($line -match "^$Key=(.*)$") { return $Matches[1].Trim('"') }
+    }
+    return ''
+}
+
+function Resolve-EnvValue {
+    param([string[]]$Keys, [string]$CurrentValue)
+    if ($CurrentValue) { return $CurrentValue }
+    if (-not $env:AZURE_ENV_NAME) { return '' }
+
+    $envFile = Join-Path $repoRoot ".azure\$($env:AZURE_ENV_NAME)\.env"
+    foreach ($key in $Keys) {
+        $value = Get-EnvValueFromFile -FilePath $envFile -Key $key
+        if ($value) { return $value }
+    }
+
+    return ''
+}
+
+function Ensure-RoleAssignment {
+    param(
+        [string]$PrincipalId,
+        [string]$Scope,
+        [string]$RoleDefinitionId
+    )
+
+    $existing = az role assignment list --assignee-object-id $PrincipalId --scope $Scope --query "[?roleDefinitionId=='$RoleDefinitionId'] | length(@)" -o tsv 2>$null
+    if ($existing -and $existing -ne '0') {
+        return
+    }
+
+    az role assignment create --assignee-object-id $PrincipalId --assignee-principal-type ServicePrincipal --scope $Scope --role $RoleDefinitionId --only-show-errors | Out-Null
+}
+
+$AgcSupportEnabled = Resolve-EnvValue -Keys @('AGC_SUPPORT_ENABLED') -CurrentValue $AgcSupportEnabled
+if (($AgcSupportEnabled ?? '').ToLowerInvariant() -ne 'true') {
+    Write-Host 'AGC support is disabled for this environment. Skipping ALB controller installation.'
+    exit 0
+}
+
+$ResourceGroup = Resolve-EnvValue -Keys @('AZURE_RESOURCE_GROUP', 'resourceGroupName') -CurrentValue $ResourceGroup
+$AksClusterName = Resolve-EnvValue -Keys @('AKS_CLUSTER_NAME', 'aksClusterName') -CurrentValue $AksClusterName
+$ControllerIdentityClientId = Resolve-EnvValue -Keys @('AGC_CONTROLLER_IDENTITY_CLIENT_ID') -CurrentValue $ControllerIdentityClientId
+$ControllerIdentityPrincipalId = Resolve-EnvValue -Keys @('AGC_CONTROLLER_IDENTITY_PRINCIPAL_ID') -CurrentValue $ControllerIdentityPrincipalId
+$AgcSubnetId = Resolve-EnvValue -Keys @('AGC_SUBNET_ID') -CurrentValue $AgcSubnetId
+$AksNodeResourceGroup = Resolve-EnvValue -Keys @('AKS_NODE_RESOURCE_GROUP') -CurrentValue $AksNodeResourceGroup
+
+if (-not $ResourceGroup) {
+    throw 'Resource group could not be resolved. Set AZURE_RESOURCE_GROUP or run within an azd environment.'
+}
+
+if (-not $AksClusterName) {
+    throw 'AKS cluster name could not be resolved. Set AKS_CLUSTER_NAME or run within an azd environment.'
+}
+
+if (-not $ControllerIdentityClientId) {
+    throw 'AGC controller identity client ID could not be resolved. Provision shared infrastructure before running this hook.'
+}
+
+if (-not $ControllerIdentityPrincipalId) {
+    throw 'AGC controller identity principal ID could not be resolved. Provision shared infrastructure before running this hook.'
+}
+
+if (-not $AgcSubnetId) {
+    throw 'AGC subnet ID could not be resolved. Provision shared infrastructure before running this hook.'
+}
+
+if (-not $AksNodeResourceGroup) {
+    throw 'AKS node resource group could not be resolved. Provision shared infrastructure before running this hook.'
+}
+
+foreach ($commandName in @('az', 'kubectl', 'helm')) {
+    if (-not (Get-Command $commandName -ErrorAction SilentlyContinue)) {
+        throw "Required command '$commandName' is not available on PATH."
+    }
+}
+
+Write-Host "Installing AGC ALB controller support for cluster '$AksClusterName' in resource group '$ResourceGroup'."
+
+$subscriptionId = az account show --query id -o tsv
+$aksNodeResourceGroupId = "/subscriptions/$subscriptionId/resourceGroups/$AksNodeResourceGroup"
+
+Ensure-RoleAssignment -PrincipalId $ControllerIdentityPrincipalId -Scope $aksNodeResourceGroupId -RoleDefinitionId 'acdd72a7-3385-48ef-bd42-f606fba81ae7'
+Ensure-RoleAssignment -PrincipalId $ControllerIdentityPrincipalId -Scope $aksNodeResourceGroupId -RoleDefinitionId 'fbc52c3f-28ad-4303-a892-8a056630b8f1'
+Ensure-RoleAssignment -PrincipalId $ControllerIdentityPrincipalId -Scope $AgcSubnetId -RoleDefinitionId '4d97b98b-1d4f-4787-a291-c67834d212e7'
+
+az aks get-credentials --resource-group $ResourceGroup --name $AksClusterName --overwrite-existing --only-show-errors | Out-Null
+
+$releaseStatus = $null
+try {
+    $releaseStatus = helm status alb-controller --namespace azure-alb-system 2>$null
+} catch {
+    $releaseStatus = $null
+}
+
+$helmArgs = @(
+    'upgrade'
+    '--install'
+    'alb-controller'
+    'oci://mcr.microsoft.com/application-lb/charts/alb-controller'
+    '--namespace'
+    'azure-alb-system'
+    '--create-namespace'
+    '--version'
+    '1.9.13'
+    '--set'
+    'albController.namespace=azure-alb-system'
+    '--set'
+    "albController.podIdentity.clientID=$ControllerIdentityClientId"
+)
+
+helm @helmArgs | Out-Null
+
+kubectl rollout status deployment/alb-controller -n azure-alb-system --timeout=300s | Out-Null
+kubectl get gatewayclass azure-alb-external -o name | Out-Null
+
+if ($releaseStatus) {
+    Write-Host 'AGC ALB controller is up to date.'
+} else {
+    Write-Host 'AGC ALB controller installed successfully.'
+}

--- a/.infra/azd/hooks/ensure-agc-controller.sh
+++ b/.infra/azd/hooks/ensure-agc-controller.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env sh
+set -eu
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+RESOURCE_GROUP="${AZURE_RESOURCE_GROUP:-${RESOURCE_GROUP:-}}"
+AKS_CLUSTER_NAME="${AKS_CLUSTER_NAME:-}"
+AGC_SUPPORT_ENABLED="${AGC_SUPPORT_ENABLED:-}"
+AGC_CONTROLLER_IDENTITY_CLIENT_ID="${AGC_CONTROLLER_IDENTITY_CLIENT_ID:-}"
+AGC_CONTROLLER_IDENTITY_PRINCIPAL_ID="${AGC_CONTROLLER_IDENTITY_PRINCIPAL_ID:-}"
+AGC_SUBNET_ID="${AGC_SUBNET_ID:-}"
+AKS_NODE_RESOURCE_GROUP="${AKS_NODE_RESOURCE_GROUP:-}"
+
+resolve_env_value() {
+  current_value="$1"
+  shift
+
+  if [ -n "$current_value" ]; then
+    printf '%s' "$current_value"
+    return 0
+  fi
+
+  if [ -z "${AZURE_ENV_NAME:-}" ]; then
+    return 0
+  fi
+
+  env_file="$REPO_ROOT/.azure/$AZURE_ENV_NAME/.env"
+  if [ ! -f "$env_file" ]; then
+    return 0
+  fi
+
+  for key in "$@"; do
+    value="$(grep -E "^${key}=" "$env_file" | head -n 1 | cut -d '=' -f2- | tr -d '"' || true)"
+    if [ -n "$value" ]; then
+      printf '%s' "$value"
+      return 0
+    fi
+  done
+}
+
+ensure_role_assignment() {
+  principal_id="$1"
+  scope="$2"
+  role_definition_id="$3"
+
+  existing_count="$(az role assignment list --assignee-object-id "$principal_id" --scope "$scope" --query "[?roleDefinitionId=='$role_definition_id'] | length(@)" -o tsv 2>/dev/null || true)"
+  if [ -n "$existing_count" ] && [ "$existing_count" != "0" ]; then
+    return 0
+  fi
+
+  az role assignment create --assignee-object-id "$principal_id" --assignee-principal-type ServicePrincipal --scope "$scope" --role "$role_definition_id" --only-show-errors >/dev/null
+}
+
+AGC_SUPPORT_ENABLED="$(resolve_env_value "$AGC_SUPPORT_ENABLED" AGC_SUPPORT_ENABLED)"
+if [ "${AGC_SUPPORT_ENABLED:-}" != "true" ]; then
+  echo "AGC support is disabled for this environment. Skipping ALB controller installation."
+  exit 0
+fi
+
+RESOURCE_GROUP="$(resolve_env_value "$RESOURCE_GROUP" AZURE_RESOURCE_GROUP resourceGroupName)"
+AKS_CLUSTER_NAME="$(resolve_env_value "$AKS_CLUSTER_NAME" AKS_CLUSTER_NAME aksClusterName)"
+AGC_CONTROLLER_IDENTITY_CLIENT_ID="$(resolve_env_value "$AGC_CONTROLLER_IDENTITY_CLIENT_ID" AGC_CONTROLLER_IDENTITY_CLIENT_ID)"
+AGC_CONTROLLER_IDENTITY_PRINCIPAL_ID="$(resolve_env_value "$AGC_CONTROLLER_IDENTITY_PRINCIPAL_ID" AGC_CONTROLLER_IDENTITY_PRINCIPAL_ID)"
+AGC_SUBNET_ID="$(resolve_env_value "$AGC_SUBNET_ID" AGC_SUBNET_ID)"
+AKS_NODE_RESOURCE_GROUP="$(resolve_env_value "$AKS_NODE_RESOURCE_GROUP" AKS_NODE_RESOURCE_GROUP)"
+
+if [ -z "$RESOURCE_GROUP" ]; then
+  echo "Resource group could not be resolved. Set AZURE_RESOURCE_GROUP or run within an azd environment."
+  exit 1
+fi
+
+if [ -z "$AKS_CLUSTER_NAME" ]; then
+  echo "AKS cluster name could not be resolved. Set AKS_CLUSTER_NAME or run within an azd environment."
+  exit 1
+fi
+
+if [ -z "$AGC_CONTROLLER_IDENTITY_CLIENT_ID" ]; then
+  echo "AGC controller identity client ID could not be resolved. Provision shared infrastructure before running this hook."
+  exit 1
+fi
+
+if [ -z "$AGC_CONTROLLER_IDENTITY_PRINCIPAL_ID" ]; then
+  echo "AGC controller identity principal ID could not be resolved. Provision shared infrastructure before running this hook."
+  exit 1
+fi
+
+if [ -z "$AGC_SUBNET_ID" ]; then
+  echo "AGC subnet ID could not be resolved. Provision shared infrastructure before running this hook."
+  exit 1
+fi
+
+if [ -z "$AKS_NODE_RESOURCE_GROUP" ]; then
+  echo "AKS node resource group could not be resolved. Provision shared infrastructure before running this hook."
+  exit 1
+fi
+
+for command_name in az kubectl helm; do
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    echo "Required command '$command_name' is not available on PATH."
+    exit 1
+  fi
+done
+
+echo "Installing AGC ALB controller support for cluster '$AKS_CLUSTER_NAME' in resource group '$RESOURCE_GROUP'."
+
+SUBSCRIPTION_ID="$(az account show --query id -o tsv)"
+AKS_NODE_RESOURCE_GROUP_ID="/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$AKS_NODE_RESOURCE_GROUP"
+
+ensure_role_assignment "$AGC_CONTROLLER_IDENTITY_PRINCIPAL_ID" "$AKS_NODE_RESOURCE_GROUP_ID" "acdd72a7-3385-48ef-bd42-f606fba81ae7"
+ensure_role_assignment "$AGC_CONTROLLER_IDENTITY_PRINCIPAL_ID" "$AKS_NODE_RESOURCE_GROUP_ID" "fbc52c3f-28ad-4303-a892-8a056630b8f1"
+ensure_role_assignment "$AGC_CONTROLLER_IDENTITY_PRINCIPAL_ID" "$AGC_SUBNET_ID" "4d97b98b-1d4f-4787-a291-c67834d212e7"
+
+az aks get-credentials --resource-group "$RESOURCE_GROUP" --name "$AKS_CLUSTER_NAME" --overwrite-existing --only-show-errors >/dev/null
+
+helm upgrade --install alb-controller oci://mcr.microsoft.com/application-lb/charts/alb-controller \
+  --namespace azure-alb-system \
+  --create-namespace \
+  --version 1.9.13 \
+  --set albController.namespace=azure-alb-system \
+  --set "albController.podIdentity.clientID=$AGC_CONTROLLER_IDENTITY_CLIENT_ID" >/dev/null
+
+kubectl rollout status deployment/alb-controller -n azure-alb-system --timeout=300s >/dev/null
+kubectl get gatewayclass azure-alb-external -o name >/dev/null
+
+echo "AGC ALB controller is ready."

--- a/.infra/azd/main.bicep
+++ b/.infra/azd/main.bicep
@@ -11,8 +11,12 @@ param environment string = 'dev'
 param projectName string = 'holidaypeakhub'
 @description('Optional override for Key Vault name (3-24 chars, lowercase letters, numbers, and hyphens).')
 param keyVaultNameOverride string = ''
-@description('Enable AKS Web App Routing addon. Keep disabled for AGIC/App Gateway-first ingress topology.')
+@description('Enable the legacy AKS Web App Routing addon. Keep disabled for the AGC target edge posture.')
 param aksWebApplicationRoutingEnabled bool = false
+@description('Enable Application Gateway for Containers shared-infrastructure prerequisites for the dev environment.')
+param agcSupportEnabled bool = environment == 'dev'
+@description('CIDR prefix for the delegated AGC subnet. Must provide at least 256 available IPs.')
+param agcSubnetAddressPrefix string = '10.0.11.0/24'
 @secure()
 @description('Optional PostgreSQL admin password for CRUD database. Leave empty to auto-generate.')
 param postgresAdminPassword string = ''
@@ -34,6 +38,8 @@ module sharedInfra '../modules/shared-infrastructure/shared-infrastructure-main.
     projectName: projectName
     keyVaultNameOverride: keyVaultNameOverride
     aksWebApplicationRoutingEnabled: aksWebApplicationRoutingEnabled
+    agcSupportEnabled: agcSupportEnabled
+    agcSubnetAddressPrefix: agcSubnetAddressPrefix
     postgresAdminPassword: postgresAdminPassword
     resourceGroupName: resourceGroupName
   }
@@ -76,3 +82,16 @@ output POSTGRES_USER string = deployShared ? postgresWorkloadUser : ''
 output POSTGRES_ADMIN_USER string = deployShared ? sharedInfra!.outputs.postgresAdminUser : ''
 output POSTGRES_AUTH_MODE string = deployShared ? postgresAuthMode : ''
 output POSTGRES_DATABASE string = deployShared ? sharedInfra!.outputs.postgresDatabaseName : ''
+output AGC_SUPPORT_ENABLED string = deployShared && sharedInfra!.outputs.agcSupportEnabled ? 'true' : 'false'
+output AGC_SUBNET_ID string = deployShared ? sharedInfra!.outputs.agcSubnetId : ''
+output AGC_SUBNET_NAME string = deployShared ? sharedInfra!.outputs.agcSubnetName : ''
+output AGC_SUBNET_PREFIX string = deployShared ? sharedInfra!.outputs.agcSubnetAddressPrefix : ''
+output AGC_CONTROLLER_DEPLOYMENT_MODE string = deployShared ? sharedInfra!.outputs.agcControllerDeploymentMode : ''
+output AGC_GATEWAY_CLASS string = deployShared ? sharedInfra!.outputs.agcGatewayClass : ''
+output AGC_CONTROLLER_IDENTITY_NAME string = deployShared ? sharedInfra!.outputs.agcControllerIdentityName : ''
+output AGC_CONTROLLER_IDENTITY_CLIENT_ID string = deployShared ? sharedInfra!.outputs.agcControllerIdentityClientId : ''
+output AGC_CONTROLLER_IDENTITY_PRINCIPAL_ID string = deployShared ? sharedInfra!.outputs.agcControllerIdentityPrincipalId : ''
+output AGC_FRONTEND_HOSTNAME string = deployShared ? sharedInfra!.outputs.agcFrontendHostname : ''
+output AGC_FRONTEND_REFERENCE string = deployShared ? sharedInfra!.outputs.agcFrontendReference : ''
+output AKS_OIDC_ISSUER_URL string = deployShared ? sharedInfra!.outputs.aksOidcIssuerUrl : ''
+output AKS_NODE_RESOURCE_GROUP string = deployShared ? sharedInfra!.outputs.aksNodeResourceGroup : ''

--- a/.infra/modules/shared-infrastructure/README.md
+++ b/.infra/modules/shared-infrastructure/README.md
@@ -58,9 +58,17 @@ This module creates **ONE instance** of each resource, shared across all service
   - `aks-crud` - 10.0.8.0/24 (CRUD node pool)
   - `apim` - 10.0.9.0/24 (API Management)
   - `private-endpoints` - 10.0.10.0/24 (Private endpoints for PaaS services)
-  - `appgw` - 10.0.11.0/24 (Application Gateway subnet, delegated to `Microsoft.Network/applicationGateways`)
-- **Network Security Groups** - One per subnet
+  - `agc` - 10.0.11.0/24 by default (Application Gateway for Containers delegated subnet, delegated to `Microsoft.ServiceNetworking/trafficControllers`)
+- **Network Security Groups** - One per subnet, including the delegated AGC subnet when AGC support is enabled
 - **Private Endpoints** - PaaS services are private by default; Azure AI Foundry is the intentional public-access exception
+
+### AGC Controller Prerequisites
+
+- **AGC delegated subnet** - Created in shared infrastructure for dev by default and exported for downstream routing work
+- **ALB controller identity** - User-assigned managed identity with workload identity federation for `azure-alb-system/alb-controller-sa`
+- **AGC RBAC** - Reader and AppGw for Containers Configuration Manager on the AKS node resource group, plus Network Contributor on the delegated AGC subnet
+- **Deployment mode** - ALB controller is installed through the supported Helm + workload identity path during `azd provision` postprovision hooks
+- **Scope boundary** - This module does not create `ApplicationLoadBalancer`, `Gateway`, `HTTPRoute`, or `Ingress` resources
 
 ### API Gateway
 
@@ -68,6 +76,7 @@ This module creates **ONE instance** of each resource, shared across all service
   - Consumption tier (dev/staging)
   - StandardV2 tier (prod)
   - VNet integration in prod
+- **Application Gateway for Containers prerequisites** - Prepared in dev without forcing any workload cutover; downstream issues publish routes and perform migration
 
 ### AI Platform
 

--- a/.infra/modules/shared-infrastructure/shared-infrastructure-main.bicep
+++ b/.infra/modules/shared-infrastructure/shared-infrastructure-main.bicep
@@ -6,8 +6,12 @@ param environment string = 'dev' // dev, staging, prod
 param projectName string = 'holidaypeakhub'
 @description('Optional override for Key Vault name (3-24 chars, lowercase letters, numbers, and hyphens). Leave empty to use default naming.')
 param keyVaultNameOverride string = ''
-@description('Enable AKS Web App Routing addon. Keep disabled for AGIC/App Gateway-first ingress topology.')
+@description('Enable the legacy AKS Web App Routing addon. Keep disabled for the AGC target edge posture.')
 param aksWebApplicationRoutingEnabled bool = false
+@description('Enable Application Gateway for Containers shared-infrastructure prerequisites for the dev environment.')
+param agcSupportEnabled bool = environment == 'dev'
+@description('CIDR prefix for the delegated AGC subnet. Must provide at least 256 available IPs.')
+param agcSubnetAddressPrefix string = '10.0.11.0/24'
 @secure()
 @description('Optional PostgreSQL administrator password for CRUD database.')
 param postgresAdminPassword string = ''
@@ -34,6 +38,8 @@ module sharedInfra './shared-infrastructure.bicep' = {
     projectName: projectName
     keyVaultNameOverride: keyVaultNameOverride
     aksWebApplicationRoutingEnabled: aksWebApplicationRoutingEnabled
+    agcSupportEnabled: agcSupportEnabled
+    agcSubnetAddressPrefix: agcSubnetAddressPrefix
     postgresAdminPassword: postgresAdminPassword
   }
   dependsOn: [
@@ -67,3 +73,16 @@ output aiSearchName string = sharedInfra.outputs.aiSearchName
 output aiSearchEndpoint string = sharedInfra.outputs.aiSearchEndpoint
 output aiSearchIndexName string = sharedInfra.outputs.aiSearchIndexName
 output aiSearchAuthMode string = sharedInfra.outputs.aiSearchAuthMode
+output agcSupportEnabled bool = sharedInfra.outputs.agcSupportEnabled
+output agcSubnetId string = sharedInfra.outputs.agcSubnetId
+output agcSubnetName string = sharedInfra.outputs.agcSubnetName
+output agcSubnetAddressPrefix string = sharedInfra.outputs.agcSubnetAddressPrefix
+output agcControllerDeploymentMode string = sharedInfra.outputs.agcControllerDeploymentMode
+output agcGatewayClass string = sharedInfra.outputs.agcGatewayClass
+output agcControllerIdentityName string = sharedInfra.outputs.agcControllerIdentityName
+output agcControllerIdentityClientId string = sharedInfra.outputs.agcControllerIdentityClientId
+output agcControllerIdentityPrincipalId string = sharedInfra.outputs.agcControllerIdentityPrincipalId
+output agcFrontendHostname string = sharedInfra.outputs.agcFrontendHostname
+output agcFrontendReference string = sharedInfra.outputs.agcFrontendReference
+output aksOidcIssuerUrl string = sharedInfra.outputs.aksOidcIssuerUrl
+output aksNodeResourceGroup string = sharedInfra.outputs.aksNodeResourceGroup

--- a/.infra/modules/shared-infrastructure/shared-infrastructure.bicep
+++ b/.infra/modules/shared-infrastructure/shared-infrastructure.bicep
@@ -8,8 +8,12 @@ param projectName string = 'holidaypeakhub'
 param keyVaultNameOverride string = ''
 @description('AKS Kubernetes version; leave empty to use Azure default')
 param aksKubernetesVersion string = ''
-@description('Enable AKS Web App Routing addon. Keep disabled for AGIC/App Gateway-first ingress topology.')
+@description('Enable the legacy AKS Web App Routing addon. Keep disabled for the AGC target edge posture.')
 param aksWebApplicationRoutingEnabled bool = false
+@description('Enable Application Gateway for Containers shared-infrastructure prerequisites for the dev environment.')
+param agcSupportEnabled bool = environment == 'dev'
+@description('CIDR prefix for the delegated AGC subnet. Must provide at least 256 available IPs.')
+param agcSubnetAddressPrefix string = '10.0.11.0/24'
 @secure()
 @description('PostgreSQL administrator password for CRUD transactional database. Leave empty to auto-generate a deterministic dev password.')
 param postgresAdminPassword string = ''
@@ -52,6 +56,11 @@ var aiProjectFriendlyName = '${projectName}${envSuffix} Foundry Project'
 var aiProjectDescription = 'Holiday Peak Hub Foundry project for ${environment}.'
 var aiFoundryBaseName = take('${safeProjectName}${replace(envSuffix, '-', '')}', 12)
 var aiFoundryLocation = 'westus3'
+var agcSubnetName = 'agc'
+var agcControllerIdentityName = '${projectName}${envSuffix}-agc-controller'
+var agcControllerNamespace = 'azure-alb-system'
+var agcControllerServiceAccount = 'alb-controller-sa'
+var agcGatewayClassName = 'azure-alb-external'
 var tags = {
   Project: projectName
   Environment: environment
@@ -95,6 +104,16 @@ module aksCrudNsg 'br/public:avm/res/network/network-security-group:0.5.2' = {
   name: 'nsg-aks-crud'
   params: {
     name: 'aks-crud-nsg'
+    location: location
+    securityRules: []
+    tags: tags
+  }
+}
+
+module agcNsg 'br/public:avm/res/network/network-security-group:0.5.2' = if (agcSupportEnabled) {
+  name: 'nsg-agc'
+  params: {
+    name: 'agc-nsg'
     location: location
     securityRules: []
     tags: tags
@@ -159,7 +178,7 @@ module vnet 'br/public:avm/res/network/virtual-network:0.7.2' = {
     addressPrefixes: [
       '10.0.0.0/16'
     ]
-    subnets: [
+    subnets: concat([
       {
         name: 'aks-system'
         addressPrefix: '10.0.0.0/22'
@@ -186,7 +205,14 @@ module vnet 'br/public:avm/res/network/virtual-network:0.7.2' = {
         networkSecurityGroupResourceId: privateEndpointsNsg.outputs.resourceId
         privateEndpointNetworkPolicies: 'Disabled'
       }
-    ]
+    ], agcSupportEnabled ? [
+      {
+        name: agcSubnetName
+        addressPrefix: agcSubnetAddressPrefix
+        networkSecurityGroupResourceId: agcNsg!.outputs.resourceId
+        delegation: 'Microsoft.ServiceNetworking/trafficControllers'
+      }
+    ] : [])
     tags: tags
   }
 }
@@ -197,6 +223,7 @@ var aksAgentsSubnetId = subnetResourceIds[1]
 var aksCrudSubnetId = subnetResourceIds[2]
 var apimSubnetId = subnetResourceIds[3]
 var peSubnetId = subnetResourceIds[4]
+var agcSubnetId = agcSupportEnabled ? subnetResourceIds[5] : ''
 
 // Private DNS Zones (AVM) — required for private endpoints
 module acrPrivateDnsZone 'br/public:avm/res/network/private-dns-zone:0.8.0' = {
@@ -777,6 +804,11 @@ module aks 'br/public:avm/res/container-service/managed-cluster:0.12.0' = {
     omsAgentEnabled: true
     enableKeyvaultSecretsProvider: true
     enableOidcIssuerProfile: true
+    securityProfile: agcSupportEnabled ? {
+      workloadIdentity: {
+        enabled: true
+      }
+    } : null
     webApplicationRoutingEnabled: aksWebApplicationRoutingEnabled
     primaryAgentPoolProfiles: [
       {
@@ -822,6 +854,28 @@ module aks 'br/public:avm/res/container-service/managed-cluster:0.12.0' = {
       }
     ]
     tags: tags
+  }
+}
+
+resource agcControllerIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = if (agcSupportEnabled) {
+  name: agcControllerIdentityName
+  location: location
+  tags: tags
+}
+
+resource aksClusterResource 'Microsoft.ContainerService/managedClusters@2025-09-01' existing = {
+  name: aksClusterName
+}
+
+resource agcControllerFederatedCredential 'Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials@2025-01-31-preview' = if (agcSupportEnabled) {
+  parent: agcControllerIdentity
+  name: 'aks-agc-controller'
+  properties: {
+    audiences: [
+      'api://AzureADTokenExchange'
+    ]
+    issuer: aks.outputs.?oidcIssuerUrl ?? ''
+    subject: 'system:serviceaccount:${agcControllerNamespace}:${agcControllerServiceAccount}'
   }
 }
 
@@ -1007,3 +1061,16 @@ output appInsightsConnectionString string = appInsights.outputs.connectionString
 output appInsightsInstrumentationKey string = appInsights.outputs.instrumentationKey
 output vnetId string = vnet.outputs.resourceId
 output vnetName string = vnet.outputs.name
+output agcSupportEnabled bool = agcSupportEnabled
+output agcSubnetId string = agcSubnetId
+output agcSubnetName string = agcSupportEnabled ? agcSubnetName : ''
+output agcSubnetAddressPrefix string = agcSupportEnabled ? agcSubnetAddressPrefix : ''
+output agcControllerDeploymentMode string = agcSupportEnabled ? 'helm-workload-identity' : ''
+output agcGatewayClass string = agcSupportEnabled ? agcGatewayClassName : ''
+output agcControllerIdentityName string = agcSupportEnabled ? agcControllerIdentity.name : ''
+output agcControllerIdentityClientId string = agcSupportEnabled ? agcControllerIdentity!.properties.clientId : ''
+output agcControllerIdentityPrincipalId string = agcSupportEnabled ? agcControllerIdentity!.properties.principalId : ''
+output agcFrontendHostname string = ''
+output agcFrontendReference string = agcSupportEnabled ? 'gateway-class:${agcGatewayClassName}' : ''
+output aksOidcIssuerUrl string = aks.outputs.?oidcIssuerUrl ?? ''
+output aksNodeResourceGroup string = aksClusterResource.properties.nodeResourceGroup ?? ''

--- a/azure.yaml
+++ b/azure.yaml
@@ -498,12 +498,14 @@ hooks:
       shell: pwsh
       run: |
         ./.infra/azd/hooks/ensure-entra-ui-app.ps1 -FailOnError:$false
+        ./.infra/azd/hooks/ensure-agc-controller.ps1
         ./.infra/azd/hooks/deploy-foundry-models.ps1
       interactive: false
     posix:
       shell: sh
       run: |
         FAIL_ON_ERROR=false ./.infra/azd/hooks/ensure-entra-ui-app.sh
+        ./.infra/azd/hooks/ensure-agc-controller.sh
         ./.infra/azd/hooks/deploy-foundry-models.sh
       interactive: false
   postdeploy:


### PR DESCRIPTION
## Summary
- add AGC shared-infrastructure prerequisites and exports for dev
- install ALB controller during azd postprovision using Helm + workload identity
- document the issue-283 scope boundary without cutting over workloads

## Testing
- az bicep build --file .infra/azd/main.bicep
- bash -n .infra/azd/hooks/ensure-agc-controller.sh

Closes #283