### PR TITLE
[P1][#299] Align Event Hub topology for returns, inventory, and user events

### DIFF
--- a/apps/crm-support-assistance/src/crm_support_assistance/event_handlers.py
+++ b/apps/crm-support-assistance/src/crm_support_assistance/event_handlers.py
@@ -50,4 +50,7 @@ def build_event_handlers() -> dict[str, EventHandler]:
             next_steps=len(brief.get("next_best_actions", [])),
         )
 
-    return {"order-events": handle_order_event}
+    return {
+        "order-events": handle_order_event,
+        "return-events": handle_order_event,
+    }

--- a/apps/crm-support-assistance/src/crm_support_assistance/main.py
+++ b/apps/crm-support-assistance/src/crm_support_assistance/main.py
@@ -71,6 +71,7 @@ app = build_service_app(
         service_name=SERVICE_NAME,
         subscriptions=[
             EventHubSubscription("order-events", "support-group"),
+            EventHubSubscription("return-events", "support-group"),
         ],
         handlers=build_event_handlers(),
     ),

--- a/apps/crm-support-assistance/tests/test_event_handlers.py
+++ b/apps/crm-support-assistance/tests/test_event_handlers.py
@@ -6,3 +6,4 @@ from crm_support_assistance.event_handlers import build_event_handlers
 def test_build_event_handlers_includes_order_events() -> None:
     handlers = build_event_handlers()
     assert "order-events" in handlers
+    assert "return-events" in handlers

--- a/apps/crud-service/src/crud_service/routes/cart.py
+++ b/apps/crud-service/src/crud_service/routes/cart.py
@@ -1,7 +1,9 @@
 """Cart routes."""
 
+from datetime import datetime, timezone
+
 from crud_service.auth import User, get_current_user
-from crud_service.integrations import get_agent_client
+from crud_service.integrations import get_agent_client, get_event_publisher
 from crud_service.repositories import CartRepository, ProductRepository
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
@@ -10,6 +12,7 @@ router = APIRouter()
 cart_repo = CartRepository()
 product_repo = ProductRepository()
 agent_client = get_agent_client()
+event_publisher = get_event_publisher()
 
 
 class AddToCartRequest(BaseModel):
@@ -94,6 +97,18 @@ async def add_to_cart(
                 status_code=status.HTTP_409_CONFLICT,
                 detail=reservation.get("reason", "Insufficient stock"),
             )
+        if isinstance(reservation, dict) and reservation.get("valid") is True:
+            try:
+                await event_publisher.publish_inventory_reserved(
+                    {
+                        "user_id": current_user.user_id,
+                        "sku": request.product_id,
+                        "quantity": request.quantity,
+                        "timestamp": datetime.now(timezone.utc).isoformat(),
+                    }
+                )
+            except Exception:
+                pass
     except HTTPException:
         raise
     except Exception:

--- a/apps/crud-service/src/crud_service/routes/users.py
+++ b/apps/crud-service/src/crud_service/routes/users.py
@@ -1,7 +1,7 @@
 """User routes."""
 
 from crud_service.auth import User, get_current_user
-from crud_service.integrations import get_agent_client
+from crud_service.integrations import get_agent_client, get_event_publisher
 from crud_service.repositories import UserRepository
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
@@ -9,6 +9,7 @@ from pydantic import BaseModel
 router = APIRouter()
 user_repo = UserRepository()
 agent_client = get_agent_client()
+event_publisher = get_event_publisher()
 
 
 class UserProfileResponse(BaseModel):
@@ -59,6 +60,19 @@ async def update_my_profile(
         user["phone"] = request.phone
 
     updated = await user_repo.update(user)
+    await event_publisher.publish(
+        "user-events",
+        "UserUpdated",
+        {
+            "id": updated.get("id"),
+            "user_id": updated.get("id"),
+            "entra_id": updated.get("entra_id"),
+            "email": updated.get("email"),
+            "name": updated.get("name"),
+            "phone": updated.get("phone"),
+            "timestamp": updated.get("updated_at") or updated.get("created_at"),
+        },
+    )
     return UserProfileResponse(**updated)
 
 

--- a/apps/crud-service/tests/unit/test_routes_new_agents.py
+++ b/apps/crud-service/tests/unit/test_routes_new_agents.py
@@ -280,6 +280,47 @@ class TestCrmProfile:
         assert data["personalization"] is None
 
 
+class TestUserEventPublishing:
+    """PATCH /users/me emits UserUpdated event."""
+
+    @pytest.mark.asyncio
+    async def test_update_profile_publishes_user_updated(self, client, monkeypatch, override_auth):
+        async def fake_get_by_entra_id(_entra_id):
+            return {
+                "id": "user-1",
+                "entra_id": "user-1",
+                "email": "user@example.com",
+                "name": "Old Name",
+                "phone": None,
+                "created_at": "2025-01-01T00:00:00Z",
+            }
+
+        async def fake_update(user):
+            return {
+                **user,
+                "updated_at": "2025-01-02T00:00:00Z",
+            }
+
+        published_events: list[tuple[str, str, dict]] = []
+
+        class FakePublisher:
+            async def publish(self, topic, event_type, data):
+                published_events.append((topic, event_type, data))
+
+        monkeypatch.setattr(users_routes.user_repo, "get_by_entra_id", fake_get_by_entra_id)
+        monkeypatch.setattr(users_routes.user_repo, "update", fake_update)
+        monkeypatch.setattr(users_routes, "event_publisher", FakePublisher())
+
+        response = client.patch("/api/users/me", json={"name": "New Name", "phone": "555-0000"})
+        assert response.status_code == 200
+        assert response.json()["name"] == "New Name"
+        assert published_events
+        topic, event_type, payload = published_events[0]
+        assert topic == "user-events"
+        assert event_type == "UserUpdated"
+        assert payload["user_id"] == "user-1"
+
+
 # ── Cart Routes ─────────────────────────────────────────────────────
 
 
@@ -302,14 +343,24 @@ class TestCartReservationValidation:
             async def validate_reservation(self, sku, quantity):
                 return {"valid": True}
 
+        published_reservations: list[dict] = []
+
+        class FakePublisher:
+            async def publish_inventory_reserved(self, reservation):
+                published_reservations.append(reservation)
+
         monkeypatch.setattr(cart_routes.product_repo, "get_by_id", fake_product)
         monkeypatch.setattr(cart_routes.cart_repo, "get_by_user", fake_cart)
         monkeypatch.setattr(cart_routes.cart_repo, "update", fake_update)
         monkeypatch.setattr(cart_routes, "agent_client", FakeAgent())
+        monkeypatch.setattr(cart_routes, "event_publisher", FakePublisher())
 
         response = client.post("/api/cart/items", json={"product_id": "p1", "quantity": 2})
         assert response.status_code == 200
         assert response.json()["message"] == "Item added to cart"
+        assert published_reservations
+        assert published_reservations[0]["user_id"] == "user-1"
+        assert published_reservations[0]["sku"] == "p1"
 
     @pytest.mark.asyncio
     async def test_rejects_invalid_reservation(self, client, monkeypatch, override_auth):

--- a/apps/logistics-returns-support/src/logistics_returns_support/event_handlers.py
+++ b/apps/logistics-returns-support/src/logistics_returns_support/event_handlers.py
@@ -41,7 +41,10 @@ def build_event_handlers() -> dict[str, EventHandler]:
             status=plan.get("status"),
         )
 
