### PR TITLE
feat: enforce MCP + retail event contracts (#406, #425)

### DIFF
--- a/apps/crud-service/src/crud_service/integrations/event_publisher.py
+++ b/apps/crud-service/src/crud_service/integrations/event_publisher.py
@@ -8,6 +8,8 @@ from azure.eventhub import EventData
 from azure.eventhub.aio import EventHubProducerClient
 from azure.identity.aio import DefaultAzureCredential
 from crud_service.config import get_settings
+from holiday_peak_lib.events import RETAIL_EVENT_TOPICS, build_retail_event_payload
+from pydantic import ValidationError
 
 logger = logging.getLogger(__name__)
 settings = get_settings()
@@ -78,11 +80,27 @@ class EventPublisher:
             logger.error(f"Unknown topic: {topic}")
             return
 
-        event_payload = {
-            "event_type": event_type,
-            "data": data,
-            "timestamp": data.get("timestamp"),
-        }
+        try:
+            if topic in RETAIL_EVENT_TOPICS:
+                event_payload = build_retail_event_payload(
+                    topic=topic,
+                    event_type=event_type,
+                    data=data,
+                )
+            else:
+                event_payload = {
+                    "event_type": event_type,
+                    "data": data,
+                    "timestamp": data.get("timestamp"),
+                }
+        except (ValidationError, ValueError) as exc:
+            logger.error(
+                "Invalid event payload for topic=%s event_type=%s: %s",
+                topic,
+                event_type,
+                exc,
+            )
+            raise ValueError(f"Invalid payload for {topic}:{event_type}") from exc
 
         event_data = EventData(json.dumps(event_payload))
         producer = self._producers[topic]

--- a/apps/crud-service/tests/unit/test_event_publisher_schemas.py
+++ b/apps/crud-service/tests/unit/test_event_publisher_schemas.py
@@ -1,0 +1,69 @@
+"""Unit tests for EventPublisher schema validation."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from crud_service.integrations.event_publisher import EventPublisher
+
+
+class _FakeProducer:
+    def __init__(self) -> None:
+        self.sent: list[list[dict[str, object]]] = []
+
+    async def close(self) -> None:
+        return None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def send_batch(self, events):
+        payloads: list[dict[str, object]] = []
+        for event in events:
+            payloads.append(json.loads(event.body_as_str()))
+        self.sent.append(payloads)
+
+
+@pytest.mark.asyncio
+async def test_publish_order_created_validates_and_normalizes_payload() -> None:
+    publisher = EventPublisher()
+    producer = _FakeProducer()
+    publisher._producers = {"order-events": producer}
+
+    await publisher.publish(
+        "order-events",
+        "OrderCreated",
+        {
+            "id": "order-1",
+            "user_id": "user-1",
+            "items": [{"product_id": "sku-1", "quantity": 1, "price": 5.0}],
+            "total": 5.0,
+            "status": "pending",
+            "created_at": "2026-03-21T00:00:00Z",
+        },
+    )
+
+    assert len(producer.sent) == 1
+    payload = producer.sent[0][0]
+    assert payload["event_type"] == "OrderCreated"
+    assert payload["data"]["order_id"] == "order-1"
+
+
+@pytest.mark.asyncio
+async def test_publish_rejects_mismatched_topic_event_type() -> None:
+    publisher = EventPublisher()
+    publisher._producers = {"order-events": _FakeProducer()}
+
+    with pytest.raises(ValueError, match="Invalid payload"):
+        await publisher.publish(
+            "order-events",
+            "PaymentProcessed",
+            {
+                "order_id": "order-1",
+                "user_id": "user-1",
+            },
+        )

--- a/apps/ecommerce-order-status/src/ecommerce_order_status/event_handlers.py
+++ b/apps/ecommerce-order-status/src/ecommerce_order_status/event_handlers.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import json
 
+from holiday_peak_lib.events import parse_retail_event
 from holiday_peak_lib.utils.event_hub import EventHandler
 from holiday_peak_lib.utils.logging import configure_logging
+from pydantic import ValidationError
 
 from .adapters import build_order_status_adapters
 
@@ -15,25 +17,46 @@ def build_event_handlers() -> dict[str, EventHandler]:
     logger = configure_logging(app_name="ecommerce-order-status-events")
     adapters = build_order_status_adapters()
 
-    async def handle_order_event(partition_context, event) -> None:  # noqa: ANN001
-        payload = json.loads(event.body_as_str())
-        data = payload.get("data", {}) if isinstance(payload, dict) else {}
-        order_id = data.get("order_id") or data.get("id")
-        tracking_id = data.get("tracking_id") or data.get("shipment_id")
+    async def handle_order_event(_partition_context, event) -> None:  # noqa: ANN001
+        try:
+            payload = json.loads(event.body_as_str())
+        except json.JSONDecodeError:
+            logger.warning(
+                "order_status_event_invalid_json",
+                extra={"event_type": None},
+            )
+            return
+        try:
+            order_event = parse_retail_event(payload, topic="order-events")
+        except (ValidationError, ValueError) as exc:
+            logger.warning(
+                "order_status_event_invalid",
+                extra={"error_type": type(exc).__name__},
+            )
+            return
+
+        order_data = order_event.data
+        order_id = order_data.order_id
+        tracking_id = order_data.tracking_id or order_data.shipment_id
         if not tracking_id and order_id:
             tracking_id = await adapters.resolver.resolve_tracking_id(str(order_id))
         if not tracking_id:
-            logger.info("order_status_event_skipped", event_type=payload.get("event_type"))
+            logger.info(
+                "order_status_event_skipped",
+                extra={"event_type": order_event.event_type},
+            )
             return
 
         context = await adapters.logistics.build_logistics_context(str(tracking_id))
         logger.info(
             "order_status_event_processed",
-            event_type=payload.get("event_type"),
-            order_id=order_id,
-            tracking_id=tracking_id,
-            status=context.shipment.status if context else None,
-            event_count=len(context.events) if context else 0,
+            extra={
+                "event_type": order_event.event_type,
+                "order_id": order_id,
+                "tracking_id": tracking_id,
+                "status": context.shipment.status if context else None,
+                "event_count": len(context.events) if context else 0,
+            },
         )
 
     return {"order-events": handle_order_event}

--- a/apps/ecommerce-order-status/tests/test_event_handlers.py
+++ b/apps/ecommerce-order-status/tests/test_event_handlers.py
@@ -1,5 +1,10 @@
 """Unit tests for order status event handlers."""
 
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 from ecommerce_order_status.event_handlers import build_event_handlers
 
 
@@ -7,3 +12,88 @@ def test_build_event_handlers_includes_order_events() -> None:
     handlers = build_event_handlers()
     assert "order-events" in handlers
     assert callable(handlers["order-events"])
+
+
+@pytest.mark.asyncio
+async def test_order_event_handler_validates_and_processes_event(monkeypatch) -> None:
+    context = SimpleNamespace(
+        shipment=SimpleNamespace(status="in_transit"),
+        events=[{"kind": "scan"}],
+    )
+    logistics = SimpleNamespace(build_logistics_context=AsyncMock(return_value=context))
+    resolver = SimpleNamespace(resolve_tracking_id=AsyncMock(return_value="T-order-1"))
+    adapters = SimpleNamespace(logistics=logistics, resolver=resolver)
+
+    monkeypatch.setattr(
+        "ecommerce_order_status.event_handlers.build_order_status_adapters",
+        lambda: adapters,
+    )
+
+    handlers = build_event_handlers()
+    event = MagicMock()
+    event.body_as_str.return_value = json.dumps(
+        {
+            "event_type": "OrderCreated",
+            "data": {
+                "id": "order-1",
+                "user_id": "user-1",
+                "items": [],
+                "total": 10.0,
+                "status": "pending",
+            },
+        }
+    )
+
+    await handlers["order-events"](MagicMock(), event)
+
+    resolver.resolve_tracking_id.assert_awaited_once_with("order-1")
+    logistics.build_logistics_context.assert_awaited_once_with("T-order-1")
+
+
+@pytest.mark.asyncio
+async def test_order_event_handler_skips_invalid_payload(monkeypatch) -> None:
+    logistics = SimpleNamespace(build_logistics_context=AsyncMock())
+    resolver = SimpleNamespace(resolve_tracking_id=AsyncMock())
+    adapters = SimpleNamespace(logistics=logistics, resolver=resolver)
+
+    monkeypatch.setattr(
+        "ecommerce_order_status.event_handlers.build_order_status_adapters",
+        lambda: adapters,
+    )
+
+    handlers = build_event_handlers()
+    event = MagicMock()
+    event.body_as_str.return_value = json.dumps(
+        {
+            "event_type": "OrderCreated",
+            "data": {
+                "user_id": "user-1",
+            },
+        }
+    )
+
+    await handlers["order-events"](MagicMock(), event)
+
+    resolver.resolve_tracking_id.assert_not_called()
+    logistics.build_logistics_context.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_order_event_handler_skips_malformed_json(monkeypatch) -> None:
+    logistics = SimpleNamespace(build_logistics_context=AsyncMock())
+    resolver = SimpleNamespace(resolve_tracking_id=AsyncMock())
+    adapters = SimpleNamespace(logistics=logistics, resolver=resolver)
+
+    monkeypatch.setattr(
+        "ecommerce_order_status.event_handlers.build_order_status_adapters",
+        lambda: adapters,
+    )
+
+    handlers = build_event_handlers()
+    event = MagicMock()
+    event.body_as_str.return_value = "{invalid"
+
+    await handlers["order-events"](MagicMock(), event)
+
+    resolver.resolve_tracking_id.assert_not_called()
+    logistics.build_logistics_context.assert_not_called()

--- a/docs/architecture/components/libs/agents.md
+++ b/docs/architecture/components/libs/agents.md
@@ -206,7 +206,17 @@ mcp.add_tool("/inventory/check", check_inventory)
 
 ### MCP Schema Discovery
 
-MCP schema discovery is not implemented by default. Apps should publish their tool list explicitly if needed.
+`FastAPIMCPServer` now supports per-tool schema metadata registration at add time:
+
+- Optional `input_model` / `output_model` validation (Pydantic)
+- Optional versioned schema references (`name`, `version`, optional `uri`)
+- Metadata captured in `FastAPIMCPServer.tool_metadata`
+
+Backward compatibility:
+
+- Existing `mcp.add_tool("/path", handler)` usage remains valid.
+- Tools without schema models continue to accept/return dict payloads unchanged.
+- Teams can incrementally add schema refs and validation without breaking existing MCP paths.
 
 ### Model Selection
 

--- a/lib/src/holiday_peak_lib/events/__init__.py
+++ b/lib/src/holiday_peak_lib/events/__init__.py
@@ -10,6 +10,22 @@ from holiday_peak_lib.events.connector_events import (
     ProductChanged,
     parse_connector_event,
 )
+from holiday_peak_lib.events.retail_events import (
+    RETAIL_EVENT_TOPICS,
+    InventoryEventData,
+    InventoryEventEnvelope,
+    OrderEventData,
+    OrderEventEnvelope,
+    PaymentEventData,
+    PaymentEventEnvelope,
+    RetailEvent,
+    ReturnEventData,
+    ReturnEventEnvelope,
+    ShipmentEventData,
+    ShipmentEventEnvelope,
+    build_retail_event_payload,
+    parse_retail_event,
+)
 
 __all__ = [
     "ConnectorEvent",
@@ -20,4 +36,18 @@ __all__ = [
     "OrderStatusChanged",
     "PriceUpdated",
     "parse_connector_event",
+    "OrderEventData",
+    "PaymentEventData",
+    "ReturnEventData",
+    "InventoryEventData",
+    "ShipmentEventData",
+    "OrderEventEnvelope",
+    "PaymentEventEnvelope",
+    "ReturnEventEnvelope",
+    "InventoryEventEnvelope",
+    "ShipmentEventEnvelope",
+    "RetailEvent",
+    "RETAIL_EVENT_TOPICS",
+    "parse_retail_event",
+    "build_retail_event_payload",
 ]

--- a/lib/src/holiday_peak_lib/events/retail_events.py
+++ b/lib/src/holiday_peak_lib/events/retail_events.py
@@ -1,0 +1,292 @@
+"""Canonical retail event schemas for cross-service Event Hub contracts."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, model_validator
+
+OrderEventType = Literal["OrderCreated", "OrderUpdated", "OrderCancelled"]
+PaymentEventType = Literal["PaymentProcessed", "PaymentFailed", "RefundIssued"]
+ReturnEventType = Literal[
+    "ReturnRequested",
+    "ReturnApproved",
+    "ReturnRejected",
+    "ReturnReceived",
+    "ReturnRestocked",
+    "ReturnRefunded",
+]
+InventoryEventType = Literal["InventoryReserved", "InventoryReleased", "InventoryUpdated"]
+ShipmentEventType = Literal["ShipmentCreated", "ShipmentUpdated"]
+
+RETAIL_EVENT_TOPICS: tuple[str, ...] = (
+    "order-events",
+    "payment-events",
+    "return-events",
+    "inventory-events",
+    "shipment-events",
+)
+
+
+class _RetailEventData(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+
+class OrderEventData(_RetailEventData):
+    """Order event payload with compatibility aliases."""
+
+    order_id: str | None = None
+    user_id: str | None = None
+    status: str | None = None
+    total: float | None = None
+    items: list[dict[str, Any]] = Field(default_factory=list)
+    created_at: str | None = None
+    updated_at: str | None = None
+    tracking_id: str | None = None
+    shipment_id: str | None = None
+    timestamp: str | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_order_id(cls, value: Any) -> Any:
+        if isinstance(value, dict) and not value.get("order_id") and value.get("id"):
+            value = dict(value)
+            value["order_id"] = value["id"]
+        return value
+
+    @model_validator(mode="after")
+    def _require_order_id(self) -> "OrderEventData":
+        if not self.order_id:
+            raise ValueError("Order event payload requires order_id (or id)")
+        return self
+
+
+class PaymentEventData(_RetailEventData):
+    """Payment/refund event payload."""
+
+    payment_id: str | None = None
+    order_id: str | None = None
+    user_id: str | None = None
+    amount: float | None = None
+    status: str | None = None
+    transaction_id: str | None = None
+    created_at: str | None = None
+    occurred_at: str | None = None
+    timestamp: str | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_payment_id(cls, value: Any) -> Any:
+        if isinstance(value, dict) and not value.get("payment_id") and value.get("id"):
+            value = dict(value)
+            value["payment_id"] = value["id"]
+        return value
+
+    @model_validator(mode="after")
+    def _require_order_id(self) -> "PaymentEventData":
+        if not self.order_id:
+            raise ValueError("Payment event payload requires order_id")
+        return self
+
+
+class ReturnEventData(_RetailEventData):
+    """Return lifecycle event payload."""
+
+    return_id: str | None = None
+    order_id: str | None = None
+    user_id: str | None = None
+    status: str | None = None
+    occurred_at: str | None = None
+    actor_id: str | None = None
+    actor_roles: list[str] = Field(default_factory=list)
+    sla: dict[str, Any] = Field(default_factory=dict)
+    timestamp: str | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_return_id(cls, value: Any) -> Any:
+        if isinstance(value, dict) and not value.get("return_id") and value.get("id"):
+            value = dict(value)
+            value["return_id"] = value["id"]
+        return value
+
+    @model_validator(mode="after")
+    def _require_ids(self) -> "ReturnEventData":
+        if not self.return_id:
+            raise ValueError("Return event payload requires return_id (or id)")
+        if not self.order_id:
+            raise ValueError("Return event payload requires order_id")
+        return self
+
+
+class InventoryEventData(_RetailEventData):
+    """Inventory lifecycle event payload."""
+
+    sku: str | None = None
+    quantity: int | None = None
+    user_id: str | None = None
+    order_id: str | None = None
+    reservation_id: str | None = None
+    location_id: str | None = None
+    timestamp: str | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_sku(cls, value: Any) -> Any:
+        if isinstance(value, dict) and not value.get("sku") and value.get("product_id"):
+            value = dict(value)
+            value["sku"] = value["product_id"]
+        return value
+
+    @model_validator(mode="after")
+    def _require_sku(self) -> "InventoryEventData":
+        if not self.sku:
+            raise ValueError("Inventory event payload requires sku (or product_id)")
+        return self
+
+
+class ShipmentEventData(_RetailEventData):
+    """Shipment lifecycle event payload."""
+
+    shipment_id: str | None = None
+    tracking_id: str | None = None
+    order_id: str | None = None
+    user_id: str | None = None
+    status: str | None = None
+    carrier: str | None = None
+    eta: str | None = None
+    timestamp: str | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_shipment_id(cls, value: Any) -> Any:
+        if isinstance(value, dict):
+            copy = dict(value)
+            if not copy.get("shipment_id") and copy.get("tracking_id"):
+                copy["shipment_id"] = copy["tracking_id"]
+            if not copy.get("tracking_id") and copy.get("shipment_id"):
+                copy["tracking_id"] = copy["shipment_id"]
+            if not copy.get("shipment_id") and copy.get("id"):
+                copy["shipment_id"] = copy["id"]
+                copy.setdefault("tracking_id", copy["id"])
+            return copy
+        return value
+
+    @model_validator(mode="after")
+    def _require_shipment_identifier(self) -> "ShipmentEventData":
+        if not self.shipment_id and not self.tracking_id:
+            raise ValueError("Shipment event payload requires shipment_id/tracking_id (or id)")
+        return self
+
+
+class _RetailEventEnvelope(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    timestamp: str | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _default_timestamp(cls, value: Any) -> Any:
+        if not isinstance(value, dict):
+            return value
+
+        data = value.get("data") if isinstance(value.get("data"), dict) else {}
+        timestamp = value.get("timestamp")
+        if not timestamp:
+            timestamp = (
+                data.get("timestamp")
+                or data.get("occurred_at")
+                or data.get("created_at")
+                or datetime.now(UTC).isoformat()
+            )
+
+        normalized = dict(value)
+        normalized["timestamp"] = str(timestamp)
+        return normalized
+
+
+class OrderEventEnvelope(_RetailEventEnvelope):
+    """Order event envelope."""
+
+    event_type: OrderEventType
+    data: OrderEventData
+
+
+class PaymentEventEnvelope(_RetailEventEnvelope):
+    """Payment event envelope."""
+
+    event_type: PaymentEventType
+    data: PaymentEventData
+
+
+class ReturnEventEnvelope(_RetailEventEnvelope):
+    """Return event envelope."""
+
+    event_type: ReturnEventType
+    data: ReturnEventData
+
+
+class InventoryEventEnvelope(_RetailEventEnvelope):
+    """Inventory event envelope."""
+
+    event_type: InventoryEventType
+    data: InventoryEventData
+
+
+class ShipmentEventEnvelope(_RetailEventEnvelope):
+    """Shipment event envelope."""
+
+    event_type: ShipmentEventType
+    data: ShipmentEventData
+
+
+RetailEvent = (
+    OrderEventEnvelope
+    | PaymentEventEnvelope
+    | ReturnEventEnvelope
+    | InventoryEventEnvelope
+    | ShipmentEventEnvelope
+)
+
+_RETAIL_TOPIC_ADAPTERS: dict[str, TypeAdapter[Any]] = {
+    "order-events": TypeAdapter(OrderEventEnvelope),
+    "payment-events": TypeAdapter(PaymentEventEnvelope),
+    "return-events": TypeAdapter(ReturnEventEnvelope),
+    "inventory-events": TypeAdapter(InventoryEventEnvelope),
+    "shipment-events": TypeAdapter(ShipmentEventEnvelope),
+}
+_RETAIL_EVENT_ADAPTER = TypeAdapter(RetailEvent)
+
+
+def parse_retail_event(
+    payload: dict[str, Any],
+    *,
+    topic: str | None = None,
+) -> RetailEvent:
+    """Parse a retail event envelope into a canonical typed model."""
+
+    if topic is not None:
+        adapter = _RETAIL_TOPIC_ADAPTERS.get(topic)
+        if adapter is None:
+            raise ValueError(f"Unsupported retail event topic: {topic}")
+        return adapter.validate_python(payload)
+
+    return _RETAIL_EVENT_ADAPTER.validate_python(payload)
+
+
+def build_retail_event_payload(
+    *,
+    topic: str,
+    event_type: str,
+    data: dict[str, Any],
+) -> dict[str, Any]:
+    """Build and validate a canonical event payload for Event Hub publication."""
+
+    payload = {
+        "event_type": event_type,
+        "data": data,
+        "timestamp": data.get("timestamp") if isinstance(data, dict) else None,
+    }
+    parsed = parse_retail_event(payload, topic=topic)
+    return parsed.model_dump(mode="json")

--- a/lib/src/holiday_peak_lib/mcp/__init__.py
+++ b/lib/src/holiday_peak_lib/mcp/__init__.py
@@ -5,11 +5,12 @@ from holiday_peak_lib.mcp.ai_search_indexing import (
     build_ai_search_indexing_client_from_env,
     register_ai_search_indexing_tools,
 )
-from holiday_peak_lib.mcp.server import FastAPIMCPServer
+from holiday_peak_lib.mcp.server import FastAPIMCPServer, MCPToolSchemaRef
 
 __all__ = [
     "AISearchIndexingClient",
     "build_ai_search_indexing_client_from_env",
     "register_ai_search_indexing_tools",
     "FastAPIMCPServer",
+    "MCPToolSchemaRef",
 ]

--- a/lib/src/holiday_peak_lib/mcp/server.py
+++ b/lib/src/holiday_peak_lib/mcp/server.py
@@ -1,6 +1,30 @@
 """Thin wrapper to expose MCP endpoints over FastAPI."""
 
-from fastapi import APIRouter, FastAPI
+from __future__ import annotations
+
+from dataclasses import dataclass
+from inspect import isawaitable
+from typing import Any, Awaitable, Callable
+
+from fastapi import APIRouter, FastAPI, HTTPException
+from pydantic import BaseModel, ValidationError
+
+ToolHandler = Callable[[dict[str, Any]], Awaitable[dict[str, Any]] | dict[str, Any]]
+
+
+@dataclass(frozen=True, slots=True)
+class MCPToolSchemaRef:
+    """Versioned schema reference for MCP tool contracts."""
+
+    name: str
+    version: str
+    uri: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {"name": self.name, "version": self.version}
+        if self.uri:
+            payload["uri"] = self.uri
+        return payload
 
 
 class FastAPIMCPServer:
@@ -9,9 +33,105 @@ class FastAPIMCPServer:
     def __init__(self, app: FastAPI) -> None:
         self.app = app
         self.router = APIRouter()
+        self._tool_metadata: dict[str, dict[str, Any]] = {}
 
-    def add_tool(self, path: str, handler) -> None:
-        self.router.post(path)(handler)
+    @property
+    def tool_metadata(self) -> dict[str, dict[str, Any]]:
+        """Return metadata registered for each MCP tool path."""
+        return dict(self._tool_metadata)
+
+    def add_tool(
+        self,
+        path: str,
+        handler: ToolHandler,
+        *,
+        input_model: type[BaseModel] | None = None,
+        output_model: type[BaseModel] | None = None,
+        input_schema_ref: MCPToolSchemaRef | None = None,
+        output_schema_ref: MCPToolSchemaRef | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        normalized_path = self._normalize_path(path)
+        validated_handler = self._wrap_handler(handler, input_model, output_model)
+        self.router.post(normalized_path)(validated_handler)
+        self._tool_metadata[normalized_path] = {
+            "input_schema_ref": self._resolve_schema_ref(input_schema_ref, input_model),
+            "output_schema_ref": self._resolve_schema_ref(output_schema_ref, output_model),
+            "metadata": dict(metadata or {}),
+        }
 
     def mount(self) -> None:
         self.app.include_router(self.router, prefix="/mcp")
+
+    def _normalize_path(self, path: str) -> str:
+        if not path.startswith("/"):
+            return f"/{path}"
+        return path
+
+    def _resolve_schema_ref(
+        self,
+        schema_ref: MCPToolSchemaRef | None,
+        model: type[BaseModel] | None,
+    ) -> dict[str, Any] | None:
+        if schema_ref is not None:
+            return schema_ref.to_dict()
+        if model is None:
+            return None
+        return MCPToolSchemaRef(name=model.__name__, version="v1").to_dict()
+
+    def _wrap_handler(
+        self,
+        handler: ToolHandler,
+        input_model: type[BaseModel] | None,
+        output_model: type[BaseModel] | None,
+    ) -> Callable[[dict[str, Any]], Awaitable[dict[str, Any]]]:
+        async def validated_handler(payload: dict[str, Any]) -> dict[str, Any]:
+            normalized_payload = payload
+            if input_model is not None:
+                try:
+                    validated_input = input_model.model_validate(payload)
+                except ValidationError as exc:
+                    raise HTTPException(
+                        status_code=422,
+                        detail={
+                            "error": "invalid_tool_input",
+                            "issues": exc.errors(),
+                        },
+                    ) from exc
+                normalized_payload = validated_input.model_dump(mode="json")
+
+            result = handler(normalized_payload)
+            if isawaitable(result):
+                result = await result
+
+            if output_model is not None:
+                try:
+                    validated_output = output_model.model_validate(result)
+                except ValidationError as exc:
+                    raise HTTPException(
+                        status_code=500,
+                        detail={
+                            "error": "invalid_tool_output",
+                            "issues": exc.errors(),
+                        },
+                    ) from exc
+                return validated_output.model_dump(mode="json")
+
+            if isinstance(result, BaseModel):
+                return result.model_dump(mode="json")
+            if not isinstance(result, dict):
+                raise HTTPException(
+                    status_code=500,
+                    detail={
+                        "error": "invalid_tool_output",
+                        "issues": [
+                            {
+                                "message": "Tool handlers must return a dict payload",
+                                "type": "type_error.dict",
+                            }
+                        ],
+                    },
+                )
+            return result
+
+        return validated_handler

--- a/lib/tests/test_mcp_server.py
+++ b/lib/tests/test_mcp_server.py
@@ -1,0 +1,108 @@
+"""Tests for FastAPIMCPServer schema validation and metadata registration."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from holiday_peak_lib.mcp.server import FastAPIMCPServer, MCPToolSchemaRef
+from pydantic import BaseModel
+
+
+class EchoInput(BaseModel):
+    value: str
+
+
+class EchoOutput(BaseModel):
+    echoed: str
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_valid_input_output_and_metadata() -> None:
+    app = FastAPI()
+    mcp = FastAPIMCPServer(app)
+
+    async def echo_tool(payload: dict[str, object]) -> dict[str, object]:
+        return {"echoed": payload["value"]}
+
+    mcp.add_tool(
+        "/echo",
+        echo_tool,
+        input_model=EchoInput,
+        output_model=EchoOutput,
+        input_schema_ref=MCPToolSchemaRef(name="EchoInput", version="v1"),
+        output_schema_ref=MCPToolSchemaRef(name="EchoOutput", version="v1"),
+        metadata={"owner": "test-suite"},
+    )
+    mcp.mount()
+
+    client = TestClient(app)
+    response = client.post("/mcp/echo", json={"value": "hello"})
+
+    assert response.status_code == 200
+    assert response.json() == {"echoed": "hello"}
+
+    metadata = mcp.tool_metadata["/echo"]
+    assert metadata["input_schema_ref"] == {"name": "EchoInput", "version": "v1"}
+    assert metadata["output_schema_ref"] == {"name": "EchoOutput", "version": "v1"}
+    assert metadata["metadata"]["owner"] == "test-suite"
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_rejects_invalid_input_payload() -> None:
+    app = FastAPI()
+    mcp = FastAPIMCPServer(app)
+
+    async def echo_tool(payload: dict[str, object]) -> dict[str, object]:
+        return {"echoed": payload["value"]}
+
+    mcp.add_tool("/echo", echo_tool, input_model=EchoInput, output_model=EchoOutput)
+    mcp.mount()
+
+    client = TestClient(app)
+    response = client.post("/mcp/echo", json={"missing": "value"})
+
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert detail["error"] == "invalid_tool_input"
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_rejects_invalid_output_payload() -> None:
+    app = FastAPI()
+    mcp = FastAPIMCPServer(app)
+
+    async def bad_tool(_payload: dict[str, object]) -> dict[str, object]:
+        return {"wrong": "shape"}
+
+    mcp.add_tool("/bad", bad_tool, output_model=EchoOutput)
+    mcp.mount()
+
+    client = TestClient(app)
+    response = client.post("/mcp/bad", json={})
+
+    assert response.status_code == 500
+    detail = response.json()["detail"]
+    assert detail["error"] == "invalid_tool_output"
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_without_schema_models_remains_compatible() -> None:
+    app = FastAPI()
+    mcp = FastAPIMCPServer(app)
+
+    async def passthrough(payload: dict[str, object]) -> dict[str, object]:
+        return {"ok": True, "payload": payload}
+
+    mcp.add_tool("/passthrough", passthrough)
+    mcp.mount()
+
+    client = TestClient(app)
+    response = client.post("/mcp/passthrough", json={"a": 1})
+
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+    assert response.json()["payload"] == {"a": 1}
+    metadata = mcp.tool_metadata["/passthrough"]
+    assert metadata["input_schema_ref"] is None
+    assert metadata["output_schema_ref"] is None

--- a/lib/tests/test_retail_events.py
+++ b/lib/tests/test_retail_events.py
@@ -1,0 +1,35 @@
+"""Tests for canonical retail event schemas."""
+
+import pytest
+from holiday_peak_lib.events import build_retail_event_payload, parse_retail_event
+
+
+def test_parse_order_event_with_legacy_id_alias() -> None:
+    payload = {
+        "event_type": "OrderCreated",
+        "data": {
+            "id": "order-123",
+            "user_id": "user-1",
+            "items": [],
+            "total": 10.5,
+            "status": "pending",
+            "created_at": "2026-03-21T00:00:00Z",
+        },
+    }
+
+    parsed = parse_retail_event(payload, topic="order-events")
+
+    assert parsed.data.order_id == "order-123"
+    assert parsed.timestamp == "2026-03-21T00:00:00Z"
+
+
+def test_build_retail_event_payload_rejects_invalid_return_event() -> None:
+    with pytest.raises(ValueError, match="return_id"):
+        build_retail_event_payload(
+            topic="return-events",
+            event_type="ReturnRequested",
+            data={
+                "order_id": "order-1",
+                "status": "requested",
+            },
+        )


### PR DESCRIPTION
## Summary\n- add MCP tool schema validation, schema references, and metadata registry support in FastAPIMCPServer\n- add canonical retail event envelopes/data models and shared parse/build helpers\n- validate CRUD publisher payloads and order-status consumer payloads against canonical schemas\n- add unit tests for MCP validation + metadata and retail event schema compatibility\n- document MCP schema discovery behavior in architecture docs\n\n## Validation\n- python -m pytest (pass)\n\nCloses #406\nCloses #425