### PR TITLE
k8s: add AGC routing publication templates

### DIFF
--- a/.infra/azd/hooks/render-helm.ps1
+++ b/.infra/azd/hooks/render-helm.ps1
@@ -7,8 +7,17 @@ $namespace = if ($env:K8S_NAMESPACE) { $env:K8S_NAMESPACE } else { "holiday-peak
 $imagePrefix = if ($env:IMAGE_PREFIX) { $env:IMAGE_PREFIX } else { "ghcr.io/azure-samples" }
 $imageTag = if ($env:IMAGE_TAG) { $env:IMAGE_TAG } else { "latest" }
 $kedaEnabled = if ($env:KEDA_ENABLED) { $env:KEDA_ENABLED } else { "false" }
-$ingressEnabled = if ($env:INGRESS_ENABLED) { $env:INGRESS_ENABLED } else { "true" }
-$ingressClassName = if ($env:INGRESS_CLASS_NAME) { $env:INGRESS_CLASS_NAME } else { "webapprouting.kubernetes.azure.com" }
+$publicationMode = if ($env:PUBLICATION_MODE) { $env:PUBLICATION_MODE } else { "legacy" }
+$legacyIngressEnabled = "false"
+$legacyIngressClassName = if ($env:LEGACY_INGRESS_CLASS_NAME) { $env:LEGACY_INGRESS_CLASS_NAME } elseif ($env:INGRESS_CLASS_NAME) { $env:INGRESS_CLASS_NAME } else { "webapprouting.kubernetes.azure.com" }
+$agcEnabled = "false"
+$agcGatewayClassName = if ($env:AGC_GATEWAY_CLASS) { $env:AGC_GATEWAY_CLASS } else { "azure-alb-external" }
+$agcSubnetId = if ($env:AGC_SUBNET_ID) { $env:AGC_SUBNET_ID } else { "" }
+$agcSharedNamespace = if ($env:AGC_SHARED_NAMESPACE) { $env:AGC_SHARED_NAMESPACE } else { $namespace }
+$agcSharedGatewayName = if ($env:AGC_SHARED_GATEWAY_NAME) { $env:AGC_SHARED_GATEWAY_NAME } else { "holiday-peak-agc" }
+$agcSharedAlbName = if ($env:AGC_SHARED_ALB_NAME) { $env:AGC_SHARED_ALB_NAME } else { $agcSharedGatewayName }
+$agcSharedResourcesCreate = if ($env:AGC_SHARED_RESOURCES_CREATE) { $env:AGC_SHARED_RESOURCES_CREATE } else { "false" }
+$agcHostname = if ($env:AGC_HOSTNAME) { $env:AGC_HOSTNAME } else { "" }
 $canaryEnabled = if ($env:CANARY_ENABLED) { $env:CANARY_ENABLED } else { "false" }
 $readinessPath = "/ready"
 $replicaCount = ""
@@ -38,6 +47,30 @@ if ($ServiceName -eq "crud-service") {
     $maxUnavailable = "0"
     $maxSurge = "1"
   }
+}
+
+switch ($publicationMode.ToLowerInvariant()) {
+  'legacy' {
+    $legacyIngressEnabled = 'true'
+  }
+  'agc' {
+    $agcEnabled = 'true'
+  }
+  'dual' {
+    $legacyIngressEnabled = 'true'
+    $agcEnabled = 'true'
+  }
+  'none' {
+    $legacyIngressEnabled = 'false'
+    $agcEnabled = 'false'
+  }
+  default {
+    throw "Unsupported PUBLICATION_MODE '$publicationMode'. Expected one of legacy, agc, dual, none."
+  }
+}
+
+if ($agcEnabled -eq 'true' -and -not $env:AGC_SHARED_RESOURCES_CREATE -and $ServiceName -eq 'crud-service') {
+  $agcSharedResourcesCreate = 'true'
 }
 
 $serviceImageVarName = "SERVICE_$($ServiceName.ToUpper().Replace('-', '_'))_IMAGE_NAME"
