### PR TITLE
[PY-08] Typing modernization in lib for Python 3.11 (#421)

### DIFF
--- a/lib/src/holiday_peak_lib/adapters/base.py
+++ b/lib/src/holiday_peak_lib/adapters/base.py
@@ -19,7 +19,7 @@ import random
 import time
 from abc import ABC, abstractmethod
 from collections import OrderedDict, deque
-from typing import Any, Iterable, Optional, Type, TypeVar
+from typing import Any, Iterable, TypeVar
 
 from pydantic import BaseModel, ValidationError
 
@@ -111,7 +111,7 @@ class BaseAdapter(ABC):
         await self._set_cache(key, result)
         return result
 
-    async def upsert(self, payload: dict[str, Any]) -> Optional[dict[str, Any]]:
+    async def upsert(self, payload: dict[str, Any]) -> dict[str, Any] | None:
         async def op():
             return await self._upsert_impl(payload)
 
@@ -137,7 +137,7 @@ class BaseAdapter(ABC):
         """Fetch data from the upstream system given a query payload."""
 
     @abstractmethod
-    async def _upsert_impl(self, payload: dict[str, Any]) -> Optional[dict[str, Any]]:
+    async def _upsert_impl(self, payload: dict[str, Any]) -> dict[str, Any] | None:
         """Create or update an entity in the upstream system."""
 
     @abstractmethod
@@ -149,7 +149,7 @@ class BaseAdapter(ABC):
         await self._acquire_rate_limit()
         await self._ensure_circuit_allows()
 
-        last_error: Optional[Exception] = None
+        last_error: Exception | None = None
         for attempt in range(1, self._retries + 2):
             try:
                 result = await asyncio.wait_for(func(), timeout=self._timeout)
@@ -210,7 +210,7 @@ class BaseAdapter(ABC):
             "reset_seconds": self._circuit_reset_seconds,
         }
 
-    async def _get_cached(self, key: tuple) -> Optional[list[dict[str, Any]]]:
+    async def _get_cached(self, key: tuple) -> list[dict[str, Any]] | None:
         if self._cache_ttl <= 0:
             return None
         async with self._lock:
@@ -267,7 +267,7 @@ class BaseConnector:
         1
     """
 
-    def __init__(self, adapter: Optional[BaseAdapter] = None, map_concurrency: int = 10) -> None:
+    def __init__(self, adapter: BaseAdapter | None = None, map_concurrency: int = 10) -> None:
         """Initialize with an optional adapter and mapping concurrency limit.
 
         >>> BaseConnector(map_concurrency=0)._map_semaphore._value
@@ -277,7 +277,7 @@ class BaseConnector:
         ...
         AdapterError: Adapter has not been configured.
         """
-        self._adapter: Optional[BaseAdapter] = adapter
+        self._adapter: BaseAdapter | None = adapter
         self._map_semaphore = asyncio.Semaphore(max(1, map_concurrency))
 
     @property
@@ -304,7 +304,7 @@ class BaseConnector:
         """Open a connection using the underlying adapter."""
         await self.adapter.connect(**kwargs)
 
-    async def _fetch_first(self, **query: Any) -> Optional[dict[str, Any]]:
+    async def _fetch_first(self, **query: Any) -> dict[str, Any] | None:
         """Return the first record that matches the query, if present.
 
         >>> class OneAdapter(BaseAdapter):
@@ -346,8 +346,8 @@ class BaseConnector:
             raise AdapterError(f"Failed to fetch data for query: {query}") from exc
 
     async def _map_single(
-        self, model: Type[ModelT], payload: Optional[dict[str, Any]]
-    ) -> Optional[ModelT]:
+        self, model: type[ModelT], payload: dict[str, Any] | None
+    ) -> ModelT | None:
         """Validate and coerce a single payload into the target model.
 
         >>> class Model(BaseModel):
@@ -370,7 +370,7 @@ class BaseConnector:
             raise AdapterError(f"Invalid payload for {model.__name__}") from exc
 
     async def _map_many(
-        self, model: Type[ModelT], payloads: Iterable[dict[str, Any]]
+        self, model: type[ModelT], payloads: Iterable[dict[str, Any]]
     ) -> list[ModelT]:
         """Normalize multiple payloads concurrently with a bounded semaphore.
 

--- a/lib/src/holiday_peak_lib/adapters/crm_adapter.py
+++ b/lib/src/holiday_peak_lib/adapters/crm_adapter.py
@@ -6,8 +6,6 @@ All helpers include doctests to demonstrate normalization and concurrency-safe
 mapping.
 """
 
-from typing import Optional
-
 from holiday_peak_lib.adapters.base import BaseAdapter, BaseConnector
 from holiday_peak_lib.schemas.crm import (
     CRMAccount,
@@ -46,10 +44,10 @@ class CRMConnector(BaseConnector):
         'a@example.com'
     """
 
-    def __init__(self, adapter: Optional[BaseAdapter] = None, map_concurrency: int = 10) -> None:
+    def __init__(self, adapter: BaseAdapter | None = None, map_concurrency: int = 10) -> None:
         super().__init__(adapter=adapter, map_concurrency=map_concurrency)
 
-    async def get_contact(self, contact_id: str) -> Optional[CRMContact]:
+    async def get_contact(self, contact_id: str) -> CRMContact | None:
         """Fetch and normalize a single contact by identifier.
 
         :param contact_id: External CRM contact identifier.
@@ -76,7 +74,7 @@ class CRMConnector(BaseConnector):
         record = await self._fetch_first(entity="contact", id=contact_id)
         return await self._map_single(CRMContact, record)
 
-    async def get_account(self, account_id: str) -> Optional[CRMAccount]:
+    async def get_account(self, account_id: str) -> CRMAccount | None:
         """Fetch and normalize a single account by identifier.
 
         Process:
@@ -140,7 +138,7 @@ class CRMConnector(BaseConnector):
 
     async def build_contact_context(
         self, contact_id: str, interaction_limit: int = 20
-    ) -> Optional[CRMContext]:
+    ) -> CRMContext | None:
         """Assemble an agent-ready context containing contact, account, and interactions.
 
         Process:

--- a/lib/src/holiday_peak_lib/adapters/funnel_adapter.py
+++ b/lib/src/holiday_peak_lib/adapters/funnel_adapter.py
@@ -5,8 +5,6 @@ analysis scenarios referenced in the business summary. Doctests illustrate how
 adapter payloads become validated funnel contexts.
 """
 
-from typing import Optional
-
 from holiday_peak_lib.adapters.base import BaseAdapter, BaseConnector
 from holiday_peak_lib.schemas.funnel import FunnelContext, FunnelMetric
 
@@ -33,13 +31,13 @@ class FunnelConnector(BaseConnector):
         'view'
     """
 
-    def __init__(self, adapter: Optional[BaseAdapter] = None, map_concurrency: int = 10) -> None:
+    def __init__(self, adapter: BaseAdapter | None = None, map_concurrency: int = 10) -> None:
         super().__init__(adapter=adapter, map_concurrency=map_concurrency)
 
     async def get_metrics(
         self,
-        campaign_id: Optional[str] = None,
-        account_id: Optional[str] = None,
+        campaign_id: str | None = None,
+        account_id: str | None = None,
         limit: int = 20,
     ) -> list[FunnelMetric]:
         """Fetch and normalize funnel metrics for a campaign or account.
@@ -70,8 +68,8 @@ class FunnelConnector(BaseConnector):
 
     async def build_funnel_context(
         self,
-        campaign_id: Optional[str] = None,
-        account_id: Optional[str] = None,
+        campaign_id: str | None = None,
+        account_id: str | None = None,
         limit: int = 20,
     ) -> FunnelContext:
         """Assemble funnel metrics into agent-ready context.

--- a/lib/src/holiday_peak_lib/adapters/inventory_adapter.py
+++ b/lib/src/holiday_peak_lib/adapters/inventory_adapter.py
@@ -5,8 +5,6 @@ fulfillment scenarios covered in the business summary. Each helper includes a
 doctest to demonstrate normalization.
 """
 
