### PR TITLE
Issue #287: cut over CRUD publication defaults to AGC

### DIFF
--- a/.github/workflows/deploy-azd.yml
+++ b/.github/workflows/deploy-azd.yml
@@ -693,7 +693,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          echo "PUBLICATION_MODE=dual" >> "$GITHUB_ENV"
+          echo "PUBLICATION_MODE=agc" >> "$GITHUB_ENV"
           echo "AGC_SUPPORT_ENABLED=${{ needs.provision.outputs.AGC_SUPPORT_ENABLED || 'false' }}" >> "$GITHUB_ENV"
           echo "AGC_GATEWAY_CLASS=${{ needs.provision.outputs.AGC_GATEWAY_CLASS || 'azure-alb-external' }}" >> "$GITHUB_ENV"
           echo "AGC_SUBNET_ID=${{ needs.provision.outputs.AGC_SUBNET_ID }}" >> "$GITHUB_ENV"
@@ -708,24 +708,7 @@ jobs:
           else
             echo "AGC gateway class '${{ needs.provision.outputs.AGC_GATEWAY_CLASS || 'azure-alb-external' }}' is not ready yet. APIM sync will be blocked later by the AGC readiness gate if this remains unresolved." >&2
           fi
-
-          if [ -n "${INGRESS_CLASS_NAME:-}" ] && kubectl get ingressclass "${INGRESS_CLASS_NAME}" >/dev/null 2>&1; then
-            echo "Using preconfigured legacy ingress class: ${INGRESS_CLASS_NAME}"
-            echo "LEGACY_INGRESS_CLASS_NAME=${INGRESS_CLASS_NAME}" >> "$GITHUB_ENV"
-            echo "INGRESS_CLASS_NAME=${INGRESS_CLASS_NAME}" >> "$GITHUB_ENV"
-            exit 0
-          fi
-
-          for cls in webapprouting.kubernetes.azure.com nginx azure-application-gateway; do
-            if kubectl get ingressclass "$cls" >/dev/null 2>&1; then
-              echo "Using transitional legacy ingress class: $cls"
-              echo "LEGACY_INGRESS_CLASS_NAME=$cls" >> "$GITHUB_ENV"
-              echo "INGRESS_CLASS_NAME=$cls" >> "$GITHUB_ENV"
-              exit 0
-            fi
-          done
-
-          echo "No legacy ingress class detected. Continuing with AGC publication as the canonical workflow path."
+          echo "Legacy ingress classes are ignored by default. Use PUBLICATION_MODE=legacy or dual with an explicit LEGACY_INGRESS_CLASS_NAME only for rollback."
 
       - name: Preflight ACR data-plane accessibility
         id: acr_preflight
@@ -1404,7 +1387,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          echo "PUBLICATION_MODE=dual" >> "$GITHUB_ENV"
+          echo "PUBLICATION_MODE=agc" >> "$GITHUB_ENV"
           echo "AGC_SUPPORT_ENABLED=${{ needs.provision.outputs.AGC_SUPPORT_ENABLED || 'false' }}" >> "$GITHUB_ENV"
           echo "AGC_GATEWAY_CLASS=${{ needs.provision.outputs.AGC_GATEWAY_CLASS || 'azure-alb-external' }}" >> "$GITHUB_ENV"
           echo "AGC_SUBNET_ID=${{ needs.provision.outputs.AGC_SUBNET_ID }}" >> "$GITHUB_ENV"