@@ -77,9 +110,23 @@ $helmArgs = @(
   '--set',
   "keda.enabled=$kedaEnabled",
   '--set',
-  "ingress.enabled=$ingressEnabled",
+  "ingress.enabled=$legacyIngressEnabled",
   '--set-string',
-  "ingress.className=$ingressClassName",
+  "ingress.className=$legacyIngressClassName",
+  '--set',
+  "agc.enabled=$agcEnabled",
+  '--set-string',
+  "agc.gatewayClassName=$agcGatewayClassName",
+  '--set',
+  "agc.sharedResources.create=$agcSharedResourcesCreate",
+  '--set-string',
+  "agc.sharedResources.namespace=$agcSharedNamespace",
+  '--set-string',
+  "agc.sharedResources.gatewayName=$agcSharedGatewayName",
+  '--set-string',
+  "agc.sharedResources.applicationLoadBalancerName=$agcSharedAlbName",
+  '--set-string',
+  "agc.sharedResources.subnetId=$agcSubnetId",
   '--set',
   "canary.enabled=$canaryEnabled",
   '--set',
@@ -101,6 +148,22 @@ if ($ServiceName -eq "crud-service") {
   $helmArgs += @('--set', 'ingress.paths[0].pathType=Prefix')
   $helmArgs += @('--set', 'ingress.paths[1].path=/api')
   $helmArgs += @('--set', 'ingress.paths[1].pathType=Prefix')
+  $helmArgs += @('--set', 'agc.paths[0].path=/health')
+  $helmArgs += @('--set', 'agc.paths[0].pathType=PathPrefix')
+  $helmArgs += @('--set', 'agc.paths[1].path=/api')
+  $helmArgs += @('--set', 'agc.paths[1].pathType=PathPrefix')
+} else {
+  $helmArgs += @('--set', 'agc.paths[0].path=/health')
+  $helmArgs += @('--set', 'agc.paths[0].pathType=PathPrefix')
+  $helmArgs += @('--set', 'agc.paths[1].path=/invoke')
+  $helmArgs += @('--set', 'agc.paths[1].pathType=PathPrefix')
+  $helmArgs += @('--set', 'agc.paths[2].path=/mcp')
+  $helmArgs += @('--set', 'agc.paths[2].pathType=PathPrefix')
+}
+
+if ($agcHostname) {
+  $helmArgs += @('--set-string', "agc.hostnames[0]=$agcHostname")
+  $helmArgs += @('--set-string', "agc.sharedResources.listeners[0].hostname=$agcHostname")
 }
 
 if ($replicaCount) {

--- a/.infra/azd/hooks/render-helm.sh
+++ b/.infra/azd/hooks/render-helm.sh
@@ -7,12 +7,42 @@ NAMESPACE="${K8S_NAMESPACE:-holiday-peak}"
 IMAGE_PREFIX="${IMAGE_PREFIX:-ghcr.io/azure-samples}"
 IMAGE_TAG="${IMAGE_TAG:-latest}"
 KEDA_ENABLED="${KEDA_ENABLED:-false}"
-INGRESS_ENABLED="${INGRESS_ENABLED:-true}"
-INGRESS_CLASS_NAME="${INGRESS_CLASS_NAME:-webapprouting.kubernetes.azure.com}"
+PUBLICATION_MODE="${PUBLICATION_MODE:-legacy}"
+LEGACY_INGRESS_ENABLED="false"
+LEGACY_INGRESS_CLASS_NAME="${LEGACY_INGRESS_CLASS_NAME:-${INGRESS_CLASS_NAME:-webapprouting.kubernetes.azure.com}}"
+AGC_ENABLED="false"
+AGC_GATEWAY_CLASS_NAME="${AGC_GATEWAY_CLASS:-azure-alb-external}"
+AGC_SUBNET_ID="${AGC_SUBNET_ID:-}"
+AGC_SHARED_NAMESPACE="${AGC_SHARED_NAMESPACE:-$NAMESPACE}"
+AGC_SHARED_GATEWAY_NAME="${AGC_SHARED_GATEWAY_NAME:-holiday-peak-agc}"
+AGC_SHARED_ALB_NAME="${AGC_SHARED_ALB_NAME:-$AGC_SHARED_GATEWAY_NAME}"
+AGC_SHARED_RESOURCES_CREATE="${AGC_SHARED_RESOURCES_CREATE:-false}"
+AGC_HOSTNAME="${AGC_HOSTNAME:-}"
 CANARY_ENABLED="${CANARY_ENABLED:-false}"
 READINESS_PATH="/ready"
 REPLICA_COUNT=""
 DEPLOY_ENV="${DEPLOY_ENV:-${AZURE_ENV_NAME:-}}"
+
+case "$PUBLICATION_MODE" in
+  legacy)
+    LEGACY_INGRESS_ENABLED="true"
+    ;;
+  agc)
+    AGC_ENABLED="true"
+    ;;
+  dual)
+    LEGACY_INGRESS_ENABLED="true"
+    AGC_ENABLED="true"
+    ;;
+  none)
+    LEGACY_INGRESS_ENABLED="false"
+    AGC_ENABLED="false"
+    ;;
+  *)
+    echo "Unsupported PUBLICATION_MODE '$PUBLICATION_MODE'. Expected one of legacy, agc, dual, none." >&2
+    exit 1
+    ;;
+esac
 
 # Determine workload type (crud-service goes to crud pool, others to agents pool)
 if [ "$SERVICE_NAME" = "crud-service" ]; then