-from typing import Optional
-
 from holiday_peak_lib.adapters.base import BaseAdapter, BaseConnector
 from holiday_peak_lib.schemas.inventory import (
     InventoryContext,
@@ -44,10 +42,10 @@ class InventoryConnector(BaseConnector):
         ('SKU-1', 1)
     """
 
-    def __init__(self, adapter: Optional[BaseAdapter] = None, map_concurrency: int = 10) -> None:
+    def __init__(self, adapter: BaseAdapter | None = None, map_concurrency: int = 10) -> None:
         super().__init__(adapter=adapter, map_concurrency=map_concurrency)
 
-    async def get_item(self, sku: str) -> Optional[InventoryItem]:
+    async def get_item(self, sku: str) -> InventoryItem | None:
         """Fetch and normalize a single inventory item.
 
         Doctest::
@@ -91,7 +89,7 @@ class InventoryConnector(BaseConnector):
         records = await self._fetch_many(entity="warehouse_stock", sku=sku)
         return await self._map_many(WarehouseStock, records)
 
-    async def build_inventory_context(self, sku: str) -> Optional[InventoryContext]:
+    async def build_inventory_context(self, sku: str) -> InventoryContext | None:
         """Assemble item and per-warehouse stock into agent-ready context.
 
         Doctest::

--- a/lib/src/holiday_peak_lib/adapters/logistics_adapter.py
+++ b/lib/src/holiday_peak_lib/adapters/logistics_adapter.py
@@ -5,8 +5,6 @@ purchase and delivery experiences described in the business summary. Every
 helper includes doctests to demonstrate normalization.
 """
 
-from typing import Optional
-
 from holiday_peak_lib.adapters.base import BaseAdapter, BaseConnector
 from holiday_peak_lib.schemas.logistics import LogisticsContext, Shipment, ShipmentEvent
 
@@ -40,10 +38,10 @@ class LogisticsConnector(BaseConnector):
         ('T1', 1)
     """
 
-    def __init__(self, adapter: Optional[BaseAdapter] = None, map_concurrency: int = 10) -> None:
+    def __init__(self, adapter: BaseAdapter | None = None, map_concurrency: int = 10) -> None:
         super().__init__(adapter=adapter, map_concurrency=map_concurrency)
 
-    async def get_shipment(self, tracking_id: str) -> Optional[Shipment]:
+    async def get_shipment(self, tracking_id: str) -> Shipment | None:
         """Fetch and normalize a shipment by tracking id.
 
         Doctest::
@@ -89,7 +87,7 @@ class LogisticsConnector(BaseConnector):
 
     async def build_logistics_context(
         self, tracking_id: str, event_limit: int = 50
-    ) -> Optional[LogisticsContext]:
+    ) -> LogisticsContext | None:
         """Assemble shipment and timeline for agent consumption.
 
         Doctest::

--- a/lib/src/holiday_peak_lib/adapters/mock_adapters.py
+++ b/lib/src/holiday_peak_lib/adapters/mock_adapters.py
@@ -6,7 +6,7 @@ assembly without external systems.
 """
 
 import datetime as _dt
-from typing import Any, Iterable, Optional
+from typing import Any, Iterable
 
 from holiday_peak_lib.adapters.base import BaseAdapter
 
@@ -44,7 +44,7 @@ class MockProductAdapter(BaseAdapter):
             ]
         return []
 
-    async def _upsert_impl(self, payload: dict[str, Any]) -> Optional[dict[str, Any]]:
+    async def _upsert_impl(self, payload: dict[str, Any]) -> dict[str, Any] | None:
         return payload
 
     async def _delete_impl(self, identifier: str) -> bool:
@@ -73,7 +73,7 @@ class MockPricingAdapter(BaseAdapter):
             ]
         return []
 
-    async def _upsert_impl(self, payload: dict[str, Any]) -> Optional[dict[str, Any]]:
+    async def _upsert_impl(self, payload: dict[str, Any]) -> dict[str, Any] | None:
         return payload
 
     async def _delete_impl(self, identifier: str) -> bool:
@@ -103,7 +103,7 @@ class MockInventoryAdapter(BaseAdapter):
             ]
         return []
 
-    async def _upsert_impl(self, payload: dict[str, Any]) -> Optional[dict[str, Any]]:
+    async def _upsert_impl(self, payload: dict[str, Any]) -> dict[str, Any] | None:
         return payload
 
     async def _delete_impl(self, identifier: str) -> bool:
@@ -140,7 +140,7 @@ class MockLogisticsAdapter(BaseAdapter):
             ]
         return []
 
-    async def _upsert_impl(self, payload: dict[str, Any]) -> Optional[dict[str, Any]]:
+    async def _upsert_impl(self, payload: dict[str, Any]) -> dict[str, Any] | None:
         return payload
 
     async def _delete_impl(self, identifier: str) -> bool:
@@ -178,7 +178,7 @@ class MockCRMAdapter(BaseAdapter):
             ]
         return []
 
-    async def _upsert_impl(self, payload: dict[str, Any]) -> Optional[dict[str, Any]]:
+    async def _upsert_impl(self, payload: dict[str, Any]) -> dict[str, Any] | None:
         return payload
 
     async def _delete_impl(self, identifier: str) -> bool:
@@ -205,7 +205,7 @@ class MockFunnelAdapter(BaseAdapter):
             ]
         return []
 
-    async def _upsert_impl(self, payload: dict[str, Any]) -> Optional[dict[str, Any]]:
+    async def _upsert_impl(self, payload: dict[str, Any]) -> dict[str, Any] | None:
         return payload
 
     async def _delete_impl(self, identifier: str) -> bool:

--- a/lib/src/holiday_peak_lib/adapters/pricing_adapter.py
+++ b/lib/src/holiday_peak_lib/adapters/pricing_adapter.py
@@ -5,8 +5,6 @@ and revenue optimization scenarios highlighted in the business summary.
 Includes doctests for every helper to validate mapping and aggregation.
 """
 
-from typing import Optional
-
 from holiday_peak_lib.adapters.base import BaseAdapter, BaseConnector
 from holiday_peak_lib.schemas.pricing import PriceContext, PriceEntry
 
@@ -36,7 +34,7 @@ class PricingConnector(BaseConnector):
         ('SKU-1', 10.0)
     """
 
-    def __init__(self, adapter: Optional[BaseAdapter] = None, map_concurrency: int = 10) -> None:
+    def __init__(self, adapter: BaseAdapter | None = None, map_concurrency: int = 10) -> None:
         super().__init__(adapter=adapter, map_concurrency=map_concurrency)
 
     async def get_prices(self, sku: str, limit: int = 10) -> list[PriceEntry]:
@@ -64,7 +62,7 @@ class PricingConnector(BaseConnector):
         records = await self._fetch_many(entity="price", sku=sku, limit=limit)
         return await self._map_many(PriceEntry, records)
 
-    async def get_active_price(self, sku: str) -> Optional[PriceEntry]:
+    async def get_active_price(self, sku: str) -> PriceEntry | None:
         """Return the first active price for the SKU if available.
 
         Doctest::

--- a/lib/src/holiday_peak_lib/adapters/product_adapter.py
+++ b/lib/src/holiday_peak_lib/adapters/product_adapter.py
@@ -6,8 +6,6 @@ helper normalizes adapter payloads into validated domain models with bounded
 async mapping and includes doctests for quick verification.
 """
 
-from typing import Optional
-
 from holiday_peak_lib.adapters.base import BaseAdapter, BaseConnector
 from holiday_peak_lib.schemas.product import CatalogProduct, ProductContext
 
@@ -41,10 +39,10 @@ class ProductConnector(BaseConnector):
         ('SKU-1', 1)
     """
 
-    def __init__(self, adapter: Optional[BaseAdapter] = None, map_concurrency: int = 10) -> None:
+    def __init__(self, adapter: BaseAdapter | None = None, map_concurrency: int = 10) -> None:
         super().__init__(adapter=adapter, map_concurrency=map_concurrency)
 
-    async def get_product(self, sku: str) -> Optional[CatalogProduct]:
+    async def get_product(self, sku: str) -> CatalogProduct | None:
         """Fetch and normalize a single catalog product.
 
         Process:
@@ -96,7 +94,7 @@ class ProductConnector(BaseConnector):
 
     async def build_product_context(
         self, sku: str, related_limit: int = 5
-    ) -> Optional[ProductContext]:
+    ) -> ProductContext | None:
         """Assemble agent-ready product context with related items.
 
         Doctest::

--- a/lib/src/holiday_peak_lib/adapters/truth_store.py
+++ b/lib/src/holiday_peak_lib/adapters/truth_store.py
@@ -14,23 +14,17 @@ Design decisions:
 """
 
 import asyncio
-import logging
-from typing import Any, Optional
+from typing import Any
 
 from azure.cosmos.aio import CosmosClient
 from azure.cosmos.exceptions import CosmosHttpResponseError, CosmosResourceNotFoundError
 from azure.identity import DefaultAzureCredential
 from holiday_peak_lib.adapters.base import AdapterError, BaseAdapter
 from holiday_peak_lib.truth.models import (
-    AssetMetadata,
-    AttributeStatus,
     AuditEvent,
-    AuditEventType,
     CategorySchema,
-    GapReport,
     MappingDocument,
     ProductStyle,
-    ProductVariant,
     ProposedAttribute,
     TenantConfig,
     TruthAttribute,
@@ -80,9 +74,9 @@ class TruthStoreAdapter(BaseAdapter):
         account_uri: str,
         database: str,
         *,
-        containers: Optional[dict[str, str]] = None,
-        connection_limit: Optional[int] = None,
-        client_kwargs: Optional[dict[str, Any]] = None,
+        containers: dict[str, str] | None = None,
+        connection_limit: int | None = None,
+        client_kwargs: dict[str, Any] | None = None,
         **adapter_kwargs: Any,
     ) -> None:
         super().__init__(**adapter_kwargs)
@@ -91,7 +85,7 @@ class TruthStoreAdapter(BaseAdapter):
         self.containers: dict[str, str] = containers or dict(_DEFAULT_CONTAINERS)
         self._connection_limit = connection_limit
         self._client_kwargs: dict[str, Any] = client_kwargs or {}
-        self.client: Optional[CosmosClient] = None
+        self.client: CosmosClient | None = None
 
     # ------------------------------------------------------------------
     # BaseAdapter abstract hooks
@@ -130,7 +124,7 @@ class TruthStoreAdapter(BaseAdapter):
             items.append(item)
         return items
 
