### PR TITLE
Complete #468 workflow hygiene and finish Docker hardening rollout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,8 @@ jobs:
       - name: Build image
         run: |
           docker build \
+            --cache-from=type=gha,scope=${{ matrix.service.image_name }} \
+            --cache-to=type=gha,mode=max,scope=${{ matrix.service.image_name }} \
             -t "${{ steps.image.outputs.image_ref }}" \
             -f "${{ matrix.service.dockerfile }}" \
             "${{ matrix.service.context }}"
@@ -168,6 +170,16 @@ jobs:
             echo "exists=false" >> "$GITHUB_OUTPUT"
             echo "Published image not found, skipping: $image_ref"
           fi
+
+      - name: Warm Buildx cache from Dockerfile context
+        if: steps.image.outputs.exists == 'true'
+        run: |
+          docker build \
+            --cache-from=type=gha,scope=${{ matrix.service.image_name }} \
+            --cache-to=type=gha,mode=max,scope=${{ matrix.service.image_name }} \
+            -f "${{ matrix.service.dockerfile }}" \
+            --target prod \
+            "${{ matrix.service.context }}"
 
       - name: Trivy scan published image (HIGH/CRITICAL)
         if: steps.image.outputs.exists == 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Publish Python test summary
         if: always() && github.event_name == 'pull_request'
         continue-on-error: true
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@v2
         with:
           name: Python Tests
           path: test-results-*.xml
@@ -95,8 +95,16 @@ jobs:
           cache-dependency-path: apps/ui/yarn.lock
       - name: Install UI dependencies
         run: yarn install --frozen-lockfile
+      - name: Run UI lint
+        run: yarn lint
+      - name: Run UI type-check
+        run: yarn type-check
       - name: Run UI unit tests
         run: yarn test --ci --coverage --testPathIgnorePatterns=tests/unit/pagesRender.test.tsx
+      - name: Install Playwright browser
+        run: yarn playwright install --with-deps chromium
+      - name: Run UI E2E smoke tests
+        run: yarn test:e2e:ci --grep "critical flows baseline"
       - name: Run UI dependency vulnerability audit
         run: |
           yarn audit --json > yarn-audit.json || true
