### PR TITLE
[Backend][Contract] CRUD truth analytics canonical endpoints

### DIFF
--- a/apps/crud-service/src/crud_service/routes/completeness.py
+++ b/apps/crud-service/src/crud_service/routes/completeness.py
@@ -158,7 +158,9 @@ def _average_review_time_minutes(proposals: list[dict]) -> float:
     return sum(durations) / len(durations)
 
 
-def _build_bucket_starts(*, now: datetime, window_hours: int, interval_minutes: int) -> list[datetime]:
+def _build_bucket_starts(
+    *, now: datetime, window_hours: int, interval_minutes: int
+) -> list[datetime]:
     total_minutes = max(window_hours * 60, interval_minutes)
     bucket_count = max(1, total_minutes // interval_minutes)
 
@@ -226,7 +228,9 @@ async def get_truth_analytics_summary():
     proposal_items = await proposed_attr_repo.query(query="SELECT * FROM c")
     audit_items = await audit_repo.query(query="SELECT * FROM c")
 
-    scores = [_to_float(item.get("score", item.get("completeness_score"))) for item in completeness_items]
+    scores = [
+        _to_float(item.get("score", item.get("completeness_score"))) for item in completeness_items
+    ]
     total_products = len(completeness_items)
     overall_completeness = (sum(scores) / total_products) if total_products else 0.0
 
@@ -336,7 +340,9 @@ async def get_truth_analytics_throughput(
     }
 
     for item in completeness_items:
-        event_time = _extract_event_time(item, ["generated_at", "created_at", "timestamp", "updated_at"])
+        event_time = _extract_event_time(
+            item, ["generated_at", "created_at", "timestamp", "updated_at"]
+        )
         if event_time is None:
             continue
         bucket_key = _bucket_for_timestamp(

--- a/apps/crud-service/tests/unit/test_truth_layer_routes.py
+++ b/apps/crud-service/tests/unit/test_truth_layer_routes.py
@@ -422,8 +422,16 @@ class TestCompletenessRoutes:
             {"id": "p-2", "status": "rejected", "reviewed_at": (now - minute * 4).isoformat()},
         ]
         audit_items = [
-            {"id": "a-1", "action": "enrichment_completed", "timestamp": (now - minute * 33).isoformat()},
-            {"id": "a-2", "action": "enrichment_completed", "timestamp": (now - minute * 3).isoformat()},
+            {
+                "id": "a-1",
+                "action": "enrichment_completed",
+                "timestamp": (now - minute * 33).isoformat(),
+            },
+            {
+                "id": "a-2",
+                "action": "enrichment_completed",
+                "timestamp": (now - minute * 3).isoformat(),
+            },
         ]
 
         with (


### PR DESCRIPTION
## Summary
- Adds CRUD-owned canonical truth analytics endpoints:
  - GET /api/truth/analytics/summary
  - GET /api/truth/analytics/completeness
  - GET /api/truth/analytics/throughput
- Adds response models and aggregation logic for required summary fields.
- Adds category-aware completeness aggregation and time-window throughput series.
- Adds targeted unit tests for contract shape and key calculations.

## Issue
Closes #494

## Validation
- python -m pytest apps/crud-service/tests/unit/test_truth_layer_routes.py -k truth_analytics -q
- python -m pytest tests/unit/test_main_composition_and_connectors.py -k route_groups -q