-    async def _upsert_impl(self, payload: dict[str, Any]) -> Optional[dict[str, Any]]:
+    async def _upsert_impl(self, payload: dict[str, Any]) -> dict[str, Any] | None:
         container_name = payload.pop("_container", None)
         if not container_name:
             raise AdapterError("_container is required in payload")
@@ -170,7 +164,7 @@ class TruthStoreAdapter(BaseAdapter):
 
     async def _cosmos_call(self, func, *args, **kwargs) -> Any:
         """Execute a Cosmos operation with 429 retry-after handling."""
-        last_exc: Optional[Exception] = None
+        last_exc: Exception | None = None
         for attempt in range(_MAX_COSMOS_RETRIES + 1):
             try:
                 return await func(*args, **kwargs)
@@ -208,7 +202,7 @@ class TruthStoreAdapter(BaseAdapter):
         result = await self._cosmos_call(container.upsert_item, item)
         return ProductStyle.model_validate(result)
 
-    async def get_product(self, entity_id: str, category_id: str) -> Optional[ProductStyle]:
+    async def get_product(self, entity_id: str, category_id: str) -> ProductStyle | None:
         """Retrieve a product style by ID and partition key."""
         await self._ensure_connected()
         container = self._get_container("products")
@@ -279,7 +273,7 @@ class TruthStoreAdapter(BaseAdapter):
     async def get_proposed_attributes(
         self,
         entity_id: str,
-        status: Optional[str] = None,
+        status: str | None = None,
     ) -> list[ProposedAttribute]:
         """Return proposed attributes for an entity, optionally filtered by status."""
         await self._ensure_connected()
@@ -302,7 +296,7 @@ class TruthStoreAdapter(BaseAdapter):
 
     async def update_proposed_status(
         self, attr_id: str, entity_id: str, status: str
-    ) -> Optional[ProposedAttribute]:
+    ) -> ProposedAttribute | None:
         """Approve or reject a proposed attribute by updating its status."""
         await self._ensure_connected()
         container = self._get_container("attributes_proposed")
@@ -317,7 +311,7 @@ class TruthStoreAdapter(BaseAdapter):
     # Schemas
     # ------------------------------------------------------------------
 
-    async def get_schema(self, category_id: str) -> Optional[CategorySchema]:
+    async def get_schema(self, category_id: str) -> CategorySchema | None:
         """Load the category schema definition."""
         await self._ensure_connected()
         container = self._get_container("schemas")
@@ -340,7 +334,7 @@ class TruthStoreAdapter(BaseAdapter):
     # Mappings
     # ------------------------------------------------------------------
 
-    async def get_mapping(self, protocol: str, version: str) -> Optional[MappingDocument]:
+    async def get_mapping(self, protocol: str, version: str) -> MappingDocument | None:
         """Load a canonical-to-protocol field mapping document."""
         await self._ensure_connected()
         container = self._get_container("mappings")
@@ -365,7 +359,7 @@ class TruthStoreAdapter(BaseAdapter):
     async def query_audit(
         self,
         entity_id: str,
-        event_type: Optional[str] = None,
+        event_type: str | None = None,
         limit: int = 50,
     ) -> list[AuditEvent]:
         """Return audit events for an entity, optionally filtered by event_type."""
@@ -410,7 +404,7 @@ class TruthStoreAdapter(BaseAdapter):
         result = await self._cosmos_call(container.upsert_item, item)
         return TenantConfig.model_validate(result)
 
-    async def get_config(self, tenant_id: str) -> Optional[TenantConfig]:
+    async def get_config(self, tenant_id: str) -> TenantConfig | None:
         """Load tenant configuration by tenant ID."""
         await self._ensure_connected()
         container = self._get_container("config")

--- a/lib/src/holiday_peak_lib/agents/memory/builder.py
+++ b/lib/src/holiday_peak_lib/agents/memory/builder.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any
 
 from .cold import ColdMemory
 from .hot import HotMemory
@@ -18,8 +18,8 @@ class MemoryRules:
     read_fallback: bool = True
     promote_on_read: bool = True
     write_through: bool = True
-    hot_ttl_seconds: Optional[int] = 300
-    warm_ttl_seconds: Optional[int] = None
+    hot_ttl_seconds: int | None = 300
+    warm_ttl_seconds: int | None = None
     write_cold: bool = False
 
 
@@ -86,7 +86,7 @@ class MemoryClient:
         return self.rules.promote_on_read and self.warm is not None
 
     @staticmethod
-    def _warm_item(key: str, value: Any, ttl: Optional[int]) -> dict[str, Any]:
+    def _warm_item(key: str, value: Any, ttl: int | None) -> dict[str, Any]:
         payload: dict[str, Any] = {"id": key, "pk": key, "value": value}
         if ttl is not None:
             payload["ttl"] = ttl
@@ -120,8 +120,8 @@ class MemoryBuilder:
         read_fallback: bool | None = None,
         promote_on_read: bool | None = None,
         write_through: bool | None = None,
-        hot_ttl_seconds: Optional[int] = None,
-        warm_ttl_seconds: Optional[int] = None,
+        hot_ttl_seconds: int | None = None,
+        warm_ttl_seconds: int | None = None,
         write_cold: bool | None = None,
     ) -> "MemoryBuilder":
         if read_fallback is not None:

--- a/lib/src/holiday_peak_lib/agents/memory/cold.py
+++ b/lib/src/holiday_peak_lib/agents/memory/cold.py
@@ -1,7 +1,6 @@
 """Cold memory layer using Azure Blob Storage."""
 
 import asyncio
-from typing import Optional
 
 from azure.core.pipeline.transport import AioHttpTransport
 from azure.identity import DefaultAzureCredential
@@ -28,7 +27,7 @@ class ColdMemory:
         self.connection_pool_size = connection_pool_size
         self.connection_timeout = connection_timeout
         self.read_timeout = read_timeout
-        self.client: Optional[BlobServiceClient] = None
+        self.client: BlobServiceClient | None = None
         self._connect_lock = asyncio.Lock()
 
     async def connect(self) -> None:

--- a/lib/src/holiday_peak_lib/agents/memory/hot.py
+++ b/lib/src/holiday_peak_lib/agents/memory/hot.py
@@ -1,7 +1,7 @@
 """Hot memory layer using Redis."""
 
 import asyncio
-from typing import Any, Optional
+from typing import Any
 
 import redis.asyncio as redis
 from holiday_peak_lib.utils.logging import configure_logging, log_async_operation
@@ -28,7 +28,7 @@ class HotMemory:
         self.socket_connect_timeout = socket_connect_timeout
         self.health_check_interval = health_check_interval
         self.retry_on_timeout = retry_on_timeout
-        self.client: Optional[redis.Redis] = None
+        self.client: redis.Redis | None = None
         self._connect_lock = asyncio.Lock()
 
     async def connect(self) -> None:
@@ -72,7 +72,7 @@ class HotMemory:
             metadata={"ttl": ttl_seconds},
         )
 