@@ -44,6 +74,10 @@ else
   ROLLING_MAX_SURGE=""
 fi
 
+if [ "$AGC_ENABLED" = "true" ] && [ -z "${AGC_SHARED_RESOURCES_CREATE:-}" ] && [ "$SERVICE_NAME" = "crud-service" ]; then
+  AGC_SHARED_RESOURCES_CREATE="true"
+fi
+
 SERVICE_IMAGE_VAR_NAME="SERVICE_$(printf '%s' "$SERVICE_NAME" | tr '[:lower:]-' '[:upper:]_')_IMAGE_NAME"
 SERVICE_IMAGE="$(printenv "$SERVICE_IMAGE_VAR_NAME" || true)"
 
@@ -70,13 +104,35 @@ HELM_ARGS="$HELM_ARGS --set serviceName=$SERVICE_NAME"
 HELM_ARGS="$HELM_ARGS --set image.repository=$IMAGE_PREFIX"
 HELM_ARGS="$HELM_ARGS --set image.tag=$IMAGE_TAG"
 HELM_ARGS="$HELM_ARGS --set keda.enabled=$KEDA_ENABLED"
-HELM_ARGS="$HELM_ARGS --set ingress.enabled=$INGRESS_ENABLED"
-HELM_ARGS="$HELM_ARGS --set-string ingress.className=$INGRESS_CLASS_NAME"
+HELM_ARGS="$HELM_ARGS --set ingress.enabled=$LEGACY_INGRESS_ENABLED"
+HELM_ARGS="$HELM_ARGS --set-string ingress.className=$LEGACY_INGRESS_CLASS_NAME"
+HELM_ARGS="$HELM_ARGS --set agc.enabled=$AGC_ENABLED"
+HELM_ARGS="$HELM_ARGS --set-string agc.gatewayClassName=$AGC_GATEWAY_CLASS_NAME"
+HELM_ARGS="$HELM_ARGS --set agc.sharedResources.create=$AGC_SHARED_RESOURCES_CREATE"
+HELM_ARGS="$HELM_ARGS --set-string agc.sharedResources.namespace=$AGC_SHARED_NAMESPACE"
+HELM_ARGS="$HELM_ARGS --set-string agc.sharedResources.gatewayName=$AGC_SHARED_GATEWAY_NAME"
+HELM_ARGS="$HELM_ARGS --set-string agc.sharedResources.applicationLoadBalancerName=$AGC_SHARED_ALB_NAME"
+HELM_ARGS="$HELM_ARGS --set-string agc.sharedResources.subnetId=$AGC_SUBNET_ID"
 if [ "$SERVICE_NAME" = "crud-service" ]; then
   HELM_ARGS="$HELM_ARGS --set ingress.paths[0].path=/health"
   HELM_ARGS="$HELM_ARGS --set ingress.paths[0].pathType=Prefix"
   HELM_ARGS="$HELM_ARGS --set ingress.paths[1].path=/api"
   HELM_ARGS="$HELM_ARGS --set ingress.paths[1].pathType=Prefix"
+  HELM_ARGS="$HELM_ARGS --set agc.paths[0].path=/health"
+  HELM_ARGS="$HELM_ARGS --set agc.paths[0].pathType=PathPrefix"
+  HELM_ARGS="$HELM_ARGS --set agc.paths[1].path=/api"
+  HELM_ARGS="$HELM_ARGS --set agc.paths[1].pathType=PathPrefix"
+else
+  HELM_ARGS="$HELM_ARGS --set agc.paths[0].path=/health"
+  HELM_ARGS="$HELM_ARGS --set agc.paths[0].pathType=PathPrefix"
+  HELM_ARGS="$HELM_ARGS --set agc.paths[1].path=/invoke"
+  HELM_ARGS="$HELM_ARGS --set agc.paths[1].pathType=PathPrefix"
+  HELM_ARGS="$HELM_ARGS --set agc.paths[2].path=/mcp"
+  HELM_ARGS="$HELM_ARGS --set agc.paths[2].pathType=PathPrefix"
+fi
+if [ -n "$AGC_HOSTNAME" ]; then
+  HELM_ARGS="$HELM_ARGS --set-string agc.hostnames[0]=$AGC_HOSTNAME"
+  HELM_ARGS="$HELM_ARGS --set-string agc.sharedResources.listeners[0].hostname=$AGC_HOSTNAME"
 fi
 HELM_ARGS="$HELM_ARGS --set canary.enabled=$CANARY_ENABLED"
 HELM_ARGS="$HELM_ARGS --set probes.readiness.path=$READINESS_PATH"

