### PR TITLE
Issue #285: refactor APIM sync to approved AGC hostnames

### DIFF
--- a/.infra/azd/hooks/sync-apim-agents.ps1
+++ b/.infra/azd/hooks/sync-apim-agents.ps1
@@ -6,14 +6,9 @@ param(
     [string]$AzureYamlPath,
     [string]$ChangedServices = $env:CHANGED_SERVICES,
     [string]$ApiPathPrefix = 'agents',
-    [switch]$UseIngress,
-    [string]$IngressHost,
-    [string]$AppGatewayName,
-    [string]$AppGatewayIp,
+    [string]$ApprovedBackendHostnames = $(if ($env:APIM_APPROVED_BACKEND_HOSTNAMES) { $env:APIM_APPROVED_BACKEND_HOSTNAMES } elseif ($env:AGC_FRONTEND_HOSTNAME) { $env:AGC_FRONTEND_HOSTNAME } else { '' }),
+    [string]$ApprovedBackendScheme = $(if ($env:APIM_APPROVED_BACKEND_SCHEME) { $env:APIM_APPROVED_BACKEND_SCHEME } elseif ($env:AGC_FRONTEND_SCHEME) { $env:AGC_FRONTEND_SCHEME } else { 'http' }),
     [bool]$IncludeCrudService = $true,
-    [bool]$RequireLoadBalancer = $true,
-    [int]$BackendResolveRetries = 24,
-    [int]$BackendResolveDelaySeconds = 5,
     [switch]$Preview
 )
 
@@ -24,16 +19,11 @@ if (-not $AzureYamlPath) {
     $AzureYamlPath = Join-Path $repoRoot 'azure.yaml'
 }
 