-    async def get(self, key: str) -> Optional[str]:
+    async def get(self, key: str) -> str | None:
         if not self.client:
             await self.connect()
         return await log_async_operation(

--- a/lib/src/holiday_peak_lib/connectors/common/protocols.py
+++ b/lib/src/holiday_peak_lib/connectors/common/protocols.py
@@ -6,7 +6,6 @@ one of these canonical types so agents can consume data uniformly.
 """
 
 from datetime import datetime
-from typing import Optional
 
 from pydantic import BaseModel, Field
 
@@ -22,17 +21,17 @@ class InventoryData(BaseModel):
 
     item_number: str
     organization_code: str
-    organization_id: Optional[int] = None
-    description: Optional[str] = None
+    organization_id: int | None = None
+    description: str | None = None
     on_hand_quantity: float = 0.0
     reserved_quantity: float = 0.0
-    available_quantity: Optional[float] = None
-    unit_of_measure: Optional[str] = None
-    subinventory_code: Optional[str] = None
-    locator: Optional[str] = None
-    lot_number: Optional[str] = None
-    expiration_date: Optional[datetime] = None
-    last_updated: Optional[datetime] = None
+    available_quantity: float | None = None
+    unit_of_measure: str | None = None
+    subinventory_code: str | None = None
+    locator: str | None = None
+    lot_number: str | None = None
+    expiration_date: datetime | None = None
+    last_updated: datetime | None = None
     attributes: dict = Field(default_factory=dict)
 
     @property
@@ -52,14 +51,14 @@ class ProductData(BaseModel):
 
     product_id: str
     name: str
-    description: Optional[str] = None
-    sku: Optional[str] = None
-    category: Optional[str] = None
-    price: Optional[float] = None
-    currency: Optional[str] = None
+    description: str | None = None
+    sku: str | None = None
+    category: str | None = None
+    price: float | None = None
+    currency: str | None = None
     images: list[str] = Field(default_factory=list)
     attributes: dict = Field(default_factory=dict)
-    last_updated: Optional[datetime] = None
+    last_updated: datetime | None = None
 
 
 class AssetData(BaseModel):
@@ -72,12 +71,12 @@ class AssetData(BaseModel):
     asset_id: str
     name: str
     url: str
-    media_type: Optional[str] = None
-    width: Optional[int] = None
-    height: Optional[int] = None
+    media_type: str | None = None
+    width: int | None = None
+    height: int | None = None
     tags: list[str] = Field(default_factory=list)
     attributes: dict = Field(default_factory=dict)
-    last_updated: Optional[datetime] = None
+    last_updated: datetime | None = None
 
 
 class CustomerData(BaseModel):
@@ -88,13 +87,13 @@ class CustomerData(BaseModel):
     """
 
     customer_id: str
-    email: Optional[str] = None
-    first_name: Optional[str] = None
-    last_name: Optional[str] = None
-    phone: Optional[str] = None
+    email: str | None = None
+    first_name: str | None = None
+    last_name: str | None = None
+    phone: str | None = None
     segments: list[str] = Field(default_factory=list)
     attributes: dict = Field(default_factory=dict)
-    last_updated: Optional[datetime] = None
+    last_updated: datetime | None = None
 
 
 class OrderData(BaseModel):
@@ -106,13 +105,13 @@ class OrderData(BaseModel):
 
     order_id: str
     status: str
-    customer_id: Optional[str] = None
-    total_amount: Optional[float] = None
-    currency: Optional[str] = None
+    customer_id: str | None = None
+    total_amount: float | None = None
+    currency: str | None = None
     line_items: list[dict] = Field(default_factory=list)
     attributes: dict = Field(default_factory=dict)
-    created_at: Optional[datetime] = None
-    last_updated: Optional[datetime] = None
+    created_at: datetime | None = None
+    last_updated: datetime | None = None
 
 
 class SegmentData(BaseModel):
@@ -124,7 +123,7 @@ class SegmentData(BaseModel):
 
     segment_id: str
     name: str
-    description: Optional[str] = None
-    size: Optional[int] = None
+    description: str | None = None
+    size: int | None = None
     attributes: dict = Field(default_factory=dict)
-    last_updated: Optional[datetime] = None
+    last_updated: datetime | None = None

--- a/lib/src/holiday_peak_lib/connectors/crm_loyalty/adobe_aep/auth.py
+++ b/lib/src/holiday_peak_lib/connectors/crm_loyalty/adobe_aep/auth.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import os
 import time
 from dataclasses import dataclass, field
-from typing import Optional
 
 import httpx
 
@@ -54,10 +53,10 @@ class AdobeImsAuth:
     def __init__(
         self,
         *,
-        client_id: Optional[str] = None,
-        client_secret: Optional[str] = None,
-        org_id: Optional[str] = None,
-        ims_url: Optional[str] = None,
+        client_id: str | None = None,
+        client_secret: str | None = None,
+        org_id: str | None = None,
+        ims_url: str | None = None,
     ) -> None:
         self._client_id = client_id or os.environ.get("AEP_CLIENT_ID", "")
         self._client_secret = client_secret or os.environ.get("AEP_CLIENT_SECRET", "")
@@ -65,7 +64,7 @@ class AdobeImsAuth:
         self._ims_url = (ims_url or os.environ.get("AEP_IMS_URL", self._DEFAULT_IMS_URL)).rstrip(
             "/"
         )
-        self._cached: Optional[AdobeImsToken] = None
+        self._cached: AdobeImsToken | None = None
 
     async def get_token(self) -> str:
         """Return a valid Bearer token, refreshing if necessary."""

--- a/lib/src/holiday_peak_lib/connectors/crm_loyalty/adobe_aep/connector.py
+++ b/lib/src/holiday_peak_lib/connectors/crm_loyalty/adobe_aep/connector.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 import os
 from datetime import datetime
-from typing import Any, Iterable, Optional
+from typing import Any, Iterable
 
 import httpx
 from holiday_peak_lib.adapters.base import AdapterError, BaseAdapter
@@ -75,7 +75,7 @@ class _AEPHttpAdapter(BaseAdapter):
             self._raise_for_status(response)
             return [response.json()]
 
-    async def _upsert_impl(self, payload: dict[str, Any]) -> Optional[dict[str, Any]]:
+    async def _upsert_impl(self, payload: dict[str, Any]) -> dict[str, Any] | None:
         """Execute a POST request; ``payload`` must contain ``_path``."""
         path: str = payload.pop("_path")
         headers = await self._build_headers()
@@ -128,11 +128,11 @@ class AdobeAEPConnector(CRMConnectorBase):
     def __init__(
         self,
         *,
-        base_url: Optional[str] = None,
-        org_id: Optional[str] = None,
-        sandbox: Optional[str] = None,
-        inlet_id: Optional[str] = None,
-        auth: Optional[AdobeImsAuth] = None,
+        base_url: str | None = None,
+        org_id: str | None = None,
+        sandbox: str | None = None,
+        inlet_id: str | None = None,
+        auth: AdobeImsAuth | None = None,
     ) -> None:
         self._base_url = (
             base_url or os.environ.get("AEP_BASE_URL", "https://platform.adobe.io")

--- a/lib/src/holiday_peak_lib/connectors/crm_loyalty/braze/connector.py
+++ b/lib/src/holiday_peak_lib/connectors/crm_loyalty/braze/connector.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import os
 from datetime import datetime, timezone
-from typing import Any, Iterable, Optional
+from typing import Any, Iterable
 
 import httpx
 from holiday_peak_lib.adapters.base import AdapterError, BaseAdapter
@@ -65,7 +65,7 @@ class BrazeConnector(BaseAdapter, CRMConnectorBase):
             "/"
         )
         self._transport = transport
-        self._client: Optional[httpx.AsyncClient] = None
+        self._client: httpx.AsyncClient | None = None
 
     # ------------------------------------------------------------------
     # Internal HTTP helpers
@@ -125,7 +125,7 @@ class BrazeConnector(BaseAdapter, CRMConnectorBase):
             return await self._list_segments(query.get("page", 0))
         raise AdapterError(f"Unknown Braze fetch operation: {op!r}")
 
-    async def _upsert_impl(self, payload: dict[str, Any]) -> Optional[dict[str, Any]]:
+    async def _upsert_impl(self, payload: dict[str, Any]) -> dict[str, Any] | None:
         """Dispatch to ``/users/track`` or ``/messages/send`` based on ``payload["_op"]``."""
         op = payload.get("_op")
         if op == "track":

--- a/lib/src/holiday_peak_lib/connectors/crm_loyalty/dynamics365_ce/auth.py
+++ b/lib/src/holiday_peak_lib/connectors/crm_loyalty/dynamics365_ce/auth.py
@@ -8,17 +8,16 @@ they expire to minimise redundant token requests.
 from __future__ import annotations
 
 import time
-from typing import Optional
 
 
 class _TokenCache:
     """Lightweight in-memory token cache."""
 
     def __init__(self) -> None:
-        self._token: Optional[str] = None
+        self._token: str | None = None
         self._expires_at: float = 0.0
 
-    def get(self) -> Optional[str]:
+    def get(self) -> str | None:
         if self._token and time.monotonic() < self._expires_at:
             return self._token
         return None

--- a/lib/src/holiday_peak_lib/connectors/crm_loyalty/dynamics365_ce/connector.py
+++ b/lib/src/holiday_peak_lib/connectors/crm_loyalty/dynamics365_ce/connector.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import os
 from datetime import datetime
-from typing import Any, Iterable, Optional
+from typing import Any, Iterable
 
 import httpx
 from holiday_peak_lib.adapters.base import AdapterError, BaseAdapter
@@ -87,7 +87,7 @@ class Dynamics365CEConnector(BaseAdapter, CRMConnectorBase):
             resource_url=self._base_url,
             credential=credential,
         )
-        self._http_client: Optional[httpx.AsyncClient] = None
+        self._http_client: httpx.AsyncClient | None = None
 
     # ------------------------------------------------------------------
     # BaseAdapter hooks
@@ -105,7 +105,7 @@ class Dynamics365CEConnector(BaseAdapter, CRMConnectorBase):
         response = await self._odata_get(entity, params=params)
         return response.get("value", [response] if response and "value" not in response else [])
 
-    async def _upsert_impl(self, payload: dict[str, Any]) -> Optional[dict[str, Any]]:
+    async def _upsert_impl(self, payload: dict[str, Any]) -> dict[str, Any] | None:
         """PATCH or POST a Dynamics 365 CE entity."""
         entity = payload.pop("_entity", "")
         entity_id = payload.pop("_id", None)

--- a/lib/src/holiday_peak_lib/connectors/crm_loyalty/salesforce/auth.py
+++ b/lib/src/holiday_peak_lib/connectors/crm_loyalty/salesforce/auth.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 import os
 import time
 from dataclasses import dataclass
-from typing import Optional
 
 import httpx
 
@@ -56,12 +55,12 @@ class SalesforceAuth:
     def __init__(
         self,
         *,
-        client_id: Optional[str] = None,
-        client_secret: Optional[str] = None,
-        username: Optional[str] = None,
-        password: Optional[str] = None,
-        login_url: Optional[str] = None,
-        http_client: Optional[httpx.AsyncClient] = None,
+        client_id: str | None = None,
+        client_secret: str | None = None,
+        username: str | None = None,
+        password: str | None = None,
+        login_url: str | None = None,
+        http_client: httpx.AsyncClient | None = None,
     ) -> None:
         self._client_id = client_id or os.environ.get("SALESFORCE_CLIENT_ID", "")
         self._client_secret = client_secret or os.environ.get("SALESFORCE_CLIENT_SECRET", "")
