### PR TITLE
[UI] Route loading/error boundaries + login redirect fix (#418 #454)

### DIFF
--- a/apps/ui/app/_shared/route-boundary.tsx
+++ b/apps/ui/app/_shared/route-boundary.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+import { useEffect } from 'react'
+
+import Image from 'next/image'
+import Link from 'next/link'
+
+import Layout from '@/layouts/centered'
+import { trackBoundaryError } from '@/lib/utils/telemetry'
+
+type RouteErrorBoundaryProps = {
+  scope: string
+  error: Error & { digest?: string }
+  reset: () => void
+}
+
+export function RouteErrorBoundary({
+  scope,
+  error,
+  reset,
+}: RouteErrorBoundaryProps) {
+  useEffect(() => {
+    trackBoundaryError(scope, error)
+  }, [scope, error])
+
+  return (
+    <Layout>
+      <div className="flex flex-col w-full max-w-xl text-center">
+        <Image
+          className="object-contain w-auto mb-8"
+          height={64}
+          width={64}
+          src="/images/illustration.svg"
+          alt="Error illustration"
+        />
+        <h3 className="text-blue-500 mb-4">Oops!</h3>
+        {error.digest && (
+          <h1 className="text-6xl text-blue-500 mb-4">{error.digest}</h1>
+        )}
+
+        <div className="mb-8 text-center text-gray-900 dark:text-white">
+          Something went wrong while loading this page. Please try again.
+        </div>
+
+        <div className="grid w-full gap-3 sm:grid-cols-2">
+          <button
+            type="button"
+            onClick={reset}
+            className="w-full px-6 py-3 text-base font-bold text-white uppercase bg-blue-500 rounded-lg hover:bg-blue-600"
+          >
+            Try Again
+          </button>
+          <Link
+            href="/"
+            className="w-full px-6 py-3 text-base font-bold text-white uppercase bg-blue-500 rounded-lg hover:bg-blue-600"
+          >
+            Back Home
+          </Link>
+        </div>
+      </div>
+    </Layout>
+  )
+}
+
+type RouteLoadingProps = {
+  section: string
+}
+
+export function RouteLoading({ section }: RouteLoadingProps) {
+  return (
+    <div className="mx-auto w-full max-w-5xl space-y-6 p-6" aria-busy="true" aria-live="polite">
+      <div className="space-y-3">
+        <div className="h-4 w-40 animate-pulse rounded bg-gray-200 dark:bg-gray-700" />
+        <div className="h-8 w-80 animate-pulse rounded bg-gray-200 dark:bg-gray-700" />
+      </div>
+
+      <div className="rounded-2xl border border-gray-200 p-6 dark:border-gray-800">
+        <p className="mb-4 text-sm text-gray-600 dark:text-gray-400">Loading {section}...</p>
+        <div className="space-y-3">
+          <div className="h-4 w-full animate-pulse rounded bg-gray-200 dark:bg-gray-700" />
+          <div className="h-4 w-4/5 animate-pulse rounded bg-gray-200 dark:bg-gray-700" />
+          <div className="h-4 w-3/5 animate-pulse rounded bg-gray-200 dark:bg-gray-700" />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/ui/app/admin/error.tsx
+++ b/apps/ui/app/admin/error.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import { RouteErrorBoundary } from '../_shared/route-boundary'
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  return <RouteErrorBoundary scope="admin" error={error} reset={reset} />
+}

--- a/apps/ui/app/admin/loading.tsx
+++ b/apps/ui/app/admin/loading.tsx
@@ -1,0 +1,5 @@
+import { RouteLoading } from '../_shared/route-boundary'
+
+export default function Loading() {
+  return <RouteLoading section="admin tools" />
+}

--- a/apps/ui/app/auth/login/page.tsx
+++ b/apps/ui/app/auth/login/page.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import Link from 'next/link';
-import { useSearchParams } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { MainLayout } from '@/components/templates/MainLayout';
 import { Button } from '@/components/atoms/Button';
 import { Card } from '@/components/molecules/Card';
@@ -10,7 +10,20 @@ import { FiShoppingBag } from 'react-icons/fi';
 import { useAuth } from '@/contexts/AuthContext';
 import { isDevAuthMockUiEnabled } from '@/lib/auth/msalConfig';
 
+function resolvePostLoginPath(rawRedirectPath: string | null): string {
+  if (!rawRedirectPath) {
+    return '/';
+  }
+
+  if (!rawRedirectPath.startsWith('/') || rawRedirectPath.startsWith('//')) {
+    return '/';
+  }
+
+  return rawRedirectPath;
+}
+
 export default function LoginPage() {
+  const router = useRouter();
   const { login, loginAsMockRole, isAuthenticated, isLoading, authConfigError } = useAuth();
   const searchParams = useSearchParams();
   const [loginError, setLoginError] = React.useState<string | null>(null);
@@ -19,6 +32,10 @@ export default function LoginPage() {
     'customer' | 'staff' | 'admin' | null
   >(null);
   const redirectPath = searchParams.get('redirect');
+  const postLoginPath = React.useMemo(
+    () => resolvePostLoginPath(redirectPath),
+    [redirectPath]
+  );
   const hasRouteProtectionRedirect = Boolean(
     redirectPath && redirectPath.startsWith('/')
   );
@@ -44,7 +61,7 @@ export default function LoginPage() {
       setIsMockLoading(true);
       setSelectedMockRole(role);
       await loginAsMockRole(role);
-      window.location.href = '/';
+      router.replace(postLoginPath);
     } catch {
       setLoginError("Couldn't proceed with your login. Please try again later.");
     } finally {
@@ -59,17 +76,25 @@ export default function LoginPage() {
     }
   }, [authConfigError]);
 
-  // If already authenticated, redirect
-  if (isAuthenticated && !isLoading) {
-    if (typeof window !== 'undefined') {
-      window.location.href = '/';
+  React.useEffect(() => {
+    if (isAuthenticated && !isLoading) {
+      router.replace(postLoginPath);
     }
-    return null;
-  }
+  }, [isAuthenticated, isLoading, postLoginPath, router]);
 
   return (
     <MainLayout>
       <div className="max-w-md mx-auto py-12">
+        {isAuthenticated && !isLoading && (
+          <div
+            role="status"
+            aria-live="polite"
+            className="mb-4 rounded-md border border-cyan-200 bg-cyan-50 px-3 py-2 text-sm text-cyan-800 dark:border-cyan-800 dark:bg-cyan-950 dark:text-cyan-200"
+          >
+            Finishing sign-in and redirecting…
+          </div>
+        )}
+
         {/* Header */}
         <div className="text-center mb-8">
           <div className="inline-flex items-center justify-center w-16 h-16 bg-ocean-100 dark:bg-ocean-900 rounded-full mb-4">

--- a/apps/ui/app/checkout/error.tsx
+++ b/apps/ui/app/checkout/error.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import { RouteErrorBoundary } from '../_shared/route-boundary'
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  return <RouteErrorBoundary scope="checkout" error={error} reset={reset} />
+}

--- a/apps/ui/app/checkout/loading.tsx
+++ b/apps/ui/app/checkout/loading.tsx
@@ -1,0 +1,5 @@
+import { RouteLoading } from '../_shared/route-boundary'
+
+export default function Loading() {
+  return <RouteLoading section="checkout" />
+}

--- a/apps/ui/app/error.tsx
+++ b/apps/ui/app/error.tsx
@@ -1,48 +1,13 @@
-'use client' // Error boundaries must be Client Components
- 
-import { useEffect } from 'react'
+'use client'
 
-import Link from "next/link";
-import Image from "next/image";
+import { RouteErrorBoundary } from './_shared/route-boundary'
 
-import Layout from "@/layouts/centered";
- 
 export default function Error({
   error,
-  reset: _reset,
+  reset,
 }: {
   error: Error & { digest?: string }
   reset: () => void
 }) {
-  useEffect(() => {
-    console.error(error)
-  }, [error])
- 
-  return (
-    <Layout>
-      <div className="flex flex-col w-full max-w-xl text-center">
-        <Image
-          className="object-contain w-auto mb-8"
-          height={64}
-          width={64}
-          src="/images/illustration.svg"
-          alt="Error illustration"
-        />
-        <h3 className="text-blue-500 mb-4">Oops!</h3>
-        {error.digest && (
-          <h1 className="text-6xl text-blue-500 mb-4">{error.digest}</h1>
-        )}
-
-        <div className="mb-8 text-center text-gray-900 dark:text-white">
-          Something went wrong while processing your request. Please try again later.
-          If the issue persists, contact support.
-        </div>
-        <div className="flex w-full">
-          <Link href="/" className="w-full px-6 py-3 text-base font-bold text-white uppercase bg-blue-500 rounded-lg hover:bg-blue-600">
-            Back Home
-          </Link>
-        </div>
-      </div>
-    </Layout>
-  )
+  return <RouteErrorBoundary scope="root" error={error} reset={reset} />
 }

--- a/apps/ui/app/loading.tsx
+++ b/apps/ui/app/loading.tsx
@@ -1,0 +1,5 @@
+import { RouteLoading } from './_shared/route-boundary'
+
+export default function Loading() {
+  return <RouteLoading section="Holiday Peak Hub" />
+}

--- a/apps/ui/app/shop/loading.tsx
+++ b/apps/ui/app/shop/loading.tsx
@@ -1,0 +1,5 @@
+import { RouteLoading } from '../_shared/route-boundary'
+
+export default function Loading() {
+  return <RouteLoading section="shop" />
+}

--- a/apps/ui/app/staff/error.tsx
+++ b/apps/ui/app/staff/error.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import { RouteErrorBoundary } from '../_shared/route-boundary'
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  return <RouteErrorBoundary scope="staff" error={error} reset={reset} />
+}

--- a/apps/ui/app/staff/loading.tsx
+++ b/apps/ui/app/staff/loading.tsx
@@ -1,0 +1,5 @@
+import { RouteLoading } from '../_shared/route-boundary'
+
+export default function Loading() {
+  return <RouteLoading section="staff workspace" />
+}

--- a/apps/ui/lib/utils/telemetry.ts
+++ b/apps/ui/lib/utils/telemetry.ts
@@ -10,6 +10,11 @@ type EventPayload = {
 
 type BrowserAppInsights = {
   trackTrace?: (trace: TracePayload) => void;
+  trackException?: (payload: {
+    exception: Error;
+    severityLevel?: number;
+    properties?: Record<string, string>;
+  }) => void;
   trackEvent?: (
     event: EventPayload,
     customProperties?: Record<string, string>,
@@ -159,4 +164,42 @@ export function trackWarning(message: string, properties?: Record<string, string
   }
 
   console.warn(message, properties || {});
+}
+
+export function trackBoundaryError(scope: string, error: Error & { digest?: string }) {
+  const appInsights = getBrowserAppInsights();
+  const properties: Record<string, string> = {
+    scope,
+  };
+
+  if (error.digest) {
+    properties.digest = error.digest;
+  }
+
+  if (appInsights?.trackException) {
+    appInsights.trackException({
+      exception: error,
+      severityLevel: 3,
+      properties,
+    });
+    return;
+  }
+
+  if (appInsights?.trackTrace) {
+    appInsights.trackTrace({
+      message: `route_error:${scope}`,
+      severityLevel: 3,
+      properties: {
+        ...properties,
+        message: error.message,
+      },
+    });
+    return;
+  }
+
+  console.error('route_error', {
+    scope,
+    digest: error.digest,
+    message: error.message,
+  });
 }

--- a/apps/ui/proxy.ts
+++ b/apps/ui/proxy.ts
@@ -58,7 +58,8 @@ export async function proxy(request: NextRequest): Promise<NextResponse> {
   // Not authenticated — redirect to login
   if (roles.length === 0) {
     const loginUrl = new URL(LOGIN_PATH, request.url);
-    loginUrl.searchParams.set('redirect', pathname);
+    const redirectTarget = `${pathname}${request.nextUrl.search}`;
+    loginUrl.searchParams.set('redirect', redirectTarget);
     return NextResponse.redirect(loginUrl);
   }
 

--- a/apps/ui/tests/unit/loginRedirect.test.tsx
+++ b/apps/ui/tests/unit/loginRedirect.test.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+
+import LoginPage from '../../app/auth/login/page';
+
+const replaceMock = jest.fn();
+const useSearchParamsMock = jest.fn(() => ({ get: () => null }));
+const useAuthMock = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    replace: replaceMock,
+    push: jest.fn(),
+  }),
+  useSearchParams: () => useSearchParamsMock(),
+}));
+
+jest.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => useAuthMock(),
+}));
+
+jest.mock('../../lib/auth/msalConfig', () => ({
+  isDevAuthMockUiEnabled: false,
+}));
+
+jest.mock('@/components/templates/MainLayout', () => ({
+  MainLayout: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="main-layout">{children}</div>
+  ),
+}));
+
+jest.mock('@/components/atoms/Button', () => ({
+  Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+jest.mock('@/components/molecules/Card', () => ({
+  Card: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+describe('login post-auth redirect behavior', () => {
+  beforeEach(() => {
+    replaceMock.mockClear();
+    useSearchParamsMock.mockReturnValue({
+      get: () => null,
+    });
+
+    useAuthMock.mockReturnValue({
+      login: jest.fn(),
+      loginAsMockRole: jest.fn(),
+      isAuthenticated: false,
+      isLoading: false,
+      authConfigError: null,
+    });
+  });
+
+  it('redirects authenticated users to redirect target and keeps non-blank transition state', async () => {
+    useSearchParamsMock.mockReturnValue({
+      get: (key: string) => (key === 'redirect' ? '/admin' : null),
+    });
+    useAuthMock.mockReturnValue({
+      login: jest.fn(),
+      loginAsMockRole: jest.fn(),
+      isAuthenticated: true,
+      isLoading: false,
+      authConfigError: null,
+    });
+
+    render(<LoginPage />);
+
+    await waitFor(() => {
+      expect(replaceMock).toHaveBeenCalledWith('/admin');
+    });
+    expect(screen.getByText('Finishing sign-in and redirecting…')).toBeInTheDocument();
+  });
+
+  it('falls back to root when redirect target is unsafe', async () => {
+    useSearchParamsMock.mockReturnValue({
+      get: (key: string) => (key === 'redirect' ? 'https://evil.example' : null),
+    });
+    useAuthMock.mockReturnValue({
+      login: jest.fn(),
+      loginAsMockRole: jest.fn(),
+      isAuthenticated: true,
+      isLoading: false,
+      authConfigError: null,
+    });
+
+    render(<LoginPage />);
+
+    await waitFor(() => {
+      expect(replaceMock).toHaveBeenCalledWith('/');
+    });
+  });
+});

--- a/apps/ui/tests/unit/middleware.test.ts
+++ b/apps/ui/tests/unit/middleware.test.ts
@@ -73,6 +73,14 @@ describe('middleware – protected routes', () => {
     expect(redirectUrl.searchParams.get('redirect')).toBe('/dashboard');
   });
 
+  it('redirects unauthenticated user from /admin to login with full redirect target', async () => {
+    await proxy(makeRequest('/admin?tab=schemas'));
+    expect(mockRedirect).toHaveBeenCalledTimes(1);
+    const redirectUrl: URL = mockRedirect.mock.calls[0][0];
+    expect(redirectUrl.pathname).toBe('/auth/login');
+    expect(redirectUrl.searchParams.get('redirect')).toBe('/admin?tab=schemas');
+  });
+
   it('rejects unsigned cookie values and redirects to login', async () => {
     await proxy(makeRequest('/orders', { 'msal-auth': 'customer' }));
     expect(mockRedirect).toHaveBeenCalledTimes(1);

--- a/apps/ui/tests/unit/routeBoundaries.test.tsx
+++ b/apps/ui/tests/unit/routeBoundaries.test.tsx
@@ -1,0 +1,70 @@
+import React from 'react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+import RootErrorBoundary from '../../app/error'
+import RootLoadingBoundary from '../../app/loading'
+import AdminErrorBoundary from '../../app/admin/error'
+import AdminLoadingBoundary from '../../app/admin/loading'
+import StaffErrorBoundary from '../../app/staff/error'
+import StaffLoadingBoundary from '../../app/staff/loading'
+import ShopLoadingBoundary from '../../app/shop/loading'
+import CheckoutErrorBoundary from '../../app/checkout/error'
+import CheckoutLoadingBoundary from '../../app/checkout/loading'
+
+const trackBoundaryError = jest.fn()
+
+jest.mock('@/lib/utils/telemetry', () => ({
+  trackBoundaryError: (...args: unknown[]) => trackBoundaryError(...args),
+}))
+
+describe('route boundaries', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders loading boundaries for root and critical segments', () => {
+    render(
+      <div>
+        <RootLoadingBoundary />
+        <AdminLoadingBoundary />
+        <StaffLoadingBoundary />
+        <ShopLoadingBoundary />
+        <CheckoutLoadingBoundary />
+      </div>,
+    )
+
+    expect(screen.getByText('Loading Holiday Peak Hub...')).toBeInTheDocument()
+    expect(screen.getByText('Loading admin tools...')).toBeInTheDocument()
+    expect(screen.getByText('Loading staff workspace...')).toBeInTheDocument()
+    expect(screen.getByText('Loading shop...')).toBeInTheDocument()
+    expect(screen.getByText('Loading checkout...')).toBeInTheDocument()
+  })
+
+  it('tracks errors with route scope and supports reset action', async () => {
+    const reset = jest.fn()
+    const adminError = Object.assign(new Error('admin failed'), { digest: 'ad-1' })
+    const staffError = Object.assign(new Error('staff failed'), { digest: 'st-1' })
+    const checkoutError = Object.assign(new Error('checkout failed'), { digest: 'co-1' })
+    const rootError = Object.assign(new Error('root failed'), { digest: 'rt-1' })
+
+    render(
+      <div>
+        <AdminErrorBoundary error={adminError} reset={reset} />
+        <StaffErrorBoundary error={staffError} reset={reset} />
+        <CheckoutErrorBoundary error={checkoutError} reset={reset} />
+        <RootErrorBoundary error={rootError} reset={reset} />
+      </div>,
+    )
+
+    await waitFor(() => {
+      expect(trackBoundaryError).toHaveBeenCalledWith('admin', adminError)
+      expect(trackBoundaryError).toHaveBeenCalledWith('staff', staffError)
+      expect(trackBoundaryError).toHaveBeenCalledWith('checkout', checkoutError)
+      expect(trackBoundaryError).toHaveBeenCalledWith('root', rootError)
+    })
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Try Again' })[0])
+    expect(reset).toHaveBeenCalledTimes(1)
+    expect(screen.getAllByRole('link', { name: 'Back Home' })).toHaveLength(4)
+  })
+})

--- a/apps/ui/tests/unit/telemetryBoundary.test.ts
+++ b/apps/ui/tests/unit/telemetryBoundary.test.ts
@@ -1,0 +1,74 @@
+import { trackBoundaryError } from '../../lib/utils/telemetry'
+
+type AppInsightsMock = {
+  trackException?: jest.Mock
+  trackTrace?: jest.Mock
+}
+
+const setAppInsights = (value?: AppInsightsMock) => {
+  if (value) {
+    ;(window as unknown as { appInsights?: AppInsightsMock }).appInsights = value
+    return
+  }
+
+  delete (window as unknown as { appInsights?: AppInsightsMock }).appInsights
+}
+
+describe('trackBoundaryError', () => {
+  const originalConsoleError = console.error
+
+  beforeEach(() => {
+    setAppInsights(undefined)
+    console.error = jest.fn()
+  })
+
+  afterAll(() => {
+    console.error = originalConsoleError
+  })
+
+  it('uses trackException when available', () => {
+    const trackException = jest.fn()
+    setAppInsights({ trackException })
+
+    const error = Object.assign(new Error('failed to render'), { digest: 'abc123' })
+    trackBoundaryError('checkout', error)
+
+    expect(trackException).toHaveBeenCalledWith({
+      exception: error,
+      severityLevel: 3,
+      properties: {
+        scope: 'checkout',
+        digest: 'abc123',
+      },
+    })
+  })
+
+  it('falls back to trace when exception tracking is unavailable', () => {
+    const trackTrace = jest.fn()
+    setAppInsights({ trackTrace })
+
+    const error = Object.assign(new Error('admin unavailable'), { digest: 'def456' })
+    trackBoundaryError('admin', error)
+
+    expect(trackTrace).toHaveBeenCalledWith({
+      message: 'route_error:admin',
+      severityLevel: 3,
+      properties: {
+        scope: 'admin',
+        digest: 'def456',
+        message: 'admin unavailable',
+      },
+    })
+  })
+
+  it('falls back to console.error when app insights is unavailable', () => {
+    const error = Object.assign(new Error('root crash'), { digest: 'ghi789' })
+    trackBoundaryError('root', error)
+
+    expect(console.error).toHaveBeenCalledWith('route_error', {
+      scope: 'root',
+      digest: 'ghi789',
+      message: 'root crash',
+    })
+  })
+})


### PR DESCRIPTION
## Summary\n- Adds route-level loading/error boundaries for root, admin, staff, checkout, and shop routes.\n- Refactors shared boundary UI into pp/_shared/route-boundary.tsx and wires telemetry via 	rackBoundaryError.\n- Fixes post-login redirect handling so ?redirect= target is preserved/sanitized and used after successful auth.\n\n## Validation\n- CI=1 yarn --cwd apps/ui test tests/unit/loginRedirect.test.tsx tests/unit/middleware.test.ts tests/unit/routeBoundaries.test.tsx tests/unit/telemetryBoundary.test.ts --runInBand --verbose (19 passed)\n\n## Scope\n- Merge-safe subset from mixed workspace state.\n- Excludes broader UI SSR refactors and coverage expansion work tracked in open issues (#417, #419).