### PR TITLE
test(ui): align critical flow /shop expectation with deployed routing (#483)

### DIFF
--- a/apps/ui/tests/e2e/critical-flows.spec.ts
+++ b/apps/ui/tests/e2e/critical-flows.spec.ts
@@ -9,7 +9,7 @@ test.describe('critical flows baseline', () => {
     await expect(page).toHaveURL(/\/$/);
 
     await page.goto('/shop');
-    await expect(page).toHaveURL(/\/category\?slug=all$/);
+    await expect(page).toHaveURL(/\/shop$/);
 
     await page.goto('/cart');
     await expect(page).toHaveURL(/\/auth\/login\?redirect=%2Fcart$/);


### PR DESCRIPTION
## Summary
- Updates pps/ui/tests/e2e/critical-flows.spec.ts to assert /shop after page.goto('/shop').
- Keeps all other auth redirect assertions unchanged.

## Validation
- PLAYWRIGHT_BASE_URL=https://blue-meadow-00fcb8810.4.azurestaticapps.net yarn test:e2e:ci --grep 'critical flows baseline'
- Result: 2 passed.

Closes #483