@@ -71,7 +70,7 @@ class SalesforceAuth:
             login_url or os.environ.get("SALESFORCE_LOGIN_URL", self._DEFAULT_LOGIN_URL)
         ).rstrip("/")
         self._http_client = http_client
-        self._token_entry: Optional[_TokenEntry] = None
+        self._token_entry: _TokenEntry | None = None
 
     async def get_token(self) -> _TokenEntry:
         """Return a valid access token, refreshing if necessary."""

--- a/lib/src/holiday_peak_lib/connectors/crm_loyalty/salesforce/connector.py
+++ b/lib/src/holiday_peak_lib/connectors/crm_loyalty/salesforce/connector.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import os
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any
 
 import httpx
 from holiday_peak_lib.adapters.base import AdapterError
@@ -61,9 +61,9 @@ class SalesforceCRMConnector(CRMConnectorBase):
     def __init__(
         self,
         *,
-        auth: Optional[SalesforceAuth] = None,
-        api_version: Optional[str] = None,
-        http_client: Optional[httpx.AsyncClient] = None,
+        auth: SalesforceAuth | None = None,
+        api_version: str | None = None,
+        http_client: httpx.AsyncClient | None = None,
     ) -> None:
         self._auth = auth or SalesforceAuth()
         self._api_version = api_version or os.environ.get(

--- a/lib/src/holiday_peak_lib/connectors/inventory_scm/oracle_scm/auth.py
+++ b/lib/src/holiday_peak_lib/connectors/inventory_scm/oracle_scm/auth.py
@@ -14,7 +14,6 @@ Configuration via environment variables:
 
 import os
 import time
-from typing import Optional
 
 import httpx
 
@@ -45,10 +44,10 @@ class OracleSCMAuth:
 
     def __init__(
         self,
-        token_url: Optional[str] = None,
-        client_id: Optional[str] = None,
-        client_secret: Optional[str] = None,
-        scope: Optional[str] = None,
+        token_url: str | None = None,
+        client_id: str | None = None,
+        client_secret: str | None = None,
+        scope: str | None = None,
         http_timeout: float = 10.0,
     ) -> None:
         self._token_url = token_url or os.environ.get("ORACLE_SCM_TOKEN_URL", "")
@@ -57,7 +56,7 @@ class OracleSCMAuth:
         self._scope = scope or os.environ.get("ORACLE_SCM_SCOPE", "")
         self._http_timeout = http_timeout
 
-        self._token: Optional[str] = None
+        self._token: str | None = None
         self._expires_at: float = 0.0
 
     def _is_token_valid(self) -> bool:

--- a/lib/src/holiday_peak_lib/connectors/inventory_scm/oracle_scm/connector.py
+++ b/lib/src/holiday_peak_lib/connectors/inventory_scm/oracle_scm/connector.py
@@ -20,7 +20,7 @@ Configuration via environment variables:
 
 import os
 from abc import ABC, abstractmethod
-from typing import Any, Optional
+from typing import Any
 
 import httpx
 from holiday_peak_lib.adapters.base import AdapterError, BaseAdapter
@@ -46,14 +46,14 @@ class InventoryConnectorBase(BaseAdapter, ABC):
     async def get_on_hand_quantity(
         self,
         item_number: str,
-        organization_code: Optional[str] = None,
+        organization_code: str | None = None,
     ) -> list[InventoryData]:
         """Return on-hand inventory records for *item_number*."""
 
     @abstractmethod
     async def list_on_hand_quantities(
         self,
-        organization_code: Optional[str] = None,
+        organization_code: str | None = None,
         **filters: Any,
     ) -> list[InventoryData]:
         """Return all on-hand inventory records, optionally filtered."""
@@ -81,10 +81,10 @@ class OracleSCMConnector(InventoryConnectorBase):
 
     def __init__(
         self,
-        base_url: Optional[str] = None,
-        auth: Optional[OracleSCMAuth] = None,
-        api_version: Optional[str] = None,
-        page_size: Optional[int] = None,
+        base_url: str | None = None,
+        auth: OracleSCMAuth | None = None,
+        api_version: str | None = None,
+        page_size: int | None = None,
         http_timeout: float = 30.0,
         **adapter_kwargs: Any,
     ) -> None:
@@ -117,7 +117,7 @@ class OracleSCMConnector(InventoryConnectorBase):
             )
         raise AdapterError(f"Unknown Oracle SCM resource: {resource!r}")
 
-    async def _upsert_impl(self, payload: dict[str, Any]) -> Optional[dict[str, Any]]:
+    async def _upsert_impl(self, payload: dict[str, Any]) -> dict[str, Any] | None:
         """Oracle SCM is read-only via this connector; not implemented."""
         raise NotImplementedError("Oracle SCM connector does not support upsert.")
 
@@ -132,7 +132,7 @@ class OracleSCMConnector(InventoryConnectorBase):
     async def get_on_hand_quantity(
         self,
         item_number: str,
-        organization_code: Optional[str] = None,
+        organization_code: str | None = None,
     ) -> list[InventoryData]:
         """Return on-hand inventory records for a single item.
 
@@ -160,7 +160,7 @@ class OracleSCMConnector(InventoryConnectorBase):
 
     async def list_on_hand_quantities(
         self,
-        organization_code: Optional[str] = None,
+        organization_code: str | None = None,
         **filters: Any,
     ) -> list[InventoryData]:
         """Return all on-hand inventory records, with optional filters.
@@ -216,10 +216,10 @@ class OracleSCMConnector(InventoryConnectorBase):
 
     def _build_filter(
         self,
-        item_number: Optional[str],
-        organization_code: Optional[str],
+        item_number: str | None,
+        organization_code: str | None,
         extra_filters: dict[str, Any],
-    ) -> Optional[str]:
+    ) -> str | None:
         """Construct an Oracle SCIM-style finder/query filter string."""
         parts: list[str] = []
         if item_number:
@@ -232,9 +232,9 @@ class OracleSCMConnector(InventoryConnectorBase):
 
     async def _fetch_on_hand_quantities(
         self,
-        item_number: Optional[str] = None,
-        organization_code: Optional[str] = None,
-        extra_filters: Optional[dict[str, Any]] = None,
+        item_number: str | None = None,
+        organization_code: str | None = None,
+        extra_filters: dict[str, Any] | None = None,
     ) -> list[dict[str, Any]]:
         """Paginate through Oracle onHandQuantities and return raw records."""
         if not self._base_url:

--- a/lib/src/holiday_peak_lib/connectors/inventory_scm/oracle_scm/mappings.py
+++ b/lib/src/holiday_peak_lib/connectors/inventory_scm/oracle_scm/mappings.py
@@ -6,12 +6,12 @@ objects that agents and downstream services can consume uniformly.
 """
 
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any
 
 from holiday_peak_lib.connectors.common.protocols import InventoryData
 
 
-def _parse_datetime(value: Optional[str]) -> Optional[datetime]:
+def _parse_datetime(value: str | None) -> datetime | None:
     """Parse an ISO-8601 string (with or without timezone) into a datetime.
 
     Returns ``None`` when *value* is empty or cannot be parsed.

--- a/lib/src/holiday_peak_lib/connectors/inventory_scm/sap_s4hana/connector.py
+++ b/lib/src/holiday_peak_lib/connectors/inventory_scm/sap_s4hana/connector.py
@@ -15,7 +15,7 @@ GET  /API_WAREHOUSE_LOC_STOCK/A_WarehouseStorageBinStock
 from __future__ import annotations
 
 import os
-from typing import Any, Iterable, Optional
+from typing import Any, Iterable
 
 import httpx
 from holiday_peak_lib.adapters.base import AdapterError, BaseAdapter
@@ -85,7 +85,7 @@ class SAPS4HANAConnector(BaseAdapter, InventoryConnectorBase):
         params: dict[str, Any] = dict(query.get("params") or {})
         return await self._odata_get(endpoint, params=params)
 