--- a/.infra/azd/hooks/render-helm.ps1
+++ b/.infra/azd/hooks/render-helm.ps1
@@ -7,9 +7,9 @@ $namespace = if ($env:K8S_NAMESPACE) { $env:K8S_NAMESPACE } else { "holiday-peak
 $imagePrefix = if ($env:IMAGE_PREFIX) { $env:IMAGE_PREFIX } else { "ghcr.io/azure-samples" }
 $imageTag = if ($env:IMAGE_TAG) { $env:IMAGE_TAG } else { "latest" }
 $kedaEnabled = if ($env:KEDA_ENABLED) { $env:KEDA_ENABLED } else { "false" }
-$publicationMode = if ($env:PUBLICATION_MODE) { $env:PUBLICATION_MODE } else { "legacy" }
+$publicationMode = if ($env:PUBLICATION_MODE) { $env:PUBLICATION_MODE } else { "agc" }
 $legacyIngressEnabled = "false"
-$legacyIngressClassName = if ($env:LEGACY_INGRESS_CLASS_NAME) { $env:LEGACY_INGRESS_CLASS_NAME } elseif ($env:INGRESS_CLASS_NAME) { $env:INGRESS_CLASS_NAME } else { "webapprouting.kubernetes.azure.com" }
+$legacyIngressClassName = if ($env:LEGACY_INGRESS_CLASS_NAME) { $env:LEGACY_INGRESS_CLASS_NAME } elseif ($env:INGRESS_CLASS_NAME) { $env:INGRESS_CLASS_NAME } else { "" }
 $agcEnabled = "false"
 $agcGatewayClassName = if ($env:AGC_GATEWAY_CLASS) { $env:AGC_GATEWAY_CLASS } else { "azure-alb-external" }
 $agcSubnetId = if ($env:AGC_SUBNET_ID) { $env:AGC_SUBNET_ID } else { "" }
@@ -67,6 +67,10 @@ switch ($publicationMode.ToLowerInvariant()) {
   default {
     throw "Unsupported PUBLICATION_MODE '$publicationMode'. Expected one of legacy, agc, dual, none."
   }
+}
+
+if ($legacyIngressEnabled -eq 'true' -and -not $legacyIngressClassName) {
+  throw "LEGACY_INGRESS_CLASS_NAME or INGRESS_CLASS_NAME must be set when PUBLICATION_MODE is legacy or dual."
 }
 
 if ($agcEnabled -eq 'true' -and -not $env:AGC_SHARED_RESOURCES_CREATE -and $ServiceName -eq 'crud-service') {

--- a/.infra/azd/hooks/render-helm.sh
+++ b/.infra/azd/hooks/render-helm.sh
@@ -7,9 +7,9 @@ NAMESPACE="${K8S_NAMESPACE:-holiday-peak}"
 IMAGE_PREFIX="${IMAGE_PREFIX:-ghcr.io/azure-samples}"
 IMAGE_TAG="${IMAGE_TAG:-latest}"
 KEDA_ENABLED="${KEDA_ENABLED:-false}"
-PUBLICATION_MODE="${PUBLICATION_MODE:-legacy}"
+PUBLICATION_MODE="${PUBLICATION_MODE:-agc}"
 LEGACY_INGRESS_ENABLED="false"
-LEGACY_INGRESS_CLASS_NAME="${LEGACY_INGRESS_CLASS_NAME:-${INGRESS_CLASS_NAME:-webapprouting.kubernetes.azure.com}}"
+LEGACY_INGRESS_CLASS_NAME="${LEGACY_INGRESS_CLASS_NAME:-${INGRESS_CLASS_NAME:-}}"
 AGC_ENABLED="false"
 AGC_GATEWAY_CLASS_NAME="${AGC_GATEWAY_CLASS:-azure-alb-external}"
 AGC_SUBNET_ID="${AGC_SUBNET_ID:-}"
@@ -43,6 +43,11 @@ case "$PUBLICATION_MODE" in
     exit 1
     ;;
 esac
+
+if [ "$LEGACY_INGRESS_ENABLED" = "true" ] && [ -z "$LEGACY_INGRESS_CLASS_NAME" ]; then
+  echo "LEGACY_INGRESS_CLASS_NAME or INGRESS_CLASS_NAME must be set when PUBLICATION_MODE is legacy or dual." >&2
+  exit 1
+fi
 
 # Determine workload type (crud-service goes to crud pool, others to agents pool)
 if [ "$SERVICE_NAME" = "crud-service" ]; then

--- a/.kubernetes/chart/values.yaml
+++ b/.kubernetes/chart/values.yaml
@@ -7,9 +7,9 @@ service:
   targetPort: 8000
   annotations: {}
 
-# Legacy ingress configuration for transitional coexistence during AGC migration.
+# Legacy ingress configuration for explicit rollback-only publication.
 ingress:
-  enabled: true
+  enabled: false
   className: ""
   host: ""  # Leave empty for path-based routing, or set hostname for host-based
   path: ""  # Defaults to /{serviceName}

--- a/docs/implementation/single-rg-deployment-runbook.md
+++ b/docs/implementation/single-rg-deployment-runbook.md
@@ -32,7 +32,7 @@ This configures azd environment values for `holidaypeakhub405-dev-rg` and runs `
 ./scripts/ops/demo-recover-and-seed.ps1
 ```
 
-This starts AKS, Application Gateway, and PostgreSQL, validates APIM CRUD endpoints, and runs CRUD demo seed job.
+This starts AKS and PostgreSQL, validates direct AGC CRUD health plus APIM CRUD endpoints, and runs CRUD demo seed job.
 
 ### 3. Pause (Cost Save)
 
@@ -58,6 +58,31 @@ This deletes `holidaypeakhub405-dev-rg` asynchronously.
 - CRUD seed hooks now support both PostgreSQL auth modes:
   - `POSTGRES_AUTH_MODE=password`
   - `POSTGRES_AUTH_MODE=entra`
+- Default AKS publication is now `PUBLICATION_MODE=agc`.
+- Legacy ingress publication is rollback-only and must be requested explicitly with:
+  - `PUBLICATION_MODE=legacy` or `PUBLICATION_MODE=dual`
+  - `LEGACY_INGRESS_CLASS_NAME=<explicit-class>`
+
+## CRUD Cutover And Rollback
+
+The dev cutover path is now `APIM -> AGC -> AKS` for CRUD.
+
+- Normal validation target:
+  - direct AGC `GET /health`
+  - APIM `GET /api/health`
+  - APIM `GET /api/products?limit=1`
+- Soak expectation:
+  - no dependency on nginx or Web App Routing for successful CRUD traffic
+
+If rollback is required during the soak window, use an explicit legacy override for the affected deploy only.
+
+```powershell
+$env:PUBLICATION_MODE = 'legacy'
+$env:LEGACY_INGRESS_CLASS_NAME = 'webapprouting.kubernetes.azure.com'
+azd deploy --service crud-service -e dev
+```
+
+Use `dual` instead of `legacy` if you need temporary side-by-side rollback validation before restoring AGC-only publication.
 
 ## UI Runtime Clarification (SWA)
 


### PR DESCRIPTION
## Summary
- switch render and workflow publication defaults from legacy/dual to AGC
- require explicit legacy ingress class selection for rollback-only legacy or dual publication
- update the single-RG runbook with AGC-first CRUD validation and explicit rollback steps

Closes #287