@@ -108,3 +116,5 @@ jobs:
           name: ui-test-results
           path: |
             apps/ui/coverage/**
+            apps/ui/test-results/**
+            apps/ui/playwright-report/**

--- a/.infra/modules/monitoring/monitoring.bicep
+++ b/.infra/modules/monitoring/monitoring.bicep
@@ -74,7 +74,7 @@ resource cosmosRuAlert 'Microsoft.Insights/metricAlerts@2018-03-01' = {
   name: '${projectName}-${environment}-cosmos-ru-high'
   location: 'global'
   properties: {
-    description: 'Cosmos RU consumption exceeded baseline threshold.'
+    description: 'Cosmos TotalRequestUnits average > 80 over PT15M (evaluated every PT5M).'
     severity: 2
     enabled: true
     scopes: [
@@ -108,7 +108,7 @@ resource cosmos5xxAlert 'Microsoft.Insights/metricAlerts@2018-03-01' = {
   name: '${projectName}-${environment}-cosmos-5xx-high'
   location: 'global'
   properties: {
-    description: 'Cosmos 5xx responses exceeded baseline threshold.'
+    description: 'Cosmos ServerSideRequests total > 5 over PT15M (evaluated every PT5M).'
     severity: 2
     enabled: true
     scopes: [
@@ -142,7 +142,7 @@ resource cosmosLatencyAlert 'Microsoft.Insights/metricAlerts@2018-03-01' = {
   name: '${projectName}-${environment}-cosmos-latency-high'
   location: 'global'
   properties: {
-    description: 'Cosmos request latency exceeded baseline threshold.'
+    description: 'Cosmos TotalRequestLatency average > 200ms over PT15M (evaluated every PT5M).'
     severity: 3
     enabled: true
     scopes: [
@@ -176,7 +176,7 @@ resource redisMemoryAlert 'Microsoft.Insights/metricAlerts@2018-03-01' = {
   name: '${projectName}-${environment}-redis-memory-high'
   location: 'global'
   properties: {
-    description: 'Redis memory utilization exceeded baseline threshold.'
+    description: 'Redis usedmemorypercentage average > 80 over PT15M (evaluated every PT5M).'
     severity: 2
     enabled: true
     scopes: [
@@ -210,7 +210,7 @@ resource redisConnectionAlert 'Microsoft.Insights/metricAlerts@2018-03-01' = {
   name: '${projectName}-${environment}-redis-connections-failed'
   location: 'global'
   properties: {
-    description: 'Redis connection failures detected.'
+    description: 'Redis errors total > 1 over PT15M (evaluated every PT5M).'
     severity: 2
     enabled: true
     scopes: [
@@ -244,7 +244,7 @@ resource redisEvictionsAlert 'Microsoft.Insights/metricAlerts@2018-03-01' = {
   name: '${projectName}-${environment}-redis-evictions-high'
   location: 'global'
   properties: {
-    description: 'Redis key eviction activity exceeded baseline threshold.'
+    description: 'Redis evictedkeys total > 0 over PT15M (evaluated every PT5M).'
     severity: 3
     enabled: true
     scopes: [
@@ -278,7 +278,7 @@ resource postgresCpuAlert 'Microsoft.Insights/metricAlerts@2018-03-01' = {
   name: '${projectName}-${environment}-postgres-cpu-high'
   location: 'global'
   properties: {
-    description: 'PostgreSQL CPU utilization exceeded baseline threshold.'
+    description: 'PostgreSQL cpu_percent average > 80 over PT15M (evaluated every PT5M).'
     severity: 2
     enabled: true
     scopes: [
@@ -312,7 +312,7 @@ resource postgresStorageAlert 'Microsoft.Insights/metricAlerts@2018-03-01' = {
   name: '${projectName}-${environment}-postgres-storage-high'
   location: 'global'
   properties: {
-    description: 'PostgreSQL storage utilization exceeded baseline threshold.'
+    description: 'PostgreSQL storage_percent average > 85 over PT15M (evaluated every PT5M).'
     severity: 2
     enabled: true
     scopes: [
@@ -346,7 +346,7 @@ resource postgresLongQueryAlert 'Microsoft.Insights/metricAlerts@2018-03-01' = {
   name: '${projectName}-${environment}-postgres-long-queries'
   location: 'global'
   properties: {
-    description: 'PostgreSQL long-running query count exceeded baseline threshold.'
+    description: 'PostgreSQL long_running_queries average > 5 over PT15M (evaluated every PT5M).'
     severity: 3
     enabled: true
     scopes: [
@@ -380,7 +380,7 @@ resource eventHubsThrottledAlert 'Microsoft.Insights/metricAlerts@2018-03-01' = 
   name: '${projectName}-${environment}-eventhubs-throttled'
   location: 'global'
   properties: {
-    description: 'Event Hubs throttled requests exceeded baseline threshold.'
+    description: 'Event Hubs ThrottledRequests total > 0 over PT15M (evaluated every PT5M).'
     severity: 2
     enabled: true
     scopes: [
@@ -414,7 +414,7 @@ resource eventHubsAbandonedMessagesAlert 'Microsoft.Insights/metricAlerts@2018-0
   name: '${projectName}-${environment}-eventhubs-abandoned'
   location: 'global'
   properties: {
-    description: 'Event Hubs abandoned messages exceeded baseline threshold.'
+    description: 'Event Hubs OutgoingMessages average < 1 over PT15M (evaluated every PT5M).'
     severity: 3
     enabled: true
     scopes: [
@@ -448,7 +448,7 @@ resource eventHubsConsumerLagAlert 'Microsoft.Insights/metricAlerts@2018-03-01' 
   name: '${projectName}-${environment}-eventhubs-consumer-lag'
   location: 'global'
   properties: {
-    description: 'Event Hubs consumer lag proxy metric exceeded baseline threshold.'
+    description: 'Event Hubs IncomingMessages total > 100000 over PT15M (evaluated every PT5M) as consumer lag proxy.'
     severity: 2
     enabled: true
     scopes: [
@@ -482,7 +482,7 @@ resource aksNodeCpuAlert 'Microsoft.Insights/metricAlerts@2018-03-01' = {
   name: '${projectName}-${environment}-aks-node-cpu-high'
   location: 'global'
   properties: {
-    description: 'AKS node CPU utilization exceeded baseline threshold.'
+    description: 'AKS node_cpu_usage_percentage average > 80 over PT15M (evaluated every PT5M).'
     severity: 2
     enabled: true
     scopes: [
@@ -516,7 +516,7 @@ resource aksPodRestartAlert 'Microsoft.Insights/metricAlerts@2018-03-01' = {
   name: '${projectName}-${environment}-aks-pod-restarts-high'
   location: 'global'
   properties: {
-    description: 'AKS pod restart activity exceeded baseline threshold.'
+    description: 'AKS pod_restart_count total > 5 over PT15M (evaluated every PT5M).'
     severity: 3
     enabled: true
     scopes: [
@@ -550,7 +550,7 @@ resource aksImagePullFailuresAlert 'Microsoft.Insights/metricAlerts@2018-03-01' 
   name: '${projectName}-${environment}-aks-image-pull-failures'
   location: 'global'
   properties: {
-    description: 'AKS image pull failures exceeded baseline threshold.'
+    description: 'AKS image_pull_failed_count total > 0 over PT15M (evaluated every PT5M).'
     severity: 2
     enabled: true
     scopes: [
@@ -584,7 +584,7 @@ resource apimFailedRequestsAlert 'Microsoft.Insights/metricAlerts@2018-03-01' = 
   name: '${projectName}-${environment}-apim-failed-requests'
   location: 'global'
   properties: {
-    description: 'APIM failed request count exceeded baseline threshold.'
+    description: 'APIM FailedRequests total > 10 over PT15M (evaluated every PT5M).'
     severity: 2
     enabled: true
     scopes: [
@@ -618,7 +618,7 @@ resource apimLatencyAlert 'Microsoft.Insights/metricAlerts@2018-03-01' = {
   name: '${projectName}-${environment}-apim-latency-p95'
   location: 'global'
   properties: {
-    description: 'APIM request duration exceeded baseline threshold.'
+    description: 'APIM Duration average > 2000ms over PT15M (evaluated every PT5M).'
     severity: 2
     enabled: true
     scopes: [
@@ -652,7 +652,7 @@ resource apim5xxRateAlert 'Microsoft.Insights/metricAlerts@2018-03-01' = {
   name: '${projectName}-${environment}-apim-5xx-rate'
   location: 'global'
   properties: {
-    description: 'APIM 5xx error rate proxy exceeded baseline threshold.'
+    description: 'APIM FailedRequests average > 1 over PT15M (evaluated every PT5M) as 5xx proxy.'
     severity: 2
     enabled: true
     scopes: [

--- a/apps/crm-campaign-intelligence/src/Dockerfile
+++ b/apps/crm-campaign-intelligence/src/Dockerfile
@@ -27,13 +27,24 @@ RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "crm_campaign_intelligence.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
 
-FROM base AS prod
+FROM base AS prod-builder
 ENV APP_ENV=prod
 COPY pyproject.toml uv.lock ./
 COPY . ./
 ENV PYTHONPATH=/app/src
 ENV PATH="/app/src/.venv/bin:$PATH"
 RUN uv sync --frozen --no-dev --no-sources
+
+FROM python:${PYTHON_VERSION} AS prod
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+RUN groupadd --gid ${APP_GID} appgroup && useradd --uid ${APP_UID} --gid ${APP_GID} --create-home --home-dir /home/appuser --shell /usr/sbin/nologin appuser \
+    && mkdir -p /app && chown -R appuser:appgroup /app
+WORKDIR /app/src
+RUN apt-get update && apt-get install -y --no-install-recommends libpq5 \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=prod-builder /app /app
 RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "crm_campaign_intelligence.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/apps/crm-profile-aggregation/src/Dockerfile
+++ b/apps/crm-profile-aggregation/src/Dockerfile
@@ -27,13 +27,24 @@ RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "crm_profile_aggregation.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
 
-FROM base AS prod
+FROM base AS prod-builder
 ENV APP_ENV=prod
 COPY pyproject.toml uv.lock ./
 COPY . ./
 ENV PYTHONPATH=/app/src
 ENV PATH="/app/src/.venv/bin:$PATH"
 RUN uv sync --frozen --no-dev --no-sources
+
+FROM python:${PYTHON_VERSION} AS prod
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+RUN groupadd --gid ${APP_GID} appgroup && useradd --uid ${APP_UID} --gid ${APP_GID} --create-home --home-dir /home/appuser --shell /usr/sbin/nologin appuser \
+    && mkdir -p /app && chown -R appuser:appgroup /app
+WORKDIR /app/src
+RUN apt-get update && apt-get install -y --no-install-recommends libpq5 \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=prod-builder /app /app
 RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "crm_profile_aggregation.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/apps/crm-segmentation-personalization/src/Dockerfile
+++ b/apps/crm-segmentation-personalization/src/Dockerfile
@@ -27,13 +27,24 @@ RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "crm_segmentation_personalization.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
 
-FROM base AS prod
+FROM base AS prod-builder
 ENV APP_ENV=prod
 COPY pyproject.toml uv.lock ./
 COPY . ./
 ENV PYTHONPATH=/app/src
 ENV PATH="/app/src/.venv/bin:$PATH"
 RUN uv sync --frozen --no-dev --no-sources
+
+FROM python:${PYTHON_VERSION} AS prod
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+RUN groupadd --gid ${APP_GID} appgroup && useradd --uid ${APP_UID} --gid ${APP_GID} --create-home --home-dir /home/appuser --shell /usr/sbin/nologin appuser \
+    && mkdir -p /app && chown -R appuser:appgroup /app
+WORKDIR /app/src
+RUN apt-get update && apt-get install -y --no-install-recommends libpq5 \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=prod-builder /app /app
 RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "crm_segmentation_personalization.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/apps/crm-support-assistance/src/Dockerfile
+++ b/apps/crm-support-assistance/src/Dockerfile
@@ -27,13 +27,24 @@ RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "crm_support_assistance.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
 
-FROM base AS prod
+FROM base AS prod-builder
 ENV APP_ENV=prod
 COPY pyproject.toml uv.lock ./
 COPY . ./
 ENV PYTHONPATH=/app/src
 ENV PATH="/app/src/.venv/bin:$PATH"
 RUN uv sync --frozen --no-dev --no-sources
+
+FROM python:${PYTHON_VERSION} AS prod
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+RUN groupadd --gid ${APP_GID} appgroup && useradd --uid ${APP_UID} --gid ${APP_GID} --create-home --home-dir /home/appuser --shell /usr/sbin/nologin appuser \
+    && mkdir -p /app && chown -R appuser:appgroup /app
+WORKDIR /app/src
+RUN apt-get update && apt-get install -y --no-install-recommends libpq5 \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=prod-builder /app /app
 RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "crm_support_assistance.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/apps/ecommerce-cart-intelligence/src/Dockerfile
+++ b/apps/ecommerce-cart-intelligence/src/Dockerfile
@@ -27,13 +27,24 @@ RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "ecommerce_cart_intelligence.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
 
-FROM base AS prod
+FROM base AS prod-builder
 ENV APP_ENV=prod
 COPY pyproject.toml uv.lock ./
 COPY . ./
 ENV PYTHONPATH=/app/src
 ENV PATH="/app/src/.venv/bin:$PATH"
 RUN uv sync --frozen --no-dev --no-sources
+
+FROM python:${PYTHON_VERSION} AS prod
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+RUN groupadd --gid ${APP_GID} appgroup && useradd --uid ${APP_UID} --gid ${APP_GID} --create-home --home-dir /home/appuser --shell /usr/sbin/nologin appuser \
+    && mkdir -p /app && chown -R appuser:appgroup /app
+WORKDIR /app/src
+RUN apt-get update && apt-get install -y --no-install-recommends libpq5 \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=prod-builder /app /app
 RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "ecommerce_cart_intelligence.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/apps/ecommerce-catalog-search/src/Dockerfile
+++ b/apps/ecommerce-catalog-search/src/Dockerfile
@@ -27,13 +27,24 @@ RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "ecommerce_catalog_search.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
 
-FROM base AS prod
+FROM base AS prod-builder
 ENV APP_ENV=prod
 COPY pyproject.toml uv.lock ./
 COPY . ./
 ENV PYTHONPATH=/app/src
 ENV PATH="/app/src/.venv/bin:$PATH"
 RUN uv sync --frozen --no-dev --no-sources
+
+FROM python:${PYTHON_VERSION} AS prod
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+RUN groupadd --gid ${APP_GID} appgroup && useradd --uid ${APP_UID} --gid ${APP_GID} --create-home --home-dir /home/appuser --shell /usr/sbin/nologin appuser \
+    && mkdir -p /app && chown -R appuser:appgroup /app
+WORKDIR /app/src
+RUN apt-get update && apt-get install -y --no-install-recommends libpq5 \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=prod-builder /app /app
 RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "ecommerce_catalog_search.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/apps/ecommerce-checkout-support/src/Dockerfile
+++ b/apps/ecommerce-checkout-support/src/Dockerfile
@@ -27,13 +27,24 @@ RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "ecommerce_checkout_support.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
 
-FROM base AS prod
+FROM base AS prod-builder
 ENV APP_ENV=prod
 COPY pyproject.toml uv.lock ./
 COPY . ./
 ENV PYTHONPATH=/app/src
 ENV PATH="/app/src/.venv/bin:$PATH"
 RUN uv sync --frozen --no-dev --no-sources
+
+FROM python:${PYTHON_VERSION} AS prod
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+RUN groupadd --gid ${APP_GID} appgroup && useradd --uid ${APP_UID} --gid ${APP_GID} --create-home --home-dir /home/appuser --shell /usr/sbin/nologin appuser \
+    && mkdir -p /app && chown -R appuser:appgroup /app
+WORKDIR /app/src
+RUN apt-get update && apt-get install -y --no-install-recommends libpq5 \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=prod-builder /app /app
 RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "ecommerce_checkout_support.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/apps/ecommerce-order-status/src/Dockerfile
+++ b/apps/ecommerce-order-status/src/Dockerfile
@@ -27,13 +27,24 @@ RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "ecommerce_order_status.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
 
-FROM base AS prod
+FROM base AS prod-builder
 ENV APP_ENV=prod
 COPY pyproject.toml uv.lock ./
 COPY . ./
 ENV PYTHONPATH=/app/src
 ENV PATH="/app/src/.venv/bin:$PATH"
 RUN uv sync --frozen --no-dev --no-sources
+
+FROM python:${PYTHON_VERSION} AS prod
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+RUN groupadd --gid ${APP_GID} appgroup && useradd --uid ${APP_UID} --gid ${APP_GID} --create-home --home-dir /home/appuser --shell /usr/sbin/nologin appuser \
+    && mkdir -p /app && chown -R appuser:appgroup /app
+WORKDIR /app/src
+RUN apt-get update && apt-get install -y --no-install-recommends libpq5 \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=prod-builder /app /app
 RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "ecommerce_order_status.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/apps/ecommerce-product-detail-enrichment/src/Dockerfile
+++ b/apps/ecommerce-product-detail-enrichment/src/Dockerfile
@@ -27,13 +27,24 @@ RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "ecommerce_product_detail_enrichment.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
 
-FROM base AS prod
+FROM base AS prod-builder
 ENV APP_ENV=prod
 COPY pyproject.toml uv.lock ./
 COPY . ./
 ENV PYTHONPATH=/app/src
 ENV PATH="/app/src/.venv/bin:$PATH"
 RUN uv sync --frozen --no-dev --no-sources
+
+FROM python:${PYTHON_VERSION} AS prod
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+RUN groupadd --gid ${APP_GID} appgroup && useradd --uid ${APP_UID} --gid ${APP_GID} --create-home --home-dir /home/appuser --shell /usr/sbin/nologin appuser \
+    && mkdir -p /app && chown -R appuser:appgroup /app
+WORKDIR /app/src
+RUN apt-get update && apt-get install -y --no-install-recommends libpq5 \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=prod-builder /app /app
 RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "ecommerce_product_detail_enrichment.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/apps/inventory-alerts-triggers/src/Dockerfile
+++ b/apps/inventory-alerts-triggers/src/Dockerfile
@@ -27,13 +27,24 @@ RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "inventory_alerts_triggers.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
 
-FROM base AS prod
+FROM base AS prod-builder
 ENV APP_ENV=prod
 COPY pyproject.toml uv.lock ./
 COPY . ./
 ENV PYTHONPATH=/app/src
 ENV PATH="/app/src/.venv/bin:$PATH"
 RUN uv sync --frozen --no-dev --no-sources
+
+FROM python:${PYTHON_VERSION} AS prod
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+RUN groupadd --gid ${APP_GID} appgroup && useradd --uid ${APP_UID} --gid ${APP_GID} --create-home --home-dir /home/appuser --shell /usr/sbin/nologin appuser \
+    && mkdir -p /app && chown -R appuser:appgroup /app
+WORKDIR /app/src
+RUN apt-get update && apt-get install -y --no-install-recommends libpq5 \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=prod-builder /app /app
 RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "inventory_alerts_triggers.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/apps/inventory-health-check/src/Dockerfile
+++ b/apps/inventory-health-check/src/Dockerfile
@@ -27,13 +27,24 @@ RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "inventory_health_check.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
 
-FROM base AS prod
+FROM base AS prod-builder
 ENV APP_ENV=prod
 COPY pyproject.toml uv.lock ./
 COPY . ./
 ENV PYTHONPATH=/app/src
 ENV PATH="/app/src/.venv/bin:$PATH"
 RUN uv sync --frozen --no-dev --no-sources
+
+FROM python:${PYTHON_VERSION} AS prod
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+RUN groupadd --gid ${APP_GID} appgroup && useradd --uid ${APP_UID} --gid ${APP_GID} --create-home --home-dir /home/appuser --shell /usr/sbin/nologin appuser \
+    && mkdir -p /app && chown -R appuser:appgroup /app
+WORKDIR /app/src
+RUN apt-get update && apt-get install -y --no-install-recommends libpq5 \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=prod-builder /app /app
 RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "inventory_health_check.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/apps/inventory-jit-replenishment/src/Dockerfile
+++ b/apps/inventory-jit-replenishment/src/Dockerfile
@@ -27,13 +27,24 @@ RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "inventory_jit_replenishment.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
 
-FROM base AS prod
+FROM base AS prod-builder
 ENV APP_ENV=prod
 COPY pyproject.toml uv.lock ./
 COPY . ./
 ENV PYTHONPATH=/app/src
 ENV PATH="/app/src/.venv/bin:$PATH"
 RUN uv sync --frozen --no-dev --no-sources
+
+FROM python:${PYTHON_VERSION} AS prod
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+RUN groupadd --gid ${APP_GID} appgroup && useradd --uid ${APP_UID} --gid ${APP_GID} --create-home --home-dir /home/appuser --shell /usr/sbin/nologin appuser \
+    && mkdir -p /app && chown -R appuser:appgroup /app
+WORKDIR /app/src
+RUN apt-get update && apt-get install -y --no-install-recommends libpq5 \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=prod-builder /app /app
 RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "inventory_jit_replenishment.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/apps/inventory-reservation-validation/src/Dockerfile
+++ b/apps/inventory-reservation-validation/src/Dockerfile
@@ -27,13 +27,24 @@ RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "inventory_reservation_validation.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
 
-FROM base AS prod
+FROM base AS prod-builder
 ENV APP_ENV=prod
 COPY pyproject.toml uv.lock ./
 COPY . ./
 ENV PYTHONPATH=/app/src
 ENV PATH="/app/src/.venv/bin:$PATH"
 RUN uv sync --frozen --no-dev --no-sources
+
+FROM python:${PYTHON_VERSION} AS prod
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+RUN groupadd --gid ${APP_GID} appgroup && useradd --uid ${APP_UID} --gid ${APP_GID} --create-home --home-dir /home/appuser --shell /usr/sbin/nologin appuser \
+    && mkdir -p /app && chown -R appuser:appgroup /app
+WORKDIR /app/src
+RUN apt-get update && apt-get install -y --no-install-recommends libpq5 \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=prod-builder /app /app
 RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "inventory_reservation_validation.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/apps/logistics-carrier-selection/src/Dockerfile
+++ b/apps/logistics-carrier-selection/src/Dockerfile
@@ -27,13 +27,24 @@ RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "logistics_carrier_selection.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
 
-FROM base AS prod
+FROM base AS prod-builder
 ENV APP_ENV=prod
 COPY pyproject.toml uv.lock ./
 COPY . ./
 ENV PYTHONPATH=/app/src
 ENV PATH="/app/src/.venv/bin:$PATH"
 RUN uv sync --frozen --no-dev --no-sources
+
+FROM python:${PYTHON_VERSION} AS prod
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+RUN groupadd --gid ${APP_GID} appgroup && useradd --uid ${APP_UID} --gid ${APP_GID} --create-home --home-dir /home/appuser --shell /usr/sbin/nologin appuser \
+    && mkdir -p /app && chown -R appuser:appgroup /app
+WORKDIR /app/src
+RUN apt-get update && apt-get install -y --no-install-recommends libpq5 \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=prod-builder /app /app
 RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "logistics_carrier_selection.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/apps/logistics-eta-computation/src/Dockerfile
+++ b/apps/logistics-eta-computation/src/Dockerfile
@@ -27,13 +27,24 @@ RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "logistics_eta_computation.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
 
-FROM base AS prod
+FROM base AS prod-builder
 ENV APP_ENV=prod
 COPY pyproject.toml uv.lock ./
 COPY . ./
 ENV PYTHONPATH=/app/src
 ENV PATH="/app/src/.venv/bin:$PATH"
 RUN uv sync --frozen --no-dev --no-sources
+
+FROM python:${PYTHON_VERSION} AS prod
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+RUN groupadd --gid ${APP_GID} appgroup && useradd --uid ${APP_UID} --gid ${APP_GID} --create-home --home-dir /home/appuser --shell /usr/sbin/nologin appuser \
+    && mkdir -p /app && chown -R appuser:appgroup /app
+WORKDIR /app/src
+RUN apt-get update && apt-get install -y --no-install-recommends libpq5 \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=prod-builder /app /app
 RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "logistics_eta_computation.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/apps/logistics-returns-support/src/Dockerfile
+++ b/apps/logistics-returns-support/src/Dockerfile
@@ -27,13 +27,24 @@ RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "logistics_returns_support.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
 
-FROM base AS prod
+FROM base AS prod-builder
 ENV APP_ENV=prod
 COPY pyproject.toml uv.lock ./
 COPY . ./
 ENV PYTHONPATH=/app/src
 ENV PATH="/app/src/.venv/bin:$PATH"
 RUN uv sync --frozen --no-dev --no-sources
+
+FROM python:${PYTHON_VERSION} AS prod
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+RUN groupadd --gid ${APP_GID} appgroup && useradd --uid ${APP_UID} --gid ${APP_GID} --create-home --home-dir /home/appuser --shell /usr/sbin/nologin appuser \
+    && mkdir -p /app && chown -R appuser:appgroup /app
+WORKDIR /app/src
+RUN apt-get update && apt-get install -y --no-install-recommends libpq5 \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=prod-builder /app /app
 RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "logistics_returns_support.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/apps/logistics-route-issue-detection/src/Dockerfile
+++ b/apps/logistics-route-issue-detection/src/Dockerfile
@@ -27,13 +27,24 @@ RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "logistics_route_issue_detection.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
 
-FROM base AS prod
+FROM base AS prod-builder
 ENV APP_ENV=prod
 COPY pyproject.toml uv.lock ./
 COPY . ./
 ENV PYTHONPATH=/app/src
 ENV PATH="/app/src/.venv/bin:$PATH"
 RUN uv sync --frozen --no-dev --no-sources
+
+FROM python:${PYTHON_VERSION} AS prod
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+RUN groupadd --gid ${APP_GID} appgroup && useradd --uid ${APP_UID} --gid ${APP_GID} --create-home --home-dir /home/appuser --shell /usr/sbin/nologin appuser \
+    && mkdir -p /app && chown -R appuser:appgroup /app
+WORKDIR /app/src
+RUN apt-get update && apt-get install -y --no-install-recommends libpq5 \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=prod-builder /app /app
 RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "logistics_route_issue_detection.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/apps/product-management-acp-transformation/src/Dockerfile
+++ b/apps/product-management-acp-transformation/src/Dockerfile
@@ -27,13 +27,24 @@ RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "product_management_acp_transformation.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
 
-FROM base AS prod
+FROM base AS prod-builder
 ENV APP_ENV=prod
 COPY pyproject.toml uv.lock ./
 COPY . ./
 ENV PYTHONPATH=/app/src
 ENV PATH="/app/src/.venv/bin:$PATH"
 RUN uv sync --frozen --no-dev --no-sources
+
+FROM python:${PYTHON_VERSION} AS prod
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+RUN groupadd --gid ${APP_GID} appgroup && useradd --uid ${APP_UID} --gid ${APP_GID} --create-home --home-dir /home/appuser --shell /usr/sbin/nologin appuser \
+    && mkdir -p /app && chown -R appuser:appgroup /app
+WORKDIR /app/src
+RUN apt-get update && apt-get install -y --no-install-recommends libpq5 \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=prod-builder /app /app
 RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "product_management_acp_transformation.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/apps/product-management-assortment-optimization/src/Dockerfile
+++ b/apps/product-management-assortment-optimization/src/Dockerfile
@@ -27,13 +27,24 @@ RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "product_management_assortment_optimization.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
 
-FROM base AS prod
+FROM base AS prod-builder
 ENV APP_ENV=prod
 COPY pyproject.toml uv.lock ./
 COPY . ./
 ENV PYTHONPATH=/app/src
 ENV PATH="/app/src/.venv/bin:$PATH"
 RUN uv sync --frozen --no-dev --no-sources
+
+FROM python:${PYTHON_VERSION} AS prod
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+RUN groupadd --gid ${APP_GID} appgroup && useradd --uid ${APP_UID} --gid ${APP_GID} --create-home --home-dir /home/appuser --shell /usr/sbin/nologin appuser \
+    && mkdir -p /app && chown -R appuser:appgroup /app
+WORKDIR /app/src
+RUN apt-get update && apt-get install -y --no-install-recommends libpq5 \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=prod-builder /app /app
 RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "product_management_assortment_optimization.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/apps/product-management-consistency-validation/src/Dockerfile
+++ b/apps/product-management-consistency-validation/src/Dockerfile
@@ -27,13 +27,24 @@ RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "product_management_consistency_validation.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
 
-FROM base AS prod
+FROM base AS prod-builder
 ENV APP_ENV=prod
 COPY pyproject.toml uv.lock ./
 COPY . ./
 ENV PYTHONPATH=/app/src
 ENV PATH="/app/src/.venv/bin:$PATH"
 RUN uv sync --frozen --no-dev --no-sources
+
+FROM python:${PYTHON_VERSION} AS prod
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+RUN groupadd --gid ${APP_GID} appgroup && useradd --uid ${APP_UID} --gid ${APP_GID} --create-home --home-dir /home/appuser --shell /usr/sbin/nologin appuser \
+    && mkdir -p /app && chown -R appuser:appgroup /app
+WORKDIR /app/src
+RUN apt-get update && apt-get install -y --no-install-recommends libpq5 \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=prod-builder /app /app
 RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "product_management_consistency_validation.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/apps/product-management-normalization-classification/src/Dockerfile
+++ b/apps/product-management-normalization-classification/src/Dockerfile
@@ -27,13 +27,24 @@ RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "product_management_normalization_classification.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
 
-FROM base AS prod
+FROM base AS prod-builder
 ENV APP_ENV=prod
 COPY pyproject.toml uv.lock ./
 COPY . ./
 ENV PYTHONPATH=/app/src
 ENV PATH="/app/src/.venv/bin:$PATH"
 RUN uv sync --frozen --no-dev --no-sources
+
+FROM python:${PYTHON_VERSION} AS prod
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+RUN groupadd --gid ${APP_GID} appgroup && useradd --uid ${APP_UID} --gid ${APP_GID} --create-home --home-dir /home/appuser --shell /usr/sbin/nologin appuser \
+    && mkdir -p /app && chown -R appuser:appgroup /app
+WORKDIR /app/src
+RUN apt-get update && apt-get install -y --no-install-recommends libpq5 \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=prod-builder /app /app
 RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "product_management_normalization_classification.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/apps/search-enrichment-agent/src/Dockerfile
+++ b/apps/search-enrichment-agent/src/Dockerfile
@@ -25,13 +25,25 @@ RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "search_enrichment_agent.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
 
-FROM base AS prod
+FROM base AS prod-builder
 ENV APP_ENV=prod
 COPY pyproject.toml ./pyproject.toml
 COPY . ./
 ENV PYTHONPATH=/app/src
 RUN python -m pip install --upgrade pip && \
     python -m pip install --no-cache-dir .
+
+FROM python:${PYTHON_VERSION} AS prod
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+RUN groupadd --gid ${APP_GID} appgroup && useradd --uid ${APP_UID} --gid ${APP_GID} --create-home --home-dir /home/appuser --shell /usr/sbin/nologin appuser \
+    && mkdir -p /app && chown -R appuser:appgroup /app
+WORKDIR /app/src
+RUN apt-get update && apt-get install -y --no-install-recommends libpq5 \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=prod-builder /usr/local /usr/local
+COPY --from=prod-builder /app /app
 RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "search_enrichment_agent.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/apps/truth-enrichment/src/Dockerfile
+++ b/apps/truth-enrichment/src/Dockerfile
@@ -26,13 +26,24 @@ RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "truth_enrichment.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
 
-FROM base AS prod
+FROM base AS prod-builder
 ENV APP_ENV=prod
 COPY pyproject.toml uv.lock ./
 COPY . ./
 ENV PYTHONPATH=/app/src
 ENV PATH="/app/src/.venv/bin:$PATH"
 RUN uv sync --frozen --no-dev --no-sources
+
+FROM python:${PYTHON_VERSION} AS prod
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+RUN groupadd --gid ${APP_GID} appgroup && useradd --uid ${APP_UID} --gid ${APP_GID} --create-home --home-dir /home/appuser --shell /usr/sbin/nologin appuser \
+    && mkdir -p /app && chown -R appuser:appgroup /app
+WORKDIR /app/src
+RUN apt-get update && apt-get install -y --no-install-recommends libpq5 \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=prod-builder /app /app
 RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "truth_enrichment.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/apps/truth-export/src/Dockerfile
+++ b/apps/truth-export/src/Dockerfile
@@ -26,13 +26,24 @@ RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "truth_export.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
 
-FROM base AS prod
+FROM base AS prod-builder
 ENV APP_ENV=prod
 COPY pyproject.toml uv.lock ./
 COPY . ./
 ENV PYTHONPATH=/app/src
 ENV PATH="/app/src/.venv/bin:$PATH"
 RUN uv sync --frozen --no-dev --no-sources
+
+FROM python:${PYTHON_VERSION} AS prod
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+RUN groupadd --gid ${APP_GID} appgroup && useradd --uid ${APP_UID} --gid ${APP_GID} --create-home --home-dir /home/appuser --shell /usr/sbin/nologin appuser \
+    && mkdir -p /app && chown -R appuser:appgroup /app
+WORKDIR /app/src
+RUN apt-get update && apt-get install -y --no-install-recommends libpq5 \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=prod-builder /app /app
 RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "truth_export.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/apps/truth-hitl/src/Dockerfile
+++ b/apps/truth-hitl/src/Dockerfile
@@ -26,13 +26,24 @@ RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "truth_hitl.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
 
-FROM base AS prod
+FROM base AS prod-builder
 ENV APP_ENV=prod
 COPY pyproject.toml uv.lock ./
 COPY . ./
 ENV PYTHONPATH=/app/src
 ENV PATH="/app/src/.venv/bin:$PATH"
 RUN uv sync --frozen --no-dev --no-sources
+
+FROM python:${PYTHON_VERSION} AS prod
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+RUN groupadd --gid ${APP_GID} appgroup && useradd --uid ${APP_UID} --gid ${APP_GID} --create-home --home-dir /home/appuser --shell /usr/sbin/nologin appuser \
+    && mkdir -p /app && chown -R appuser:appgroup /app
+WORKDIR /app/src
+RUN apt-get update && apt-get install -y --no-install-recommends libpq5 \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=prod-builder /app /app
 RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "truth_hitl.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/apps/truth-ingestion/src/Dockerfile
+++ b/apps/truth-ingestion/src/Dockerfile
@@ -26,13 +26,24 @@ RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "truth_ingestion.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
 
-FROM base AS prod
+FROM base AS prod-builder
 ENV APP_ENV=prod
 COPY pyproject.toml uv.lock ./
 COPY . ./
 ENV PYTHONPATH=/app/src
 ENV PATH="/app/src/.venv/bin:$PATH"
 RUN uv sync --frozen --no-dev --no-sources
+
+FROM python:${PYTHON_VERSION} AS prod
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+RUN groupadd --gid ${APP_GID} appgroup && useradd --uid ${APP_UID} --gid ${APP_GID} --create-home --home-dir /home/appuser --shell /usr/sbin/nologin appuser \
+    && mkdir -p /app && chown -R appuser:appgroup /app
+WORKDIR /app/src
+RUN apt-get update && apt-get install -y --no-install-recommends libpq5 \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=prod-builder /app /app
 RUN chown -R appuser:appgroup /app
 USER appuser
 CMD ["uvicorn", "truth_ingestion.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary\n- Upgrade test reporter to dorny/test-reporter@v2 in test workflow.\n- Add Buildx GHA layer caching to CI Docker build paths.\n- Normalize generic monitoring alert descriptions with explicit thresholds/windows/evaluation cadence.\n- Complete multi-stage Docker hardening (prod-builder + clean runtime prod) across service Dockerfiles, removing build-only dependencies from runtime layers.\n\n## Validation\n- python -m pytest passed: 1594 passed in 220.93s.\n- Workflow checks by grep:\n  - dorny/test-reporter@v2 present.\n  - cache-from/cache-to type=gha present in CI build paths.\n  - No aseline threshold generic descriptions remain in monitoring module.\n  - No FROM base AS prod remains across service Dockerfiles.\n\n## Docker evidence blocker\n- Local Docker daemon was unavailable for runtime/image-size evidence collection.\n- Tracked in blocker issue: #472\n\nCloses #468\nCloses #437\nCloses #455\nCloses #458