-    async def _upsert_impl(self, payload: dict[str, Any]) -> Optional[dict[str, Any]]:
+    async def _upsert_impl(self, payload: dict[str, Any]) -> dict[str, Any] | None:
         """Execute a generic OData POST request.
 
         Keys in *payload*

--- a/lib/src/holiday_peak_lib/connectors/registry.py
+++ b/lib/src/holiday_peak_lib/connectors/registry.py
@@ -10,7 +10,7 @@ import pkgutil
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Mapping, Optional, Type
+from typing import Any, Mapping
 
 from holiday_peak_lib.adapters.base import BaseAdapter
 
@@ -21,7 +21,7 @@ class ConnectorDefinition:
 
     domain: str
     vendor: str
-    connector_class: Type[Any]
+    connector_class: type[Any]
     module: str
     metadata: dict[str, Any] = field(default_factory=dict)
 
@@ -62,7 +62,7 @@ class ConnectorRegistry:
         self,
         domain: str,
         vendor: str,
-        connector_class: Type[Any],
+        connector_class: type[Any],
         *,
         metadata: dict[str, Any] | None = None,
         overwrite: bool = False,
@@ -83,7 +83,7 @@ class ConnectorRegistry:
             metadata=metadata or {},
         )
 
-    def get(self, domain: str, vendor: str) -> Optional[Type[Any]]:
+    def get(self, domain: str, vendor: str) -> type[Any] | None:
         """Return connector class by domain/vendor or ``None`` when unavailable."""
         definition = self.get_definition(domain, vendor)
         return definition.connector_class if definition else None

--- a/lib/src/holiday_peak_lib/schemas/acp.py
+++ b/lib/src/holiday_peak_lib/schemas/acp.py
@@ -1,6 +1,6 @@
 """Agentic Commerce Protocol (ACP) schemas used across services."""
 
-from typing import Any, Optional
+from typing import Any
 
 from pydantic import BaseModel, Field
 
@@ -35,5 +35,5 @@ class AcpProduct(BaseModel):
     target_countries: list[str] = Field(default_factory=lambda: ["US"])
     store_country: str = "US"
     protocol_version: str = "1.0"
-    partner_profile: Optional[AcpPartnerProfile] = None
+    partner_profile: AcpPartnerProfile | None = None
     extended_attributes: dict[str, Any] = Field(default_factory=dict)

--- a/lib/src/holiday_peak_lib/schemas/core.py
+++ b/lib/src/holiday_peak_lib/schemas/core.py
@@ -1,30 +1,28 @@
 """Core schemas."""
 
-from typing import List, Optional
-
 from pydantic import BaseModel, Field
 
 
 class UserContext(BaseModel):
     user_id: str
-    segment: Optional[str] = None
-    preferences: Optional[dict] = None
+    segment: str | None = None
+    preferences: dict | None = None
 
 
 class Product(BaseModel):
     sku: str
     name: str
-    description: Optional[str] = None
-    price: Optional[float] = None
+    description: str | None = None
+    price: float | None = None
     attributes: dict = Field(default_factory=dict)
 
 
 class RecommendationRequest(BaseModel):
     query: str
-    user: Optional[UserContext] = None
+    user: UserContext | None = None
     limit: int = 5
 
 
 class RecommendationResponse(BaseModel):
-    items: List[Product]
+    items: list[Product]
     latency_ms: float

--- a/lib/src/holiday_peak_lib/schemas/crm.py
+++ b/lib/src/holiday_peak_lib/schemas/crm.py
@@ -6,7 +6,7 @@ summary. Doctests illustrate validation and defaults.
 """
 
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any
 
 from pydantic import BaseModel, Field
 
@@ -22,11 +22,11 @@ class CRMAccount(BaseModel):
 
     account_id: str
     name: str
-    region: Optional[str] = None
-    owner: Optional[str] = None
-    industry: Optional[str] = None
-    tier: Optional[str] = None
-    lifecycle_stage: Optional[str] = None
+    region: str | None = None
+    owner: str | None = None
+    industry: str | None = None
+    tier: str | None = None
+    lifecycle_stage: str | None = None
     attributes: dict[str, Any] = Field(default_factory=dict)
 
 
@@ -40,15 +40,15 @@ class CRMContact(BaseModel):
     """
 
     contact_id: str
-    account_id: Optional[str] = None
-    email: Optional[str] = None
-    phone: Optional[str] = None
-    locale: Optional[str] = None
-    timezone: Optional[str] = None
+    account_id: str | None = None
+    email: str | None = None
+    phone: str | None = None
+    locale: str | None = None
+    timezone: str | None = None
     marketing_opt_in: bool = False
-    first_name: Optional[str] = None
-    last_name: Optional[str] = None
-    title: Optional[str] = None
+    first_name: str | None = None
+    last_name: str | None = None
+    title: str | None = None
     tags: list[str] = Field(default_factory=list)
     preferences: dict[str, Any] = Field(default_factory=dict)
     attributes: dict[str, Any] = Field(default_factory=dict)
@@ -66,15 +66,15 @@ class CRMInteraction(BaseModel):
     """
 
     interaction_id: str
-    contact_id: Optional[str] = None
-    account_id: Optional[str] = None
+    contact_id: str | None = None
+    account_id: str | None = None
     channel: str
     occurred_at: datetime
-    duration_seconds: Optional[int] = None
-    outcome: Optional[str] = None
-    subject: Optional[str] = None
-    summary: Optional[str] = None
-    sentiment: Optional[str] = None
+    duration_seconds: int | None = None
+    outcome: str | None = None
+    subject: str | None = None
+    summary: str | None = None
+    sentiment: str | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
 
 
@@ -88,5 +88,5 @@ class CRMContext(BaseModel):
     """
 
     contact: CRMContact
-    account: Optional[CRMAccount] = None
+    account: CRMAccount | None = None
     interactions: list[CRMInteraction] = Field(default_factory=list)

--- a/lib/src/holiday_peak_lib/schemas/funnel.py
+++ b/lib/src/holiday_peak_lib/schemas/funnel.py
@@ -5,7 +5,6 @@ business summary. Doctests show instantiation with defaults.
 """
 
 from datetime import datetime
-from typing import Optional
 
 from pydantic import BaseModel, Field
 
@@ -19,9 +18,9 @@ class FunnelMetric(BaseModel):
 
     stage: str
     count: int
-    conversion_rate: Optional[float] = None
-    channel: Optional[str] = None
-    stage_time_ms: Optional[float] = None
+    conversion_rate: float | None = None
+    channel: str | None = None
+    stage_time_ms: float | None = None
     attributes: dict = Field(default_factory=dict)
 
 
@@ -33,7 +32,7 @@ class FunnelContext(BaseModel):
     'click'
     """
 
-    campaign_id: Optional[str] = None
-    account_id: Optional[str] = None
+    campaign_id: str | None = None
+    account_id: str | None = None
     metrics: list[FunnelMetric] = Field(default_factory=list)
-    updated_at: Optional[datetime] = None
+    updated_at: datetime | None = None

--- a/lib/src/holiday_peak_lib/schemas/inventory.py
+++ b/lib/src/holiday_peak_lib/schemas/inventory.py
@@ -6,7 +6,6 @@ basic construction and defaults.
 """
 
 from datetime import datetime
-from typing import Optional
 
 from pydantic import BaseModel, Field
 
@@ -21,8 +20,8 @@ class WarehouseStock(BaseModel):
     warehouse_id: str
     available: int
     reserved: int = 0
-    location: Optional[str] = None
-    updated_at: Optional[datetime] = None
+    location: str | None = None
+    updated_at: datetime | None = None
 
 
 class InventoryItem(BaseModel):
@@ -37,10 +36,10 @@ class InventoryItem(BaseModel):
     sku: str
     available: int
     reserved: int = 0
-    backorder_date: Optional[datetime] = None
-    safety_stock: Optional[int] = None
-    lead_time_days: Optional[int] = None
-    status: Optional[str] = None
+    backorder_date: datetime | None = None
+    safety_stock: int | None = None
+    lead_time_days: int | None = None
+    status: str | None = None
     attributes: dict = Field(default_factory=dict)
 
 

--- a/lib/src/holiday_peak_lib/schemas/logistics.py
+++ b/lib/src/holiday_peak_lib/schemas/logistics.py
@@ -6,7 +6,6 @@ construction.
 """
 
 from datetime import datetime
-from typing import Optional
 
 from pydantic import BaseModel, Field
 
@@ -20,9 +19,9 @@ class ShipmentEvent(BaseModel):
     """
 
     code: str
-    description: Optional[str] = None
+    description: str | None = None
     occurred_at: datetime
-    location: Optional[str] = None
+    location: str | None = None
     metadata: dict = Field(default_factory=dict)
 
 
@@ -34,15 +33,15 @@ class Shipment(BaseModel):
     """
 
     tracking_id: str
-    order_id: Optional[str] = None
-    carrier: Optional[str] = None
+    order_id: str | None = None
+    carrier: str | None = None
     status: str
-    eta: Optional[datetime] = None
-    last_updated: Optional[datetime] = None
-    origin: Optional[str] = None
-    destination: Optional[str] = None
-    service_level: Optional[str] = None
-    weight_kg: Optional[float] = None
+    eta: datetime | None = None
+    last_updated: datetime | None = None
+    origin: str | None = None
+    destination: str | None = None
+    service_level: str | None = None
+    weight_kg: float | None = None
     attributes: dict = Field(default_factory=dict)
 
 

--- a/lib/src/holiday_peak_lib/schemas/pricing.py
+++ b/lib/src/holiday_peak_lib/schemas/pricing.py
@@ -6,7 +6,7 @@ required fields and defaults.
 """
 
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any
 
 from pydantic import BaseModel, Field
 
@@ -23,14 +23,14 @@ class PriceEntry(BaseModel):
     sku: str
     currency: str
     amount: float
-    list_amount: Optional[float] = None
-    discount_code: Optional[str] = None
-    channel: Optional[str] = None
-    region: Optional[str] = None
+    list_amount: float | None = None
+    discount_code: str | None = None
+    channel: str | None = None
+    region: str | None = None
     tax_included: bool = False
     promotional: bool = False
-    effective_from: Optional[datetime] = None
-    effective_to: Optional[datetime] = None
+    effective_from: datetime | None = None
+    effective_to: datetime | None = None
     attributes: dict[str, Any] = Field(default_factory=dict)
 
 