-    return {"order-events": handle_order_event}
+    return {
+        "order-events": handle_order_event,
+        "return-events": handle_order_event,
+    }
 
 
 def _resolve_tracking_id(data: dict[str, object]) -> str | None:

--- a/apps/logistics-returns-support/src/logistics_returns_support/main.py
+++ b/apps/logistics-returns-support/src/logistics_returns_support/main.py
@@ -71,6 +71,7 @@ app = build_service_app(
         service_name=SERVICE_NAME,
         subscriptions=[
             EventHubSubscription("order-events", "returns-group"),
+            EventHubSubscription("return-events", "returns-group"),
         ],
         handlers=build_event_handlers(),
     ),

--- a/apps/logistics-returns-support/tests/test_event_handlers.py
+++ b/apps/logistics-returns-support/tests/test_event_handlers.py
@@ -6,3 +6,4 @@ from logistics_returns_support.event_handlers import build_event_handlers
 def test_build_event_handlers_includes_order_events() -> None:
     handlers = build_event_handlers()
     assert "order-events" in handlers
+    assert "return-events" in handlers

--- a/docs/architecture/eventhub-topology-matrix.md
+++ b/docs/architecture/eventhub-topology-matrix.md
@@ -1,0 +1,20 @@
+# Event Hub topology matrix
+
+_Last updated: 2026-03-18_
+
+## Active topology
+
+| Topic | Primary publishers | Active subscribers |
+|---|---|---|
+| `order-events` | CRUD `orders` routes, ACP checkout completion | `crm-*`, `ecommerce-*`, `inventory-*`, `logistics-*`, `product-management-*` services |
+| `payment-events` | CRUD `payments` routes, Stripe webhook, ACP checkout completion | `crm-campaign-intelligence` |
+| `return-events` | CRUD customer/staff returns lifecycle routes | `logistics-returns-support`, `crm-support-assistance` |
+| `inventory-events` | CRUD `cart` route (successful reservation publish path) | `ecommerce-checkout-support`, `inventory-health-check`, `inventory-alerts-triggers`, `inventory-jit-replenishment` |
+| `user-events` | CRUD `users` route (`PATCH /api/users/me` as `UserUpdated`) | `crm-campaign-intelligence`, `crm-profile-aggregation` |
+| `shipment-events` | Reserved publisher path in CRUD integration (`publish_shipment_created`) | _No direct subscribers currently wired_ |
+
+## Notes
+
+- Product-domain event publishing remains pending a dedicated product mutation route set in CRUD.
+- Shipment-domain subscribers remain pending in logistics services for end-to-end shipment lifecycle orchestration.
+- This matrix is intended as a living architecture artifact and should be updated alongside topology changes.


### PR DESCRIPTION
## Summary\n- wire CRUD cart reservation flow to publish InventoryReserved events\n- wire CRUD profile update flow to publish UserUpdated events\n- add eturn-events subscriptions/handlers to logistics-returns-support and crm-support-assistance\n- document current Event Hub coverage in docs/architecture/eventhub-topology-matrix.md\n- add/extend focused tests for new publisher/subscriber paths\n\n## Validation\n- python -m pytest apps/crud-service/tests/unit/test_routes_new_agents.py apps/logistics-returns-support/tests/test_event_handlers.py apps/crm-support-assistance/tests/test_event_handlers.py\n- Result: 18 passed\n\n## Notes\n- shipment-topic end-to-end consumer wiring remains pending follow-up work\n- product-domain mutation event publishing remains pending dedicated product mutation endpoints in CRUD\n