-$script:resolvedIngressGatewayHost = ''
-$script:useIngressMode = $UseIngress.IsPresent -or $env:USE_INGRESS -eq 'true'
-$script:resolvedAppGatewayName = if ($AppGatewayName) { $AppGatewayName } elseif ($env:APP_GW_NAME) { $env:APP_GW_NAME } else { '' }
-$script:resolvedAppGatewayIp = if ($AppGatewayIp) { $AppGatewayIp } elseif ($env:APP_GW_IP) { $env:APP_GW_IP } else { '' }
-$script:resolvedIngressHostOverride = if ($IngressHost) { $IngressHost } elseif ($env:INGRESS_HOST) { $env:INGRESS_HOST } else { '' }
-$script:ingressValidated = $false
-
-if ($script:useIngressMode) {
-    $RequireLoadBalancer = $false
-}
+$script:resolvedApprovedBackendHosts = @()
+$script:resolvedApprovedBackendHost = ''
+$script:resolvedApprovedBackendScheme = ''
+$script:resolvedApprovedBackendReference = ''
+$script:approvedBackendValidated = $false
 
 function Get-EnvValueFromFile {
     param(
@@ -52,6 +42,16 @@ function Get-EnvValueFromFile {
     }
 
     return ''
+}
+
+function Split-HostnameList {
+    param([string]$Value)
+
+    if (-not $Value) {
+        return @()
+    }
+
+    return @($Value -split '[,\s]+' | ForEach-Object { $_.Trim() } | Where-Object { $_ } | Select-Object -Unique)
 }
 
 function Convert-ToXmlEscapedValue {
@@ -153,6 +153,73 @@ function Get-AksClusterName {
     return ''
 }
 
+function Get-ApprovedBackendHosts {
+    param([string]$RepoRoot)
+
+    $candidates = Split-HostnameList -Value $ApprovedBackendHostnames
+    if ($candidates.Count -gt 0) {
+        return $candidates
+    }
+
+    if ($env:AZURE_ENV_NAME) {
+        $envFile = Join-Path $RepoRoot ".azure\$($env:AZURE_ENV_NAME)\.env"
+        $value = Get-EnvValueFromFile -FilePath $envFile -Key 'APIM_APPROVED_BACKEND_HOSTNAMES'
+        $candidates = Split-HostnameList -Value $value
+        if ($candidates.Count -gt 0) {
+            return $candidates
+        }
+
+        $value = Get-EnvValueFromFile -FilePath $envFile -Key 'AGC_FRONTEND_HOSTNAME'
+        $candidates = Split-HostnameList -Value $value
+        if ($candidates.Count -gt 0) {
+            return $candidates
+        }
+    }
+
+    return @()
+}
+
+function Get-ApprovedBackendScheme {
+    param([string]$RepoRoot)
+
+    if ($ApprovedBackendScheme) {
+        return $ApprovedBackendScheme.ToLowerInvariant()
+    }
+
+    if ($env:AZURE_ENV_NAME) {
+        $envFile = Join-Path $RepoRoot ".azure\$($env:AZURE_ENV_NAME)\.env"
+        $value = Get-EnvValueFromFile -FilePath $envFile -Key 'APIM_APPROVED_BACKEND_SCHEME'
+        if ($value) {
+            return $value.ToLowerInvariant()
+        }
+
+        $value = Get-EnvValueFromFile -FilePath $envFile -Key 'AGC_FRONTEND_SCHEME'
+        if ($value) {
+            return $value.ToLowerInvariant()
+        }
+    }
+
+    return 'http'
+}
+
+function Get-ApprovedBackendReference {
+    param([string]$RepoRoot)
+
+    if ($env:AGC_FRONTEND_REFERENCE) {
+        return $env:AGC_FRONTEND_REFERENCE
+    }
+
+    if ($env:AZURE_ENV_NAME) {
+        $envFile = Join-Path $RepoRoot ".azure\$($env:AZURE_ENV_NAME)\.env"
+        $value = Get-EnvValueFromFile -FilePath $envFile -Key 'AGC_FRONTEND_REFERENCE'
+        if ($value) {
+            return $value
+        }
+    }
+
+    return ''
+}
+
 function Ensure-AksCredentials {
     param(
         [string]$Rg,
@@ -165,7 +232,7 @@ function Ensure-AksCredentials {
     }
 
     if (-not (Get-Command kubectl -ErrorAction SilentlyContinue)) {
-        throw 'kubectl is required to resolve APIM backends. Install kubectl or run with -RequireLoadBalancer:$false.'
+        throw 'kubectl is required to validate APIM backend targets. Install kubectl before running APIM sync.'
     }
 
     if (-not (Get-Command az -ErrorAction SilentlyContinue)) {
@@ -251,129 +318,34 @@ function Get-AksServicesFromAzureYaml {
     return $services
 }
 
-function Resolve-IngressGatewayHost {
-    param(
-        [Parameter(Mandatory = $true)][string]$Rg,
-        [string]$GatewayName
-    )
+function Test-IsIpLiteral {
+    param([Parameter(Mandatory = $true)][string]$Value)
 
-    if ($script:resolvedIngressGatewayHost) {
-        return $script:resolvedIngressGatewayHost
-    }
-
-    if ($script:resolvedIngressHostOverride) {
-        $script:resolvedIngressGatewayHost = $script:resolvedIngressHostOverride
-        return $script:resolvedIngressGatewayHost
-    }
-
-    if ($script:resolvedAppGatewayIp) {
-        $script:resolvedIngressGatewayHost = $script:resolvedAppGatewayIp
-        return $script:resolvedIngressGatewayHost
-    }
-
-    function Resolve-PublicHostFromGateway {
-        param([Parameter(Mandatory = $true)][string]$Gateway)
-
-        $pipId = az network application-gateway show --resource-group $Rg --name $Gateway --query 'frontendIPConfigurations[0].publicIPAddress.id' -o tsv 2>$null
-        if (-not $pipId) {
-            return ''
-        }
-
-        $publicHost = az network public-ip show --ids $pipId --query ipAddress -o tsv 2>$null
-        if ($publicHost) {
-            return $publicHost
-        }
-
-        $publicHost = az network public-ip show --ids $pipId --query dnsSettings.fqdn -o tsv 2>$null
-        if ($publicHost) {
-            return $publicHost
-        }
-
-        return ''
-    }
-
-    function Add-UniqueHostCandidate {
-        param(
-            [System.Collections.Generic.List[string]]$Collection,
-            [string]$Candidate
-        )
-
-        if (-not $Candidate) {
-            return
-        }
-
-        $trimmed = $Candidate.Trim()
-        if (-not $trimmed) {
-            return
-        }
-
-        if (-not $Collection.Contains($trimmed)) {
-            $Collection.Add($trimmed)
-        }
-    }
-
-    $resolvedHost = ''
-
-    $effectiveGatewayName = if ($GatewayName) { $GatewayName } else { $script:resolvedAppGatewayName }
-    if ($effectiveGatewayName) {
-        $resolvedHost = Resolve-PublicHostFromGateway -Gateway $effectiveGatewayName
-        if (-not $resolvedHost) {
-            throw "Failed to resolve ingress host from explicit application gateway '$effectiveGatewayName'."
-        }
-
-        $script:resolvedIngressGatewayHost = $resolvedHost
-        return $script:resolvedIngressGatewayHost
-    }
-
-    $autoGateways = @(az network application-gateway list --resource-group $Rg --query '[].name' -o tsv 2>$null | Where-Object { $_.Trim() })
-    if ($autoGateways.Count -gt 1) {
-        $appGatewayCandidates = @($autoGateways | Where-Object { $_ -match 'appgw' })
-        if ($appGatewayCandidates.Count -eq 1) {
-            $autoGateways = $appGatewayCandidates
-        }
-        else {
-            throw "Multiple application gateways detected in '$Rg'. Provide -AppGatewayName, -AppGatewayIp, or -IngressHost."
-        }
-    }
-
-    if ($autoGateways.Count -eq 1) {
-        $resolvedHost = Resolve-PublicHostFromGateway -Gateway $autoGateways[0]
-        if (-not $resolvedHost) {
-            throw "Failed to resolve ingress host from detected application gateway '$($autoGateways[0])'."
-        }
-    }
-
-    if (-not $resolvedHost) {
-        $ingressCandidates = [System.Collections.Generic.List[string]]::new()
-        Add-UniqueHostCandidate -Collection $ingressCandidates -Candidate (kubectl get svc -A -l 'app.kubernetes.io/name=nginx' -o jsonpath="{.items[0].status.loadBalancer.ingress[0].ip}" 2>$null)
-        Add-UniqueHostCandidate -Collection $ingressCandidates -Candidate (kubectl get svc -A -l 'app.kubernetes.io/name=nginx' -o jsonpath="{.items[0].status.loadBalancer.ingress[0].hostname}" 2>$null)
-        Add-UniqueHostCandidate -Collection $ingressCandidates -Candidate (kubectl get svc nginx -n app-routing-system -o jsonpath="{.status.loadBalancer.ingress[0].ip}" 2>$null)
-        Add-UniqueHostCandidate -Collection $ingressCandidates -Candidate (kubectl get svc nginx -n app-routing-system -o jsonpath="{.status.loadBalancer.ingress[0].hostname}" 2>$null)
-        Add-UniqueHostCandidate -Collection $ingressCandidates -Candidate (kubectl get svc ingress-nginx-controller -n ingress-nginx -o jsonpath="{.status.loadBalancer.ingress[0].ip}" 2>$null)
-        Add-UniqueHostCandidate -Collection $ingressCandidates -Candidate (kubectl get svc ingress-nginx-controller -n ingress-nginx -o jsonpath="{.status.loadBalancer.ingress[0].hostname}" 2>$null)
-
-        if ($ingressCandidates.Count -gt 1) {
-            throw 'Ambiguous ingress host candidates detected. Provide -AppGatewayName, -AppGatewayIp, or -IngressHost.'
-        }
-
-        if ($ingressCandidates.Count -eq 1) {
-            $resolvedHost = $ingressCandidates[0]
-        }
-    }
-
-    if ($resolvedHost) {
-        $script:resolvedIngressGatewayHost = $resolvedHost
-    }
-
-    return $script:resolvedIngressGatewayHost
+    $ip = $null
+    return [System.Net.IPAddress]::TryParse($Value, [ref]$ip)
 }
 
-function Test-IngressCrudHealth {
+function Resolve-ApprovedBackendHost {
+    if ($script:resolvedApprovedBackendHost) {
+        return $script:resolvedApprovedBackendHost
+    }
+
+    if (-not $script:resolvedApprovedBackendHosts -or $script:resolvedApprovedBackendHosts.Count -eq 0) {
+        $referenceText = if ($script:resolvedApprovedBackendReference) { " (AGC frontend reference: $($script:resolvedApprovedBackendReference))" } else { '' }
+        throw "No approved AGC backend hostname was provided. Set APIM_APPROVED_BACKEND_HOSTNAMES or AGC_FRONTEND_HOSTNAME before running APIM sync$referenceText."
+    }
+
+    $script:resolvedApprovedBackendHost = $script:resolvedApprovedBackendHosts[0]
+    return $script:resolvedApprovedBackendHost
+}
+
+function Test-ApprovedBackendCrudHealth {
     param(
-        [Parameter(Mandatory = $true)][string]$GatewayHost
+        [Parameter(Mandatory = $true)][string]$BackendHost,
+        [Parameter(Mandatory = $true)][string]$Scheme
     )
 
-    $probeUrl = "http://$GatewayHost/health"
+    $probeUrl = "${Scheme}://$BackendHost/health"
     $lastStatus = ''
     $lastBody = ''
 
@@ -381,7 +353,7 @@ function Test-IngressCrudHealth {
         try {
             $response = Invoke-WebRequest -Uri $probeUrl -Method GET -TimeoutSec 10 -UseBasicParsing
             if ($response.StatusCode -eq 200) {
-                Write-Host "Validated ingress host '$GatewayHost' via $probeUrl"
+                Write-Host "Validated approved AGC backend host '$BackendHost' via $probeUrl"
                 return
             }
 
@@ -393,7 +365,7 @@ function Test-IngressCrudHealth {
             if ($statusCode) {
                 $lastStatus = [string]$statusCode
                 if ($statusCode -eq 404) {
-                    Write-Host "Validated ingress host '$GatewayHost' via $probeUrl (404 indicates reachable ingress path without rewrite)"
+                    Write-Host "Validated approved AGC backend host '$BackendHost' via $probeUrl (404 indicates reachable path without CRUD health publication)"
                     return
                 }
             }
@@ -403,145 +375,86 @@ function Test-IngressCrudHealth {
         Start-Sleep -Seconds 5
     }
 
-    throw "Ingress validation failed for '$GatewayHost' (last status: $lastStatus) using $probeUrl. Last response: $lastBody"
+    throw "AGC backend validation failed for '$BackendHost' (last status: $lastStatus) using $probeUrl. Last response: $lastBody"
 }
 
-function Ensure-IngressReady {
-    if ($script:ingressValidated) {
+function Ensure-ApprovedBackendReady {
+    if ($script:approvedBackendValidated) {
         return
     }
 
-    $resolvedHost = Resolve-IngressGatewayHost -Rg $script:resolvedResourceGroup -GatewayName $script:resolvedAppGatewayName
-    if (-not $resolvedHost) {
-        throw 'Ingress endpoint could not be resolved for APIM backend sync. Refusing to fall back to cluster-local addresses that APIM cannot reach.'
-    }
+    $resolvedHost = Resolve-ApprovedBackendHost
 
     if (-not $Preview) {
-        Test-IngressCrudHealth -GatewayHost $resolvedHost
+        Test-ApprovedBackendCrudHealth -BackendHost $resolvedHost -Scheme $script:resolvedApprovedBackendScheme
     }
 
-    $script:ingressValidated = $true
+    $script:approvedBackendValidated = $true
 }
 
 function Resolve-ServiceBackendUrl {
     param(
         [Parameter(Mandatory = $true)][string]$Service,
-        [Parameter(Mandatory = $true)][string]$Namespace,
-        [bool]$RequireLb = $true,
-        [int]$Retries = 24,
-        [int]$DelaySeconds = 5
+        [Parameter(Mandatory = $true)][string]$Namespace
     )
 
-    $serviceName = ''
-    $servicePort = '80'
-    $lbHost = ''
+    Ensure-ApprovedBackendReady
+    $backendHost = Resolve-ApprovedBackendHost
+    $baseUrl = "$($script:resolvedApprovedBackendScheme)://$backendHost"
 
-    if ($script:useIngressMode) {
-        Ensure-IngressReady
-        if ($Service -eq 'crud-service') {
-            return "http://$($script:resolvedIngressGatewayHost)"
-        }
-        return "http://$($script:resolvedIngressGatewayHost)/$Service"
+    if ($Service -eq 'crud-service') {
+        return $baseUrl
     }
+
+    return "$baseUrl/$Service"
+}
+
+function Get-ServiceName {
+    param(
+        [Parameter(Mandatory = $true)][string]$Service,
+        [Parameter(Mandatory = $true)][string]$Namespace
+    )
 
     if (Get-Command kubectl -ErrorAction SilentlyContinue) {
         $serviceName = kubectl get svc -n $Namespace -l "app=$Service" -o jsonpath="{.items[0].metadata.name}" 2>$null
         if ($LASTEXITCODE -eq 0 -and $serviceName) {
-            $servicePortCandidate = kubectl get svc $serviceName -n $Namespace -o jsonpath="{.spec.ports[0].port}" 2>$null
-            if ($LASTEXITCODE -eq 0 -and $servicePortCandidate) {
-                $servicePort = $servicePortCandidate
-            }
-
-            for ($attempt = 1; $attempt -le $Retries; $attempt++) {
-                $lbIp = kubectl get svc $serviceName -n $Namespace -o jsonpath="{.status.loadBalancer.ingress[0].ip}" 2>$null
-                if ($LASTEXITCODE -eq 0 -and $lbIp) {
-                    $lbHost = $lbIp
-                    break
-                }
-
-                $lbDns = kubectl get svc $serviceName -n $Namespace -o jsonpath="{.status.loadBalancer.ingress[0].hostname}" 2>$null
-                if ($LASTEXITCODE -eq 0 -and $lbDns) {
-                    $lbHost = $lbDns
-                    break
-                }
-
-                if ($attempt -lt $Retries) {
-                    Start-Sleep -Seconds $DelaySeconds
-                }
-            }
-
-            if ($lbHost) {
-                return "http://${lbHost}:$servicePort"
-            }
-
-            if (-not $RequireLb) {
-                $clusterIp = kubectl get svc $serviceName -n $Namespace -o jsonpath="{.spec.clusterIP}" 2>$null
-                if ($LASTEXITCODE -eq 0 -and $clusterIp) {
-                    return "http://${clusterIp}:$servicePort"
-                }
-                return "http://$serviceName.$Namespace.svc.cluster.local:$servicePort"
-            }
+            return $serviceName
         }
     }
 
     if ($script:resolvedAksClusterName -and $script:resolvedResourceGroup) {
         $serviceName = Invoke-AksKubectlJsonPath -Rg $script:resolvedResourceGroup -ClusterName $script:resolvedAksClusterName -KubectlArgs "get svc -n $Namespace -l app=$Service -o jsonpath='{.items[0].metadata.name}'"
         if ($serviceName) {
-            $servicePortCandidate = Invoke-AksKubectlJsonPath -Rg $script:resolvedResourceGroup -ClusterName $script:resolvedAksClusterName -KubectlArgs "get svc $serviceName -n $Namespace -o jsonpath='{.spec.ports[0].port}'"
-            if ($servicePortCandidate) {
-                $servicePort = $servicePortCandidate
-            }
-
-            for ($attempt = 1; $attempt -le $Retries; $attempt++) {
-                $lbIp = Invoke-AksKubectlJsonPath -Rg $script:resolvedResourceGroup -ClusterName $script:resolvedAksClusterName -KubectlArgs "get svc $serviceName -n $Namespace -o jsonpath='{.status.loadBalancer.ingress[0].ip}'"
-                if ($lbIp) {
-                    $lbHost = $lbIp
-                    break
-                }
-
-                $lbDns = Invoke-AksKubectlJsonPath -Rg $script:resolvedResourceGroup -ClusterName $script:resolvedAksClusterName -KubectlArgs "get svc $serviceName -n $Namespace -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'"
-                if ($lbDns) {
-                    $lbHost = $lbDns
-                    break
-                }
-
-                if ($attempt -lt $Retries) {
-                    Start-Sleep -Seconds $DelaySeconds
-                }
-            }
-
-            if ($lbHost) {
-                return "http://${lbHost}:$servicePort"
-            }
-
-            if (-not $RequireLb) {
-                $clusterIp = Invoke-AksKubectlJsonPath -Rg $script:resolvedResourceGroup -ClusterName $script:resolvedAksClusterName -KubectlArgs "get svc $serviceName -n $Namespace -o jsonpath='{.spec.clusterIP}'"
-                if ($clusterIp) {
-                    return "http://${clusterIp}:$servicePort"
-                }
-            }
+            return $serviceName
         }
     }
 
-    if ($RequireLb -and $Service -eq 'crud-service') {
-        try {
-            $fallbackHost = Resolve-IngressGatewayHost -Rg $script:resolvedResourceGroup -GatewayName $script:resolvedAppGatewayName
-            if (-not $Preview) {
-                Test-IngressCrudHealth -GatewayHost $fallbackHost
-            }
-            Write-Host "Using ingress fallback host '$fallbackHost' for CRUD APIM backend because no load balancer endpoint was resolved."
-            return "http://$fallbackHost"
-        }
-        catch {
-            throw "Service '$Service' has no resolvable load balancer backend and ingress fallback failed in namespace '$Namespace'. $($_.Exception.Message)"
+    return $Service
+}
+
+function Get-ServiceClusterIp {
+    param(
+        [Parameter(Mandatory = $true)][string]$Service,
+        [Parameter(Mandatory = $true)][string]$Namespace
+    )
+
+    $serviceName = Get-ServiceName -Service $Service -Namespace $Namespace
+
+    if (Get-Command kubectl -ErrorAction SilentlyContinue) {
+        $clusterIp = kubectl get svc $serviceName -n $Namespace -o jsonpath="{.spec.clusterIP}" 2>$null
+        if ($LASTEXITCODE -eq 0 -and $clusterIp) {
+            return $clusterIp
         }
     }
 
-    if ($RequireLb) {
-        throw "Service '$Service' has no resolvable load balancer backend in namespace '$Namespace'."
+    if ($script:resolvedAksClusterName -and $script:resolvedResourceGroup) {
+        $clusterIp = Invoke-AksKubectlJsonPath -Rg $script:resolvedResourceGroup -ClusterName $script:resolvedAksClusterName -KubectlArgs "get svc $serviceName -n $Namespace -o jsonpath='{.spec.clusterIP}'"
+        if ($clusterIp) {
+            return $clusterIp
+        }
     }
 
-    return "http://$Service-$Service.$Namespace.svc.cluster.local:$servicePort"
+    return ''
 }
 
 function Get-ServiceEndpointIps {
@@ -569,6 +482,26 @@ function Get-ServiceEndpointIps {
     return @($endpointIps | Sort-Object -Unique)
 }
 
+function Get-NodeIps {
+    $nodeIps = @()
+
+    if (Get-Command kubectl -ErrorAction SilentlyContinue) {
+        $ipsFromKubectl = kubectl get nodes -o jsonpath="{.items[*].status.addresses[?(@.type=='InternalIP')].address} {.items[*].status.addresses[?(@.type=='ExternalIP')].address}" 2>$null
+        if ($LASTEXITCODE -eq 0 -and $ipsFromKubectl) {
+            $nodeIps += @($ipsFromKubectl -split '\s+' | Where-Object { $_ })
+        }
+    }
+
+    if (($nodeIps.Count -eq 0) -and $script:resolvedAksClusterName -and $script:resolvedResourceGroup) {
+        $ipsFromAksCommand = Invoke-AksKubectlJsonPath -Rg $script:resolvedResourceGroup -ClusterName $script:resolvedAksClusterName -KubectlArgs "get nodes -o jsonpath='{.items[*].status.addresses[?(@.type==\"InternalIP\")].address} {.items[*].status.addresses[?(@.type==\"ExternalIP\")].address}'"
+        if ($ipsFromAksCommand) {
+            $nodeIps += @($ipsFromAksCommand -split '\s+' | Where-Object { $_ })
+        }
+    }
+
+    return @($nodeIps | Sort-Object -Unique)
+}
+
 function Get-UrlHost {
     param([Parameter(Mandatory = $true)][string]$Url)
 
@@ -580,24 +513,49 @@ function Get-UrlHost {
     }
 }
 
-function Assert-StableCrudBackendTarget {
+function Assert-ApprovedBackendTarget {
     param(
         [Parameter(Mandatory = $true)][string]$BackendUrl,
+        [Parameter(Mandatory = $true)][string]$Service,
         [Parameter(Mandatory = $true)][string]$Namespace
     )
 
     $backendHost = Get-UrlHost -Url $BackendUrl
     if (-not $backendHost) {
-        throw "Unable to parse host from CRUD APIM backend URL '$BackendUrl'."
+        throw "Unable to parse host from APIM backend URL '$BackendUrl'."
     }
 
-    $endpointIps = Get-ServiceEndpointIps -Service 'crud-service' -Namespace $Namespace
+    if (-not ($script:resolvedApprovedBackendHosts -contains $backendHost)) {
+        $allowedHosts = $script:resolvedApprovedBackendHosts -join ', '
+        throw "Refusing to set APIM backend '$BackendUrl': host '$backendHost' is not in the approved AGC hostname list: $allowedHosts"
+    }
+
+    if (Test-IsIpLiteral -Value $backendHost) {
+        throw "Refusing to set APIM backend '$BackendUrl': approved target '$backendHost' is an IP literal. APIM backends must target AGC hostnames only."
+    }
+
+    if ($backendHost.EndsWith('.svc.cluster.local', [System.StringComparison]::OrdinalIgnoreCase) -or $backendHost.EndsWith('.svc', [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "Refusing to set APIM backend '$BackendUrl': host '$backendHost' is cluster-local."
+    }
+
+    $clusterIp = Get-ServiceClusterIp -Service $Service -Namespace $Namespace
+    if ($clusterIp -and $backendHost -eq $clusterIp) {
+        throw "Refusing to set APIM backend '$BackendUrl': host '$backendHost' matches the '$Service' ClusterIP."
+    }
+
+    $endpointIps = Get-ServiceEndpointIps -Service $Service -Namespace $Namespace
     if ($endpointIps -contains $backendHost) {
         $joinedIps = $endpointIps -join ', '
-        throw "Refusing to set unstable CRUD APIM backend '$BackendUrl': host '$backendHost' matches current crud-service endpoint IP(s): $joinedIps"
+        throw "Refusing to set APIM backend '$BackendUrl': host '$backendHost' matches current '$Service' endpoint IP(s): $joinedIps"
     }
 
-    Write-Host "Validated stable CRUD APIM backend host '$backendHost'."
+    $nodeIps = Get-NodeIps
+    if ($nodeIps -contains $backendHost) {
+        $joinedIps = $nodeIps -join ', '
+        throw "Refusing to set APIM backend '$BackendUrl': host '$backendHost' matches AKS node IP(s): $joinedIps"
+    }
+
+    Write-Host "Validated approved APIM backend host '$backendHost' for service '$Service'."
 }
 
 function Ensure-AgentApi {
@@ -619,7 +577,8 @@ function Ensure-AgentApi {
         return
     }
 
-    $backend = Resolve-ServiceBackendUrl -Service $Service -Namespace $Ns -RequireLb:$RequireLoadBalancer -Retries $BackendResolveRetries -DelaySeconds $BackendResolveDelaySeconds
+    $backend = Resolve-ServiceBackendUrl -Service $Service -Namespace $Ns
+    Assert-ApprovedBackendTarget -BackendUrl $backend -Service $Service -Namespace $Ns
 
     az apim api show --resource-group $Rg --service-name $Apim --api-id $apiId --only-show-errors *> $null
     if ($LASTEXITCODE -eq 0) {
@@ -683,8 +642,8 @@ function Update-CrudApi {
         return
     }
 
-    $backend = Resolve-ServiceBackendUrl -Service $service -Namespace $Ns -RequireLb:$RequireLoadBalancer -Retries $BackendResolveRetries -DelaySeconds $BackendResolveDelaySeconds
-    Assert-StableCrudBackendTarget -BackendUrl $backend -Namespace $Ns
+    $backend = Resolve-ServiceBackendUrl -Service $service -Namespace $Ns
+    Assert-ApprovedBackendTarget -BackendUrl $backend -Service $service -Namespace $Ns
 
     $apiExists = $false
     az apim api show --resource-group $Rg --service-name $Apim --api-id 'crud-service' --only-show-errors *> $null
@@ -855,6 +814,13 @@ if (-not $resolvedApimName) {
 
 $script:resolvedResourceGroup = $resolvedResourceGroup
 $script:resolvedAksClusterName = Get-AksClusterName -Rg $resolvedResourceGroup -RepoRoot $repoRoot
+$script:resolvedApprovedBackendHosts = Get-ApprovedBackendHosts -RepoRoot $repoRoot
+$script:resolvedApprovedBackendScheme = Get-ApprovedBackendScheme -RepoRoot $repoRoot
+$script:resolvedApprovedBackendReference = Get-ApprovedBackendReference -RepoRoot $repoRoot
+
+if ($script:resolvedApprovedBackendScheme -notin @('http', 'https')) {
+    throw "Unsupported APIM approved backend scheme '$($script:resolvedApprovedBackendScheme)'. Supported values are 'http' and 'https'."
+}
 
 Ensure-AksCredentials -Rg $resolvedResourceGroup -RepoRoot $repoRoot -SkipForPreview:$Preview
 

--- a/.infra/azd/hooks/sync-apim-agents.sh
+++ b/.infra/azd/hooks/sync-apim-agents.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+﻿#!/usr/bin/env sh
 
 set -eu
 
@@ -11,16 +11,12 @@ RESOURCE_GROUP="${AZURE_RESOURCE_GROUP:-${RESOURCE_GROUP:-}}"
 APIM_NAME="${APIM_NAME:-}"
 APIM_CORS_ALLOWED_ORIGINS="${APIM_CORS_ALLOWED_ORIGINS:-http://localhost:3000}"
 AKS_CLUSTER_NAME="${AKS_CLUSTER_NAME:-}"
-APP_GW_NAME="${APP_GW_NAME:-}"
-APP_GW_IP="${APP_GW_IP:-}"
-INGRESS_HOST="${INGRESS_HOST:-}"
-USE_INGRESS="${USE_INGRESS:-false}"
-REQUIRE_LOAD_BALANCER=true
-BACKEND_RESOLVE_RETRIES="${BACKEND_RESOLVE_RETRIES:-24}"
-BACKEND_RESOLVE_DELAY_SECONDS="${BACKEND_RESOLVE_DELAY_SECONDS:-5}"
+APIM_APPROVED_BACKEND_HOSTNAMES="${APIM_APPROVED_BACKEND_HOSTNAMES:-${AGC_FRONTEND_HOSTNAME:-}}"
+APIM_APPROVED_BACKEND_SCHEME="${APIM_APPROVED_BACKEND_SCHEME:-${AGC_FRONTEND_SCHEME:-http}}"
 PREVIEW=false
-RESOLVED_INGRESS_HOST=""
-INGRESS_VALIDATED=false
+RESOLVED_APPROVED_BACKEND_HOST=""
+APPROVED_BACKEND_VALIDATED=false
+APPROVED_BACKEND_REFERENCE="${AGC_FRONTEND_REFERENCE:-}"
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -28,15 +24,10 @@ while [ "$#" -gt 0 ]; do
       PREVIEW=true
       ;;
     --require-load-balancer)
-      REQUIRE_LOAD_BALANCER=true
-      USE_INGRESS=false
       ;;
     --allow-non-lb)
-      REQUIRE_LOAD_BALANCER=false
       ;;
     --use-ingress)
-      USE_INGRESS=true
-      REQUIRE_LOAD_BALANCER=false
       ;;
     --namespace)
       shift
@@ -54,17 +45,13 @@ while [ "$#" -gt 0 ]; do
       shift
       AKS_CLUSTER_NAME="$1"
       ;;
-    --app-gw-name)
+    --approved-backend-hostnames)
       shift
-      APP_GW_NAME="$1"
+      APIM_APPROVED_BACKEND_HOSTNAMES="$1"
       ;;
-    --app-gw-ip)
+    --approved-backend-scheme)
       shift
-      APP_GW_IP="$1"
-      ;;
-    --ingress-host)
-      shift
-      INGRESS_HOST="$1"
+      APIM_APPROVED_BACKEND_SCHEME="$1"
       ;;
     --azure-yaml)
       shift
@@ -81,9 +68,6 @@ while [ "$#" -gt 0 ]; do
   esac
   shift
 done
-
-# Initialize App Gateway IP cache
-APP_GW_IP=""
 
 if [ -z "$RESOURCE_GROUP" ] && [ -n "${AZURE_ENV_NAME:-}" ]; then
   ENV_FILE="$REPO_ROOT/.azure/$AZURE_ENV_NAME/.env"
@@ -113,6 +97,34 @@ if [ -z "$APIM_NAME" ]; then
   exit 1
 fi
 
+if [ -z "$APIM_APPROVED_BACKEND_HOSTNAMES" ] && [ -n "${AZURE_ENV_NAME:-}" ]; then
+  ENV_FILE="$REPO_ROOT/.azure/$AZURE_ENV_NAME/.env"
+  if [ -f "$ENV_FILE" ]; then
+    APIM_APPROVED_BACKEND_HOSTNAMES="$(grep -E '^(APIM_APPROVED_BACKEND_HOSTNAMES|AGC_FRONTEND_HOSTNAME)=' "$ENV_FILE" | head -n 1 | cut -d '=' -f2- | tr -d '"' || true)"
+    if [ -z "$APPROVED_BACKEND_REFERENCE" ]; then
+      APPROVED_BACKEND_REFERENCE="$(grep -E '^(AGC_FRONTEND_REFERENCE)=' "$ENV_FILE" | head -n 1 | cut -d '=' -f2- | tr -d '"' || true)"
+    fi
+  fi
+fi
+
+if [ -z "$APIM_APPROVED_BACKEND_SCHEME" ] && [ -n "${AZURE_ENV_NAME:-}" ]; then
+  ENV_FILE="$REPO_ROOT/.azure/$AZURE_ENV_NAME/.env"
+  if [ -f "$ENV_FILE" ]; then
+    APIM_APPROVED_BACKEND_SCHEME="$(grep -E '^(APIM_APPROVED_BACKEND_SCHEME|AGC_FRONTEND_SCHEME)=' "$ENV_FILE" | head -n 1 | cut -d '=' -f2- | tr -d '"' || true)"
+  fi
+fi
+
+[ -z "$APIM_APPROVED_BACKEND_SCHEME" ] && APIM_APPROVED_BACKEND_SCHEME="http"
+
+case "$APIM_APPROVED_BACKEND_SCHEME" in
+  http|https)
+    ;;
+  *)
+    echo "Unsupported APIM approved backend scheme '$APIM_APPROVED_BACKEND_SCHEME'. Supported values are 'http' and 'https'." >&2
+    exit 1
+    ;;
+esac
+
 if [ -z "$AKS_CLUSTER_NAME" ] && [ -n "${AZURE_ENV_NAME:-}" ]; then
   ENV_FILE="$REPO_ROOT/.azure/$AZURE_ENV_NAME/.env"
   if [ -f "$ENV_FILE" ]; then
@@ -126,7 +138,7 @@ fi
 
 if [ "$PREVIEW" = false ]; then
   if ! command -v kubectl >/dev/null 2>&1; then
-    echo "kubectl is required to resolve APIM backends."
+    echo "kubectl is required to validate APIM backend targets."
     exit 1
   fi
   if [ -z "$AKS_CLUSTER_NAME" ]; then
@@ -205,229 +217,117 @@ fi
 
 echo "Syncing APIM APIs for AKS agent services into $APIM_NAME (RG: $RESOURCE_GROUP)..."
 
-resolve_ingress_gateway_ip() {
-  if [ -n "$RESOLVED_INGRESS_HOST" ]; then
-    printf '%s' "$RESOLVED_INGRESS_HOST"
-    return 0
-  fi
-
-  resolve_app_gw_public_host() {
-    gateway_name="$1"
-    pip_id=""
-    host=""
-
-    pip_id="$(az network application-gateway show \
-      --resource-group "$RESOURCE_GROUP" \
-      --name "$gateway_name" \
-      --query 'frontendIPConfigurations[0].publicIPAddress.id' -o tsv 2>/dev/null || true)"
-
-    if [ -n "$pip_id" ]; then
-      host="$(az network public-ip show --ids "$pip_id" --query ipAddress -o tsv 2>/dev/null || true)"
-      if [ -z "$host" ]; then
-        host="$(az network public-ip show --ids "$pip_id" --query dnsSettings.fqdn -o tsv 2>/dev/null || true)"
-      fi
-      if [ -n "$host" ]; then
-        printf '%s' "$host"
-        return 0
-      fi
-    fi
-
-    return 1
-  }
-
-  append_unique_candidate() {
-    candidate="$1"
-    candidate="$(printf '%s' "$candidate" | xargs)"
-    [ -z "$candidate" ] && return 0
-
-    if [ -z "$INGRESS_CANDIDATES" ]; then
-      INGRESS_CANDIDATES="$candidate"
-      return 0
-    fi
-
-    if ! printf '%s\n' "$INGRESS_CANDIDATES" | grep -Fxq "$candidate"; then
-      INGRESS_CANDIDATES="$INGRESS_CANDIDATES
-$candidate"
-    fi
-  }
-
-  count_candidates() {
-    if [ -z "$1" ]; then
-      printf '0'
-      return
-    fi
-    printf '%s\n' "$1" | sed '/^[[:space:]]*$/d' | wc -l | tr -d '[:space:]'
-  }
-
-  if [ -n "$INGRESS_HOST" ]; then
-    RESOLVED_INGRESS_HOST="$INGRESS_HOST"
-    printf '%s' "$RESOLVED_INGRESS_HOST"
-    return 0
-  fi
-
-  if [ -n "$APP_GW_IP" ]; then
-    RESOLVED_INGRESS_HOST="$APP_GW_IP"
-    printf '%s' "$RESOLVED_INGRESS_HOST"
-    return 0
-  fi
-
-  if [ -n "$APP_GW_NAME" ]; then
-    RESOLVED_INGRESS_HOST="$(resolve_app_gw_public_host "$APP_GW_NAME" || true)"
-    if [ -z "$RESOLVED_INGRESS_HOST" ]; then
-      echo "Failed to resolve ingress host from explicit application gateway '$APP_GW_NAME'." >&2
-      return 1
-    fi
-    printf '%s' "$RESOLVED_INGRESS_HOST"
-    return 0
-  fi
-
-  INGRESS_CANDIDATES=""
-  append_unique_candidate "$(kubectl get svc -A -l app.kubernetes.io/name=nginx -o jsonpath='{.items[0].status.loadBalancer.ingress[0].ip}' 2>/dev/null || true)"
-  append_unique_candidate "$(kubectl get svc -A -l app.kubernetes.io/name=nginx -o jsonpath='{.items[0].status.loadBalancer.ingress[0].hostname}' 2>/dev/null || true)"
-  append_unique_candidate "$(kubectl get svc nginx -n app-routing-system -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || true)"
-  append_unique_candidate "$(kubectl get svc nginx -n app-routing-system -o jsonpath='{.status.loadBalancer.ingress[0].hostname}' 2>/dev/null || true)"
-  append_unique_candidate "$(kubectl get svc ingress-nginx-controller -n ingress-nginx -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || true)"
-  append_unique_candidate "$(kubectl get svc ingress-nginx-controller -n ingress-nginx -o jsonpath='{.status.loadBalancer.ingress[0].hostname}' 2>/dev/null || true)"
-
-  INGRESS_CANDIDATE_COUNT="$(count_candidates "$INGRESS_CANDIDATES")"
-  if [ "$INGRESS_CANDIDATE_COUNT" -gt 1 ]; then
-    echo "Ambiguous ingress host candidates detected. Provide --app-gw-name, --app-gw-ip, or --ingress-host." >&2
-    return 1
-  fi
-
-  if [ "$INGRESS_CANDIDATE_COUNT" -eq 1 ]; then
-    RESOLVED_INGRESS_HOST="$(printf '%s\n' "$INGRESS_CANDIDATES" | sed '/^[[:space:]]*$/d' | head -n 1)"
-    printf '%s' "$RESOLVED_INGRESS_HOST"
-    return 0
-  fi
-
-  APP_GW_NAMES="$(az network application-gateway list --resource-group "$RESOURCE_GROUP" --query '[].name' -o tsv 2>/dev/null || true)"
-  APP_GW_COUNT="$(count_candidates "$APP_GW_NAMES")"
-
-  if [ "$APP_GW_COUNT" -gt 1 ]; then
-    echo "Multiple application gateways detected in '$RESOURCE_GROUP'. Provide --app-gw-name, --app-gw-ip, or --ingress-host." >&2
-    return 1
-  fi
-
-  if [ "$APP_GW_COUNT" -eq 1 ]; then
-    AUTO_GW_NAME="$(printf '%s\n' "$APP_GW_NAMES" | sed '/^[[:space:]]*$/d' | head -n 1)"
-    RESOLVED_INGRESS_HOST="$(resolve_app_gw_public_host "$AUTO_GW_NAME" || true)"
-    if [ -n "$RESOLVED_INGRESS_HOST" ]; then
-      printf '%s' "$RESOLVED_INGRESS_HOST"
-      return 0
-    fi
-    echo "Failed to resolve ingress host from detected application gateway '$AUTO_GW_NAME'." >&2
-    return 1
-  fi
-
-  return 1
+split_hostname_list() {
+  printf '%s' "$1" | tr ',' '\n' | tr -s '[:space:]' '\n' | sed '/^[[:space:]]*$/d' | awk '!seen[$0]++'
 }
 
-validate_ingress_health() {
+resolve_approved_backend_host() {
+  if [ -n "$RESOLVED_APPROVED_BACKEND_HOST" ]; then
+    printf '%s' "$RESOLVED_APPROVED_BACKEND_HOST"
+    return 0
+  fi
+
+  RESOLVED_APPROVED_BACKEND_HOST="$(split_hostname_list "$APIM_APPROVED_BACKEND_HOSTNAMES" | head -n 1)"
+  if [ -z "$RESOLVED_APPROVED_BACKEND_HOST" ]; then
+    if [ -n "$APPROVED_BACKEND_REFERENCE" ]; then
+      echo "No approved AGC backend hostname was provided. Set APIM_APPROVED_BACKEND_HOSTNAMES or AGC_FRONTEND_HOSTNAME before APIM sync. AGC frontend reference: $APPROVED_BACKEND_REFERENCE" >&2
+    else
+      echo "No approved AGC backend hostname was provided. Set APIM_APPROVED_BACKEND_HOSTNAMES or AGC_FRONTEND_HOSTNAME before APIM sync." >&2
+    fi
+    return 1
+  fi
+
+  printf '%s' "$RESOLVED_APPROVED_BACKEND_HOST"
+}
+
+validate_approved_backend_health() {
   host="$1"
-  probe_url="http://$host/health"
-  probe_body="/tmp/apim-ingress-health.json"
+  probe_url="$APIM_APPROVED_BACKEND_SCHEME://$host/health"
+  probe_body="/tmp/apim-agc-health.json"
   status_code=""
 
   for attempt in $(seq 1 8); do
     status_code="$(curl -sS -o "$probe_body" -w '%{http_code}' --max-time 10 "$probe_url" || true)"
     if [ "$status_code" = "200" ] || [ "$status_code" = "404" ]; then
-      echo "Validated ingress host '$host' via $probe_url"
+      echo "Validated approved AGC backend host '$host' via $probe_url"
       return 0
     fi
     sleep 5
   done
 
-  echo "Ingress validation failed for '$host' (last status: ${status_code:-n/a}) using $probe_url" >&2
+  echo "AGC backend validation failed for '$host' (last status: ${status_code:-n/a}) using $probe_url" >&2
   cat "$probe_body" 2>/dev/null >&2 || true
   return 1
 }
 
-ensure_ingress_ready() {
-  if [ "$INGRESS_VALIDATED" = true ]; then
+ensure_approved_backend_ready() {
+  if [ "$APPROVED_BACKEND_VALIDATED" = true ]; then
     return 0
   fi
 
-  RESOLVED_INGRESS_HOST="$(resolve_ingress_gateway_ip || true)"
-  if [ -z "$RESOLVED_INGRESS_HOST" ]; then
-    echo "Ingress endpoint could not be resolved for APIM backend sync. Refusing to fall back to cluster-local addresses that APIM cannot reach." >&2
-    return 1
-  fi
+  RESOLVED_APPROVED_BACKEND_HOST="$(resolve_approved_backend_host || true)"
+  [ -z "$RESOLVED_APPROVED_BACKEND_HOST" ] && return 1
 
   if [ "$PREVIEW" = false ]; then
-    validate_ingress_health "$RESOLVED_INGRESS_HOST"
+    validate_approved_backend_health "$RESOLVED_APPROVED_BACKEND_HOST"
   fi
 
-  INGRESS_VALIDATED=true
+  APPROVED_BACKEND_VALIDATED=true
   return 0
 }
 
 resolve_backend_url() {
   svc="$1"
-  resolved_name=""
-  resolved_port="80"
-  lb_host=""
-  attempt=1
-
-  # If using Ingress (AGIC), resolve via App Gateway public IP
-  if [ "$USE_INGRESS" = true ]; then
-    ensure_ingress_ready
-    # CRUD uses app-native ingress paths (/health, /api) at gateway root.
-    if [ "$svc" = "crud-service" ]; then
-      printf 'http://%s' "$RESOLVED_INGRESS_HOST"
-    else
-      printf 'http://%s/%s' "$RESOLVED_INGRESS_HOST" "$svc"
-    fi
+  ensure_approved_backend_ready
+  if [ "$svc" = "crud-service" ]; then
+    printf '%s://%s' "$APIM_APPROVED_BACKEND_SCHEME" "$RESOLVED_APPROVED_BACKEND_HOST"
     return
   fi
 
+  printf '%s://%s/%s' "$APIM_APPROVED_BACKEND_SCHEME" "$RESOLVED_APPROVED_BACKEND_HOST" "$svc"
+}
+
+get_service_name() {
+  svc="$1"
+  resolved_name="$svc"
+
   if command -v kubectl >/dev/null 2>&1; then
     resolved_name="$(kubectl get svc -n "$NAMESPACE" -l "app=$svc" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
-    if [ -n "$resolved_name" ]; then
-      resolved_port="$(kubectl get svc "$resolved_name" -n "$NAMESPACE" -o jsonpath='{.spec.ports[0].port}' 2>/dev/null || true)"
-      [ -z "$resolved_port" ] && resolved_port="80"
-
-      while [ "$attempt" -le "$BACKEND_RESOLVE_RETRIES" ]; do
-        lb_host="$(kubectl get svc "$resolved_name" -n "$NAMESPACE" -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || true)"
-        if [ -n "$lb_host" ]; then
-          printf 'http://%s:%s' "$lb_host" "$resolved_port"
-          return
-        fi
-
-        lb_host="$(kubectl get svc "$resolved_name" -n "$NAMESPACE" -o jsonpath='{.status.loadBalancer.ingress[0].hostname}' 2>/dev/null || true)"
-        if [ -n "$lb_host" ]; then
-          printf 'http://%s:%s' "$lb_host" "$resolved_port"
-          return
-        fi
-
-        if [ "$attempt" -lt "$BACKEND_RESOLVE_RETRIES" ]; then
-          sleep "$BACKEND_RESOLVE_DELAY_SECONDS"
-        fi
-        attempt=$((attempt + 1))
-      done
-
-      if [ "$REQUIRE_LOAD_BALANCER" = false ]; then
-        cluster_ip="$(kubectl get svc "$resolved_name" -n "$NAMESPACE" -o jsonpath='{.spec.clusterIP}' 2>/dev/null || true)"
-        if [ -n "$cluster_ip" ]; then
-          printf 'http://%s:%s' "$cluster_ip" "$resolved_port"
-          return
-        fi
-
-        printf 'http://%s.%s.svc.cluster.local:%s' "$resolved_name" "$NAMESPACE" "$resolved_port"
-        return
-      fi
-
-      echo "Service '$svc' has no load balancer address in namespace '$NAMESPACE'." >&2
-      return 1
-    fi
+    [ -n "$resolved_name" ] && printf '%s' "$resolved_name" && return
   fi
 
-  if [ "$REQUIRE_LOAD_BALANCER" = true ]; then
-    echo "Service '$svc' could not be resolved from Kubernetes in namespace '$NAMESPACE'." >&2
-    return 1
+  if [ -n "$AKS_CLUSTER_NAME" ] && [ -n "$RESOURCE_GROUP" ]; then
+    aks_logs="$(az aks command invoke \
+      --resource-group "$RESOURCE_GROUP" \
+      --name "$AKS_CLUSTER_NAME" \
+      --command "kubectl get svc -n $NAMESPACE -l app=$svc -o jsonpath='{.items[0].metadata.name}'" \
+      --query logs -o tsv 2>/dev/null || true)"
+    resolved_name="$(printf '%s' "$aks_logs" | awk 'NF{line=$0} END{print line}')"
+    [ -n "$resolved_name" ] && printf '%s' "$resolved_name" && return
   fi
 
-  printf 'http://%s-%s.%s.svc.cluster.local:80' "$svc" "$svc" "$NAMESPACE"
+  printf '%s' "$svc"
+}
+
+get_service_cluster_ip() {
+  svc="$1"
+  resolved_name="$(get_service_name "$svc")"
+  cluster_ip=""
+
+  if command -v kubectl >/dev/null 2>&1; then
+    cluster_ip="$(kubectl get svc "$resolved_name" -n "$NAMESPACE" -o jsonpath='{.spec.clusterIP}' 2>/dev/null || true)"
+    [ -n "$cluster_ip" ] && printf '%s' "$cluster_ip" && return
+  fi
+
+  if [ -n "$AKS_CLUSTER_NAME" ] && [ -n "$RESOURCE_GROUP" ]; then
+    aks_logs="$(az aks command invoke \
+      --resource-group "$RESOURCE_GROUP" \
+      --name "$AKS_CLUSTER_NAME" \
+      --command "kubectl get svc $resolved_name -n $NAMESPACE -o jsonpath='{.spec.clusterIP}'" \
+      --query logs -o tsv 2>/dev/null || true)"
+    cluster_ip="$(printf '%s' "$aks_logs" | awk 'NF{line=$0} END{print line}')"
+    [ -n "$cluster_ip" ] && printf '%s' "$cluster_ip" && return
+  fi
 }
 
 get_service_endpoint_ips() {
@@ -465,23 +365,89 @@ print(parsed.hostname or "")
 PY
 }
 
-assert_stable_crud_backend_target() {
+is_ip_literal() {
+  python - "$1" <<'PY'
+import ipaddress
+import sys
+
+value = sys.argv[1]
+try:
+    ipaddress.ip_address(value)
+except ValueError:
+    print("false")
+else:
+    print("true")
+PY
+}
+
+get_node_ips() {
+  node_ips=""
+
+  if command -v kubectl >/dev/null 2>&1; then
+    node_ips="$(kubectl get nodes -o jsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address} {.items[*].status.addresses[?(@.type=="ExternalIP")].address}' 2>/dev/null || true)"
+  fi
+
+  if [ -z "$node_ips" ] && [ -n "$AKS_CLUSTER_NAME" ] && [ -n "$RESOURCE_GROUP" ]; then
+    aks_logs="$(az aks command invoke \
+      --resource-group "$RESOURCE_GROUP" \
+      --name "$AKS_CLUSTER_NAME" \
+      --command "kubectl get nodes -o jsonpath='{.items[*].status.addresses[?(@.type==\"InternalIP\")].address} {.items[*].status.addresses[?(@.type==\"ExternalIP\")].address}'" \
+      --query logs -o tsv 2>/dev/null || true)"
+    node_ips="$(printf '%s' "$aks_logs" | awk 'NF{line=$0} END{print line}')"
+  fi
+
+  printf '%s' "$node_ips"
+}
+
+assert_approved_backend_target() {
   backend_url="$1"
+  service_name="$2"
   backend_host="$(get_url_host "$backend_url")"
 
   if [ -z "$backend_host" ]; then
-    echo "Unable to parse host from CRUD APIM backend URL '$backend_url'." >&2
+    echo "Unable to parse host from APIM backend URL '$backend_url'." >&2
     return 1
   fi
 
-  endpoint_ips="$(get_service_endpoint_ips crud-service "$NAMESPACE")"
+  if ! split_hostname_list "$APIM_APPROVED_BACKEND_HOSTNAMES" | grep -Fxq "$backend_host"; then
+    allowed_hosts="$(split_hostname_list "$APIM_APPROVED_BACKEND_HOSTNAMES" | paste -sd ',' -)"
+    echo "Refusing to set APIM backend '$backend_url': host '$backend_host' is not in the approved AGC hostname list: $allowed_hosts" >&2
+    return 1
+  fi
+
+  if [ "$(is_ip_literal "$backend_host")" = "true" ]; then
+    echo "Refusing to set APIM backend '$backend_url': approved target '$backend_host' is an IP literal. APIM backends must target AGC hostnames only." >&2
+    return 1
+  fi
+
+  case "$backend_host" in
+    *.svc.cluster.local|*.svc)
+      echo "Refusing to set APIM backend '$backend_url': host '$backend_host' is cluster-local." >&2
+      return 1
+      ;;
+  esac
+
+  cluster_ip="$(get_service_cluster_ip "$service_name")"
+  if [ -n "$cluster_ip" ] && [ "$backend_host" = "$cluster_ip" ]; then
+    echo "Refusing to set APIM backend '$backend_url': host '$backend_host' matches the '$service_name' ClusterIP." >&2
+    return 1
+  fi
+
+  endpoint_ips="$(get_service_endpoint_ips "$service_name" "$NAMESPACE")"
   if [ -n "$endpoint_ips" ] && printf '%s\n' "$endpoint_ips" | tr ' ' '\n' | sed '/^[[:space:]]*$/d' | grep -Fxq "$backend_host"; then
     endpoint_list="$(printf '%s\n' "$endpoint_ips" | tr ' ' '\n' | sed '/^[[:space:]]*$/d' | paste -sd ',' -)"
-    echo "Refusing to set unstable CRUD APIM backend '$backend_url': host '$backend_host' matches current crud-service endpoint IP(s): $endpoint_list" >&2
+    echo "Refusing to set APIM backend '$backend_url': host '$backend_host' matches current '$service_name' endpoint IP(s): $endpoint_list" >&2
     return 1
   fi
 
-  echo "Validated stable CRUD APIM backend host '$backend_host'."
+  node_ips="$(get_node_ips)"
+  if [ -n "$node_ips" ] && printf '%s\n' "$node_ips" | tr ' ' '\n' | sed '/^[[:space:]]*$/d' | grep -Fxq "$backend_host"; then
+    node_list="$(printf '%s\n' "$node_ips" | tr ' ' '\n' | sed '/^[[:space:]]*$/d' | paste -sd ',' -)"
+    echo "Refusing to set APIM backend '$backend_url': host '$backend_host' matches AKS node IP(s): $node_list" >&2
+    return 1
+  fi
+
+  echo "Validated approved APIM backend host '$backend_host' for service '$service_name'."
 }
 
 ensure_crud_api() {
@@ -495,7 +461,7 @@ ensure_crud_api() {
   fi
 
   BACKEND_URL="$(resolve_backend_url crud-service)"
-  assert_stable_crud_backend_target "$BACKEND_URL"
+  assert_approved_backend_target "$BACKEND_URL" crud-service
 
   if az apim api show --resource-group "$RESOURCE_GROUP" --service-name "$APIM_NAME" --api-id "crud-service" >/dev/null 2>&1; then
     API_ID="crud-service"
@@ -692,6 +658,7 @@ echo "$SERVICES" | while IFS= read -r SERVICE; do
   fi
 
   BACKEND_URL="$(resolve_backend_url "$SERVICE")"
+  assert_approved_backend_target "$BACKEND_URL" "$SERVICE"
 
   if az apim api show --resource-group "$RESOURCE_GROUP" --service-name "$APIM_NAME" --api-id "$API_ID" >/dev/null 2>&1; then
     az apim api update \

--- a/azure.yaml
+++ b/azure.yaml
@@ -512,12 +512,13 @@ hooks:
     windows:
       shell: pwsh
       run: |
-        ./.infra/azd/hooks/sync-apim-agents.ps1 -Namespace holiday-peak -ApiPathPrefix agents -UseIngress -IncludeCrudService:$true
+        $env:APIM_APPROVED_BACKEND_HOSTNAMES = $env:AGC_FRONTEND_HOSTNAME
+        ./.infra/azd/hooks/sync-apim-agents.ps1 -Namespace holiday-peak -ApiPathPrefix agents -IncludeCrudService:$true
         ./.infra/azd/hooks/ensure-foundry-agents.ps1 -UsePortForward -FailOnError:$false
       interactive: false
     posix:
       shell: sh
       run: |
-        ./.infra/azd/hooks/sync-apim-agents.sh --namespace holiday-peak --api-path-prefix agents --use-ingress
+        APIM_APPROVED_BACKEND_HOSTNAMES="$AGC_FRONTEND_HOSTNAME" ./.infra/azd/hooks/sync-apim-agents.sh --namespace holiday-peak --api-path-prefix agents
         ./.infra/azd/hooks/ensure-foundry-agents.sh --port-forward --non-blocking
       interactive: false

--- a/docs/roadmap/013-agc-edge-migration.md
+++ b/docs/roadmap/013-agc-edge-migration.md
@@ -78,6 +78,7 @@ flowchart LR
 - CRUD and at least one agent can be published through AGC
 - All migrated services remain `ClusterIP`
 - APIM sync resolves a stable AGC hostname instead of pod, node, or service IPs
+- APIM sync consumes `APIM_APPROVED_BACKEND_HOSTNAMES` from `AGC_FRONTEND_HOSTNAME` and fails closed on IP literals, `ClusterIP`, node IPs, endpoint IPs, and `*.svc.cluster.local` targets
 
 ### Phase 3: Validation and Cutover
 


### PR DESCRIPTION
## Summary
- refactor APIM sync hooks to target approved AGC hostnames only
- reject APIM backend targets that are IP literals, ClusterIP, node IPs, endpoint IPs, or cluster-local service DNS
- wire azd postdeploy to pass the approved AGC hostname contract into APIM sync

Closes #285