@@ -43,5 +43,5 @@ class PriceContext(BaseModel):
     """
 
     sku: str
-    active: Optional[PriceEntry] = None
+    active: PriceEntry | None = None
     offers: list[PriceEntry] = Field(default_factory=list)

--- a/lib/src/holiday_peak_lib/schemas/product.py
+++ b/lib/src/holiday_peak_lib/schemas/product.py
@@ -5,7 +5,7 @@ cross-sell flows described in the business summary. Doctests demonstrate how
 payloads are validated and structured.
 """
 
-from typing import Any, Optional
+from typing import Any
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -21,13 +21,13 @@ class CatalogProduct(BaseModel):
 
     sku: str
     name: str
-    description: Optional[str] = None
-    brand: Optional[str] = None
-    category: Optional[str] = None
-    price: Optional[float] = None
-    currency: Optional[str] = None
-    image_url: Optional[str] = None
-    rating: Optional[float] = None
+    description: str | None = None
+    brand: str | None = None
+    category: str | None = None
+    price: float | None = None
+    currency: str | None = None
+    image_url: str | None = None
+    rating: float | None = None
     tags: list[str] = Field(default_factory=list)
     attributes: dict[str, Any] = Field(default_factory=dict)
     variants: list[dict[str, Any]] = Field(default_factory=list)

--- a/lib/src/holiday_peak_lib/schemas/truth.py
+++ b/lib/src/holiday_peak_lib/schemas/truth.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, Literal, Optional
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -179,10 +179,10 @@ class ProductVariant(BaseModel):
 
     id: str
     style_id: str = Field(alias="styleId")
