### PR TITLE
fix(ci): remediate deploy-azd-dev startup_failure permission contract (#479)

### DIFF
--- a/.github/workflows/deploy-azd-dev.yml
+++ b/.github/workflows/deploy-azd-dev.yml
@@ -56,6 +56,10 @@ permissions:
 
 jobs:
   deploy:
+    permissions:
+      id-token: write
+      contents: read
+      issues: write
     uses: ./.github/workflows/deploy-azd.yml
     with:
       environment: dev


### PR DESCRIPTION
## Summary\n- Aligns caller permissions for reusable deploy workflow invocation in .github/workflows/deploy-azd-dev.yml.\n- Adds explicit jobs.deploy.permissions with least required scopes for nested watchdog issue-comment behavior.\n\n## Evidence\n- Failing run: https://github.com/Azure-Samples/holiday-peak-hub/actions/runs/23382771084\n\n## Validation\n- Local workflow YAML parse sanity check passed for changed workflow files.\n\nCloses #479