--- a/.kubernetes/chart/templates/agc-routing.yaml
+++ b/.kubernetes/chart/templates/agc-routing.yaml
@@ -1,0 +1,86 @@
+{{- if .Values.agc.enabled }}
+{{- $sharedNamespace := .Values.agc.sharedResources.namespace | default .Release.Namespace }}
+{{- $gatewayName := .Values.agc.sharedResources.gatewayName | default "holiday-peak-agc" }}
+{{- $albName := .Values.agc.sharedResources.applicationLoadBalancerName | default $gatewayName }}
+{{- if and .Values.agc.sharedResources.create .Values.agc.sharedResources.subnetId }}
+apiVersion: alb.networking.azure.io/v1
+kind: ApplicationLoadBalancer
+metadata:
+  name: {{ $albName }}
+  namespace: {{ $sharedNamespace }}
+  labels:
+    app: {{ .Values.serviceName }}
+spec:
+  associations:
+    - {{ .Values.agc.sharedResources.subnetId | quote }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ $gatewayName }}
+  namespace: {{ $sharedNamespace }}
+  labels:
+    app: {{ .Values.serviceName }}
+spec:
+  gatewayClassName: {{ .Values.agc.gatewayClassName | quote }}
+  listeners:
+    {{- range .Values.agc.sharedResources.listeners }}
+    - name: {{ .name | quote }}
+      protocol: {{ .protocol | quote }}
+      port: {{ .port }}
+      {{- if .hostname }}
+      hostname: {{ .hostname | quote }}
+      {{- end }}
+      allowedRoutes:
+        namespaces:
+          from: Same
+    {{- end }}
+---
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "holiday-peak-service.fullname" . }}-agc
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.serviceName }}
+spec:
+  parentRefs:
+    {{- if .Values.agc.parentRefs }}
+    {{- range .Values.agc.parentRefs }}
+    - name: {{ .name | quote }}
+      {{- if .namespace }}
+      namespace: {{ .namespace | quote }}
+      {{- end }}
+    {{- end }}
+    {{- else }}
+    - name: {{ $gatewayName | quote }}
+      namespace: {{ $sharedNamespace | quote }}
+    {{- end }}
+  {{- if .Values.agc.hostnames }}
+  hostnames:
+    {{- range .Values.agc.hostnames }}
+    - {{ . | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- if .Values.agc.paths }}
+    {{- range .Values.agc.paths }}
+    - matches:
+        - path:
+            type: {{ .pathType | default "PathPrefix" }}
+            value: {{ .path | quote }}
+      backendRefs:
+        - name: {{ include "holiday-peak-service.fullname" $ }}
+          port: {{ $.Values.service.port | default 80 }}
+    {{- end }}
+    {{- else }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/"
+      backendRefs:
+        - name: {{ include "holiday-peak-service.fullname" . }}
+          port: {{ .Values.service.port | default 80 }}
+    {{- end }}
+{{- end }}

--- a/.kubernetes/chart/values.yaml
+++ b/.kubernetes/chart/values.yaml
@@ -7,10 +7,10 @@ service:
   targetPort: 8000
   annotations: {}
 
-# Ingress configuration for AKS Web Application Routing (NGINX-based add-on)
+# Legacy ingress configuration for transitional coexistence during AGC migration.
 ingress:
   enabled: true
-  className: "webapprouting.kubernetes.azure.com"
+  className: ""
   host: ""  # Leave empty for path-based routing, or set hostname for host-based
   path: ""  # Defaults to /{serviceName}
   paths: []  # Optional explicit ingress paths, e.g. [{ path: /health, pathType: Prefix }, { path: /api, pathType: Prefix }]
@@ -18,6 +18,25 @@ ingress:
   requestTimeout: 30
   tls: []
   annotations: {}
+
+# Application Gateway for Containers publication.
+agc:
+  enabled: false
+  gatewayClassName: ""
+  hostnames: []
+  paths: []
+  parentRefs: []
+  sharedResources:
+    create: false
+    namespace: ""
+    applicationLoadBalancerName: "holiday-peak-agc"
+    gatewayName: "holiday-peak-agc"
+    subnetId: ""
+    listeners:
+      - name: http
+        protocol: HTTP
+        port: 80
+        hostname: ""
 
 # Container image
 image:


### PR DESCRIPTION
## Summary
- add AGC publication templates for ApplicationLoadBalancer, Gateway, and HTTPRoute
- keep services on ClusterIP while supporting legacy and AGC coexistence
- update Helm render hooks to choose publication mode without hardcoding chart defaults to Web App Routing

## Testing
- ./.infra/azd/hooks/render-helm.ps1 -ServiceName crud-service with PUBLICATION_MODE=agc
- ./.infra/azd/hooks/render-helm.ps1 -ServiceName ecommerce-catalog-search with PUBLICATION_MODE=agc
- bash -n .infra/azd/hooks/render-helm.sh

Closes #284