-    upc: Optional[str] = None
-    size: Optional[str] = None
-    width: Optional[str] = None
-    color: Optional[str] = None
+    upc: str | None = None
+    size: str | None = None
+    width: str | None = None
+    color: str | None = None
     asset_ids: list[str] = Field(default_factory=list, alias="assetIds")
     updated_at: datetime = Field(
         default_factory=lambda: datetime.now(timezone.utc),
@@ -215,7 +215,7 @@ class TruthAttribute(BaseModel):
     entity_id: str = Field(alias="entityId")
     attribute_key: str = Field(alias="attributeKey")
     value: Any
-    unit: Optional[str] = None
+    unit: str | None = None
     source: AttributeSource
     share_policy: SharePolicy = Field(SharePolicy.INTERNAL_ONLY, alias="sharePolicy")
     provenance: Provenance = Field(default_factory=Provenance)
@@ -244,7 +244,7 @@ class ProposedAttribute(BaseModel):
     entity_id: str = Field(alias="entityId")
     attribute_key: str = Field(alias="attributeKey")
     value: Any
-    unit: Optional[str] = None
+    unit: str | None = None
     source: AttributeSource
     share_policy: SharePolicy = Field(SharePolicy.INTERNAL_ONLY, alias="sharePolicy")
     provenance: Provenance = Field(default_factory=Provenance)
@@ -255,11 +255,11 @@ class ProposedAttribute(BaseModel):
     model_run_id: str = Field(alias="modelRunId")
     evidence_refs: list[str] = Field(default_factory=list, alias="evidenceRefs")
     validation_errors: list[str] = Field(default_factory=list, alias="validationErrors")
-    source_type: Optional[SourceType] = Field(None, alias="sourceType")
+    source_type: SourceType | None = Field(None, alias="sourceType")
     source_assets: list[str] = Field(default_factory=list, alias="sourceAssets")
     original_data: dict[str, Any] = Field(default_factory=dict, alias="originalData")
     enriched_data: dict[str, Any] = Field(default_factory=dict, alias="enrichedData")
-    reasoning: Optional[str] = None
+    reasoning: str | None = None
 
 
 class ProductEnrichmentProposal(ProposedAttribute):
@@ -278,20 +278,20 @@ class IntentClassification(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     query_type: Literal["simple", "complex"] | None = Field(None, alias="queryType")
-    category: Optional[str] = None
+    category: str | None = None
     attributes: list[str] = Field(default_factory=list)
-    use_case: Optional[str] = Field(None, alias="useCase")
-    brand: Optional[str] = None
+    use_case: str | None = Field(None, alias="useCase")
+    brand: str | None = None
     price_range: tuple[float | None, float | None] = Field(
         default=(None, None),
         alias="priceRange",
     )
     filters: dict[str, Any] = Field(default_factory=dict)
     sub_queries: list[str] = Field(default_factory=list, alias="subQueries")
-    intent: Optional[str] = None
+    intent: str | None = None
     confidence: float = Field(..., ge=0.0, le=1.0)
     entities: dict[str, Any] = Field(default_factory=dict)
-    reasoning: Optional[str] = None
+    reasoning: str | None = None
 
 
 class SearchEnrichedProduct(BaseModel):
@@ -300,13 +300,13 @@ class SearchEnrichedProduct(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     sku: str
-    id: Optional[str] = None
-    entity_id: Optional[str] = Field(None, alias="entityId")
-    name: Optional[str] = None
-    brand: Optional[str] = None
-    category: Optional[str] = None
-    description: Optional[str] = None
-    price: Optional[float] = None
+    id: str | None = None
+    entity_id: str | None = Field(None, alias="entityId")
+    name: str | None = None
+    brand: str | None = None
+    category: str | None = None
+    description: str | None = None
+    price: float | None = None
     use_cases: list[str] = Field(default_factory=list, alias="useCases")
     complementary_products: list[str] = Field(
         default_factory=list,
@@ -314,23 +314,23 @@ class SearchEnrichedProduct(BaseModel):
     )
     substitute_products: list[str] = Field(default_factory=list, alias="substituteProducts")
     search_keywords: list[str] = Field(default_factory=list, alias="searchKeywords")
-    enriched_description: Optional[str] = Field(None, alias="enrichedDescription")
+    enriched_description: str | None = Field(None, alias="enrichedDescription")
     enriched_at: datetime = Field(
         default_factory=lambda: datetime.now(timezone.utc),
         alias="enrichedAt",
     )
-    enrichment_model: Optional[str] = Field(None, alias="enrichmentModel")
-    source_approval_version: Optional[int] = Field(None, alias="sourceApprovalVersion")
-    score: Optional[float] = Field(None, ge=0.0, le=1.0)
-    source_type: Optional[SourceType] = Field(None, alias="sourceType")
+    enrichment_model: str | None = Field(None, alias="enrichmentModel")
+    source_approval_version: int | None = Field(None, alias="sourceApprovalVersion")
+    score: float | None = Field(None, ge=0.0, le=1.0)
+    source_type: SourceType | None = Field(None, alias="sourceType")
     source_assets: list[str] = Field(default_factory=list, alias="sourceAssets")
     original_data: dict[str, Any] = Field(default_factory=dict, alias="originalData")
     enriched_data: dict[str, Any] = Field(default_factory=dict, alias="enrichedData")
-    intent_classification: Optional[IntentClassification] = Field(
+    intent_classification: IntentClassification | None = Field(
         None,
         alias="intentClassification",
     )
-    reasoning: Optional[str] = None
+    reasoning: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -403,8 +403,8 @@ class AssetMetadata(BaseModel):
     product_id: str = Field(alias="productId")
     url: str
     asset_type: str = Field(alias="assetType")
-    mime_type: Optional[str] = Field(None, alias="mimeType")
-    alt_text: Optional[str] = Field(None, alias="altText")
+    mime_type: str | None = Field(None, alias="mimeType")
+    alt_text: str | None = Field(None, alias="altText")
     updated_at: datetime = Field(
         default_factory=lambda: datetime.now(timezone.utc),
         alias="updatedAt",
@@ -460,9 +460,9 @@ class ExportJob(BaseModel):
     job_id: str = Field(alias="jobId")
     entity_id: str = Field(alias="entityId")
     protocol: str
-    partner_id: Optional[str] = Field(None, alias="partnerId")
-    requested_by: Optional[str] = Field(None, alias="requestedBy")
-    requested_at: Optional[datetime] = Field(None, alias="requestedAt")
+    partner_id: str | None = Field(None, alias="partnerId")
+    requested_by: str | None = Field(None, alias="requestedBy")
+    requested_at: datetime | None = Field(None, alias="requestedAt")
     options: dict[str, Any] = Field(default_factory=dict)
 
 

--- a/lib/src/holiday_peak_lib/truth/evidence.py
+++ b/lib/src/holiday_peak_lib/truth/evidence.py
@@ -14,7 +14,7 @@ extraction runs for a given tenant (off by default).
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Any, Optional
+from typing import Any
 
 from pydantic import BaseModel, Field
 
@@ -120,7 +120,7 @@ class EvidenceConfig(BaseModel):
             "output parsing.  Disabled by default."
         ),
     )
-    auto_approve_threshold: Optional[float] = Field(
+    auto_approve_threshold: float | None = Field(
         default=None,
         ge=0.0,
         le=1.0,

--- a/lib/src/holiday_peak_lib/truth/models.py
+++ b/lib/src/holiday_peak_lib/truth/models.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, Optional
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -67,8 +67,8 @@ class ProductStyle(BaseModel):
     style_id: str = Field(default_factory=_new_id)
     category_id: str = Field(..., alias="categoryId")
     name: str
-    brand: Optional[str] = None
-    description: Optional[str] = None
+    brand: str | None = None
+    description: str | None = None
     tags: list[str] = Field(default_factory=list)
     source_system: str
     source_id: str
@@ -96,9 +96,9 @@ class ProductVariant(BaseModel):
     style_id: str
     category_id: str = Field(..., alias="categoryId")
     sku: str
-    size: Optional[str] = None
-    color: Optional[str] = None
-    price: Optional[float] = None
+    size: str | None = None
+    color: str | None = None
+    price: float | None = None
     currency: str = "USD"
     inventory_count: int = 0
     source_system: str
@@ -131,8 +131,8 @@ class TruthAttribute(BaseModel):
     source_system: str
     source_id: str
     status: AttributeStatus = AttributeStatus.APPROVED
-    approved_by: Optional[str] = None
-    approved_at: Optional[datetime] = None
+    approved_by: str | None = None
+    approved_at: datetime | None = None
     created_at: datetime = Field(default_factory=_utcnow)
     updated_at: datetime = Field(default_factory=_utcnow)
 
@@ -158,9 +158,9 @@ class ProposedAttribute(BaseModel):
     source_system: str
     source_id: str
     status: AttributeStatus = AttributeStatus.PENDING
-    reviewer: Optional[str] = None
-    review_note: Optional[str] = None
-    reviewed_at: Optional[datetime] = None
+    reviewer: str | None = None
+    review_note: str | None = None
+    reviewed_at: datetime | None = None
     created_at: datetime = Field(default_factory=_utcnow)
     updated_at: datetime = Field(default_factory=_utcnow)
     evidence_ids: list[str] = Field(default_factory=list)
@@ -202,9 +202,9 @@ class AuditEvent(BaseModel):
     entity_id: str = Field(..., alias="entityId")
     event_type: AuditEventType
     actor: str
-    attribute_name: Optional[str] = None
-    old_value: Optional[Any] = None
-    new_value: Optional[Any] = None
+    attribute_name: str | None = None
+    old_value: Any | None = None
+    new_value: Any | None = None
     source_system: str
     source_id: str
     occurred_at: datetime = Field(default_factory=_utcnow)
@@ -228,10 +228,10 @@ class AssetMetadata(BaseModel):
     product_id: str = Field(..., alias="productId")
     asset_type: str
     url: str
-    alt_text: Optional[str] = None
-    width: Optional[int] = None
-    height: Optional[int] = None
-    file_size_bytes: Optional[int] = None
+    alt_text: str | None = None
+    width: int | None = None
+    height: int | None = None
+    file_size_bytes: int | None = None
     source_system: str
     source_id: str
     created_at: datetime = Field(default_factory=_utcnow)

--- a/lib/src/holiday_peak_lib/truth/schemas.py
+++ b/lib/src/holiday_peak_lib/truth/schemas.py
@@ -6,7 +6,7 @@ ships pre-built schemas for common retail categories.
 
 from __future__ import annotations
 
-from typing import Any, Literal, Optional
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -24,9 +24,9 @@ class UcpAttribute(BaseModel):
     label: str
     data_type: Literal["string", "number", "boolean", "list", "object"] = "string"
     required: bool = False
-    max_length: Optional[int] = None
+    max_length: int | None = None
     allowed_values: list[Any] = Field(default_factory=list)
-    description: Optional[str] = None
+    description: str | None = None
 
 
 class UcpSchema(BaseModel):

--- a/lib/src/holiday_peak_lib/truth/store.py
+++ b/lib/src/holiday_peak_lib/truth/store.py
@@ -12,7 +12,7 @@ Key design decisions:
 
 from __future__ import annotations
 
-from typing import Any, Iterable, Optional
+from typing import Any, Iterable
 
 from holiday_peak_lib.adapters.base import BaseAdapter
 
@@ -105,7 +105,7 @@ class TruthStoreAdapter(BaseAdapter):
             items.append(item)
         return items
 
-    async def _upsert_impl(self, payload: dict[str, Any]) -> Optional[dict[str, Any]]:
+    async def _upsert_impl(self, payload: dict[str, Any]) -> dict[str, Any] | None:
         """Idempotent upsert of a document into the target container."""
         self._assert_connected()
         return await self._container_proxy.upsert_item(body=payload)
@@ -126,13 +126,13 @@ class TruthStoreAdapter(BaseAdapter):
     # Convenience helpers
     # ------------------------------------------------------------------
 
-    async def get_by_id(self, item_id: str, partition_key: str) -> Optional[dict[str, Any]]:
+    async def get_by_id(self, item_id: str, partition_key: str) -> dict[str, Any] | None:
         """Return a single document by id and partition key, or ``None``."""
         results = await self.fetch({"id": item_id, "partition_key": partition_key})
         items = list(results)
         return items[0] if items else None
 
-    async def upsert_document(self, document: dict[str, Any]) -> Optional[dict[str, Any]]:
+    async def upsert_document(self, document: dict[str, Any]) -> dict[str, Any] | None:
         """Convenience wrapper around :meth:`upsert`."""
         return await self.upsert(document)
 

--- a/lib/src/holiday_peak_lib/utils/bulkhead.py
+++ b/lib/src/holiday_peak_lib/utils/bulkhead.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +39,7 @@ class Bulkhead:
         self,
         name: str,
         concurrency_limit: int = 10,
-        queue_timeout: Optional[float] = 0.0,
+        queue_timeout: float | None = 0.0,
     ) -> None:
         if concurrency_limit < 1:
             raise ValueError("concurrency_limit must be >= 1")

--- a/lib/src/holiday_peak_lib/utils/circuit_breaker.py
+++ b/lib/src/holiday_peak_lib/utils/circuit_breaker.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 import time
 from enum import Enum
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 logger = logging.getLogger(__name__)
 
@@ -55,7 +55,7 @@ class CircuitBreaker:
 
         self._state = CircuitState.CLOSED
         self._failure_count = 0
-        self._last_failure_time: Optional[float] = None
+        self._last_failure_time: float | None = None
         self._half_open_calls = 0
         self._lock = asyncio.Lock()
 
@@ -91,7 +91,7 @@ class CircuitBreaker:
         self,
         func: Callable[..., Any],
         *args: Any,
-        fallback: Optional[Callable[[], Any]] = None,
+        fallback: Callable[[], Any] | None = None,
         **kwargs: Any,
     ) -> Any:
         """Execute *func* through the circuit breaker.

--- a/lib/src/holiday_peak_lib/utils/logging.py
+++ b/lib/src/holiday_peak_lib/utils/logging.py
@@ -7,7 +7,7 @@ import tracemalloc
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from time import perf_counter
-from typing import Any, Awaitable, Callable, Optional
+from typing import Any, Awaitable, Callable
 
 from holiday_peak_lib.utils.correlation import get_correlation_id
 
@@ -47,7 +47,7 @@ def _token_estimate(payload: Any) -> int:
 
 
 def configure_logging(
-    connection_string: Optional[str] = None, app_name: Optional[str] = None
+    connection_string: str | None = None, app_name: str | None = None
 ) -> logging.Logger:
     resolved_app = app_name or DEFAULT_APP_NAME
     base_logger = logging.getLogger(f"holiday-peak-lib.{resolved_app}")
@@ -87,10 +87,10 @@ def configure_logging(
 async def log_async_operation(
     logger: logging.Logger,
     name: str,
-    intent: Optional[str],
+    intent: str | None,
     func: Callable[[], Awaitable[Any]],
-    token_count: Optional[int] = None,
-    metadata: Optional[dict] = None,
+    token_count: int | None = None,
+    metadata: dict | None = None,
 ) -> Any:
     _ensure_tracemalloc()
     start_mem, _ = tracemalloc.get_traced_memory()
@@ -137,9 +137,9 @@ async def log_async_operation(
 def log_operation(
     logger: logging.Logger,
     name: str,
-    intent: Optional[str],
-    token_count: Optional[int] = None,
-    metadata: Optional[dict] = None,
+    intent: str | None,
+    token_count: int | None = None,
+    metadata: dict | None = None,
 ):
     _ensure_tracemalloc()
     start_mem, _ = tracemalloc.get_traced_memory()

--- a/lib/src/holiday_peak_lib/utils/rate_limiter.py
+++ b/lib/src/holiday_peak_lib/utils/rate_limiter.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import time
 from collections import defaultdict, deque
-from typing import Optional
 
 
 class RateLimitExceededError(Exception):
@@ -80,7 +79,7 @@ class RateLimiter:
             count = sum(1 for ts in window if ts >= cutoff)
             return max(0, self.limit - count)
 
-    def reset(self, tenant_id: Optional[str] = None) -> None:
+    def reset(self, tenant_id: str | None = None) -> None:
         """Reset rate-limit counters.
 
         Args:


### PR DESCRIPTION
## Summary\n- Applies Python 3.11 typing modernization (UP006,UP007) and typing-import cleanup in lib/src/holiday_peak_lib.\n- Normalizes formatting/import order to satisfy repository hooks.\n- Scope intentionally limited to type-annotation modernization (no feature behavior changes).\n\n## Validation\n- python -m ruff check lib/src/holiday_peak_lib --target-version py311 --select UP006,UP007,F401\n- python -m pytest lib/tests/test_router.py lib/tests/test_memory.py lib/tests/test_adapters.py -q (61 passed)\n\n## Notes\n- Split from mixed workspace state to produce a merge-safe PR mapped to #421.