### PR TITLE
feat(lib): normalize Foundry trace event contracts with outcome_status and model_tier

### DIFF
--- a/docs/implementation/telemetry-envelope-v1.md
+++ b/docs/implementation/telemetry-envelope-v1.md
@@ -1,22 +1,210 @@
 # Telemetry envelope v1
 
-This document defines the minimum telemetry event envelope for shared `lib` emission paths.
+This document defines the telemetry event envelope for shared `lib` emission paths via `FoundryTracer`.
 
-## Required dimensions
+**Source of truth**: `lib/src/holiday_peak_lib/utils/telemetry.py`
 
-| Field | Type | Description |
+---
+
+## 1. Required envelope dimensions
+
+Every event emitted by `FoundryTracer._record()` includes these fields:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `timestamp` | `string` | Yes | UTC ISO-8601 timestamp of emission. |
+| `service` | `string` | Yes | Service name emitting the event (e.g. `"ecommerce-catalog-search"`). |
+| `operation` | `string` | Yes | Logical operation/target for the event (maps to `name`). |
+| `trace_id` | `string \| null` | Yes | Distributed trace identifier from metadata or active span context. |
+| `correlation_id` | `string \| null` | Yes | Request correlation identifier from metadata or request context. |
+| `status` | `string` | Yes | Raw outcome/status value for the event (same as `outcome`). |
+| `latency_ms` | `number \| null` | Yes | Latency in milliseconds (reads `latency_ms`, `elapsed_ms`, or `duration_ms` from metadata). |
+| `type` | `string` | Yes | Event type: `model_invocation`, `tool_call`, `decision`. |
+| `name` | `string` | Yes | Event-specific name (model target, tool name, or decision type). |
+| `outcome` | `string` | Yes | Semantic outcome string (service-specific, e.g. `"slm"`, `"skip_no_gaps"`). |
+| `outcome_status` | `string` | Yes | **Normalized** status enum: `success \| error \| degraded \| skipped \| pending`. |
+| `metadata` | `object` | Yes | Event-specific key-value payload. |
+
+## 2. Normalized `outcome_status` enum
+
+The `outcome_status` field normalizes the free-form `outcome` string into a machine-parsable enum. This enables UI aggregators to classify events without per-service special-casing.
+
+| Value | Meaning | Example outcomes mapped |
 |---|---|---|
-| `service` | `string` | Service name emitting the event. |
-| `operation` | `string` | Logical operation/target for the event. |
-| `trace_id` | `string \| null` | Distributed trace identifier from metadata or active span context. |
-| `correlation_id` | `string \| null` | Request correlation identifier from metadata or request context. |
-| `status` | `string` | Outcome/status value for the event. |
-| `latency_ms` | `number \| null` | Latency in milliseconds (`latency_ms`, `elapsed_ms`, or `duration_ms`). |
-| `timestamp` | `string` | UTC ISO-8601 timestamp of emission. |
+| `success` | Operation completed normally | `success`, `ok`, `completed`, `enrich`, `slm`, `llm`, `keyword`, `intelligent`, `provider_controlled`, `llm_by_complexity` |
+| `error` | Operation failed | `error`, `failed`, `failure`, `timeout`, `exception`, or any outcome containing `"error"` or `"fail"` |
+| `degraded` | Operation completed with reduced quality | `degraded`, `fallback`, `partial` |
+| `skipped` | Operation intentionally not performed | `skip`, `skip_no_gaps`, `skipped`, `no_upgrade`, `noop`, `missing_entity_id`, `product_not_found` |
+| `pending` | Operation started, not yet resolved | `pending`, `start`, `queued`, `in_progress` |
 
-## Compatibility notes
+**Default**: Unrecognized outcomes map to `success` (model selection results like `"llm_by_slm_upgrade"` are successful routing decisions).
 
-- Existing fields are preserved where present (for example `type`, `name`, `outcome`, and `metadata`).
+## 3. Event type catalog
+
+### 3.1 `model_invocation`
+
+Emitted when a model target is invoked. One event per model call.
+
+| Metadata key | Type | Required | Description |
+|---|---|---|---|
+| `model` | `string` | Yes | Model deployment name (e.g. `"gpt-5"`, `"phi-4-mini"`). |
+| `model_tier` | `string` | Yes | Routing tier: `slm \| llm \| unknown`. Derived from agent config. |
+| `elapsed_ms` | `number` | Yes | Invocation wall-clock time in milliseconds. |
+| `stream` | `boolean` | No | Whether streaming was enabled. |
+| `temperature` | `number` | No | Temperature parameter used. |
+| `top_p` | `number` | No | Top-p parameter used. |
+| `error` | `string \| null` | No | Error text if outcome is `error`. |
+
+**Example**:
+```json
+{
+  "timestamp": "2026-03-24T14:30:00.000Z",
+  "service": "ecommerce-catalog-search",
+  "operation": "rich",
+  "trace_id": "abc123",
+  "correlation_id": "req-456",
+  "status": "success",
+  "latency_ms": 120.5,
+  "type": "model_invocation",
+  "name": "rich",
+  "outcome": "success",
+  "outcome_status": "success",
+  "metadata": {
+    "model": "gpt-5",
+    "model_tier": "llm",
+    "elapsed_ms": 120.5,
+    "stream": false,
+    "temperature": 0.2,
+    "top_p": 0.9,
+    "error": null
+  }
+}
+```
+
+### 3.2 `tool_call`
+
+Emitted for each tool declared in a model invocation payload. Records tool participation in the call.
+
+| Metadata key | Type | Required | Description |
+|---|---|---|---|
+| (inherits from parent model call) | — | — | Metadata from the parent `model_invocation` unless overridden. |
+
+**Example**:
+```json
+{
+  "timestamp": "2026-03-24T14:30:00.100Z",
+  "service": "ecommerce-catalog-search",
+  "operation": "search_catalog",
+  "trace_id": "abc123",
+  "correlation_id": "req-456",
+  "status": "success",
+  "latency_ms": 120.5,
+  "type": "tool_call",
+  "name": "search_catalog",
+  "outcome": "success",
+  "outcome_status": "success",
+  "metadata": {
+    "elapsed_ms": 120.5,
+    "stream": false,
+    "temperature": 0.2,
+    "top_p": 0.9,
+    "error": null
+  }
+}
+```
+
+### 3.3 `decision`
+
+Emitted for agent routing and workflow decisions. Domain-specific decisions are encouraged — the `outcome_status` normalizer handles classification.
+
+| Metadata key | Type | Required | Description |
+|---|---|---|---|
+| (service-specific) | varies | No | Decision-specific context keys (e.g. `entity_id`, `reason`, `has_slm`). |
+
+**Common decision names from `base_agent.py`**:
+
+| `name` (decision) | Typical `outcome` values | Normalized `outcome_status` |
+|---|---|---|
+| `invoke_model` | `start` | `pending` |
+| `routing_strategy` | `provider_controlled` | `success` |
+| `model_upgrade` | `llm_by_complexity`, `llm_by_slm_upgrade` | `success` |
+| `model_selection` | `slm`, `<target_name>` | `success` |
+
+**Common service-specific decisions**:
+
+| Service | Decision name | Typical outcomes | Normalized |
+|---|---|---|---|
+| `truth-enrichment` | `enrichment_request_validation` | `missing_entity_id` | `skipped` |
+| `truth-enrichment` | `enrichment_lookup` | `product_not_found` | `skipped` |
+| `truth-enrichment` | `enrichment_decision` | `skip_no_gaps`, `enrich` | `skipped`, `success` |
+| `ecommerce-catalog-search` | `search_mode_selection` | `keyword`, `intelligent` | `success` |
+| `search-enrichment-agent` | `search_enrichment_validation` | `missing_entity_id` | `skipped` |
+| `search-enrichment-agent` | `search_enrichment_strategy` | strategy name | `success` |
+
+**Example**:
+```json
+{
+  "timestamp": "2026-03-24T14:30:00.050Z",
+  "service": "truth-enrichment",
+  "operation": "enrichment_decision",
+  "trace_id": "abc123",
+  "correlation_id": "req-456",
+  "status": "skip_no_gaps",
+  "latency_ms": null,
+  "type": "decision",
+  "name": "enrichment_decision",
+  "outcome": "skip_no_gaps",
+  "outcome_status": "skipped",
+  "metadata": {
+    "entity_id": "sku-12345",
+    "schema_category": "apparel"
+  }
+}
+```
+
+### 3.4 `evaluation` (via `record_evaluation`)
+
+Recorded separately from the trace stream. Represents agent evaluation payloads for quality tracking.
+
+| Metadata key | Type | Required | Description |
+|---|---|---|---|
+| `operation` | `string` | No | Defaults to `"evaluation"`. |
+| `status` | `string` | No | Defaults to `"recorded"`. |
+| (domain-specific) | varies | No | Evaluation metrics, scores, details. |
+
+## 4. Endpoint contracts
+
+Events are exposed via auto-registered FastAPI endpoints in `app_factory_components/endpoints.py`:
+
+| Endpoint | Response shape | Notes |
+|---|---|---|
+| `GET /agent/traces?limit=N` | `{ "service": str, "traces": [event, ...] }` | Most recent `N` events (default 50, max `FOUNDRY_TRACING_MAX_EVENTS`). Reverse chronological. |
+| `GET /agent/metrics` | `{ "service": str, "enabled": bool, "app_insights_configured": bool, "traces_buffered": int, "instrumentation": {...}, "counts": {...} }` | Aggregate counters keyed by `{event_type}` and `{event_type}:{outcome}`. |
+| `GET /agent/evaluation/latest` | `{ "service": str, "latest": event \| null }` | Most recent evaluation payload or `null`. |
+
+## 5. Resolution precedence
+
+| Field | Priority 1 (highest) | Priority 2 | Fallback |
+|---|---|---|---|
+| `trace_id` | `metadata["trace_id"]` | `metadata["traceId"]` or `metadata["operation_id"]` | Active OpenTelemetry span context |
+| `correlation_id` | `metadata["correlation_id"]` | Request-scoped context var | `null` |
+| `latency_ms` | `metadata["latency_ms"]` | `metadata["elapsed_ms"]` | `metadata["duration_ms"]` |
+
+## 6. Service onboarding checklist
+
+To emit compliant telemetry events from a new agent service:
+
+- [ ] **Extend `BaseRetailAgent`** — model invocation, tool, and decision tracing are automatic via `invoke_model()`.
+- [ ] **Use `_trace_decision()`** for domain-specific decisions with descriptive `decision` and `outcome` strings.
+- [ ] **Use `_trace_tools()`** only if you need to trace tools outside the standard `invoke_model` flow.
+- [ ] **Pass `model_tier`** when calling `trace_model_invocation()` directly (automatic when using `BaseRetailAgent.__invoke_target`).
+- [ ] **Include `entity_id`** in decision metadata when the operation targets a specific entity.
+- [ ] **Verify endpoint availability** — `GET /agent/traces`, `/agent/metrics`, `/agent/evaluation/latest` are auto-registered by `build_service_app()`.
+- [ ] **Test**: Run `pytest` and verify events include all required envelope fields.
+
+## 7. Compatibility notes
+
+- Existing fields (`type`, `name`, `outcome`, `metadata`) are preserved alongside the normalized fields.
+- `outcome_status` is computed from `outcome` at emission time — never set by callers.
+- `model_tier` defaults to `"unknown"` when not provided.
 - `trace_id` and `correlation_id` may be `null` when no context is available.
-- Correlation precedence: event metadata value first, then request context.
-- Trace precedence: event metadata value first, then active OpenTelemetry span context.

--- a/lib/src/holiday_peak_lib/agents/base_agent.py
+++ b/lib/src/holiday_peak_lib/agents/base_agent.py
@@ -347,12 +347,23 @@ class BaseRetailAgent(BaseAgent, ABC):
                 "error": error_text,
             }
             try:
+                # Derive model_tier from config
+                model_tier = "unknown"
+                if self.slm and target.name == self.slm.name:
+                    model_tier = "slm"
+                elif self.llm and target.name == self.llm.name:
+                    model_tier = "llm"
+
                 self._get_foundry_tracer().trace_model_invocation(
                     model=target.model,
                     target=target.name,
                     outcome=outcome,
+                    model_tier=model_tier,
                     metadata=trace_metadata,
                 )
+                # Tools are traced with model outcome when they participated
+                # in the invocation; individual tool execution tracking
+                # is handled at the adapter/handler level.
                 self._trace_tools(payload_tools, outcome, trace_metadata)
             except (AttributeError, TypeError, ValueError, RuntimeError):
                 pass

--- a/lib/src/holiday_peak_lib/utils/telemetry.py
+++ b/lib/src/holiday_peak_lib/utils/telemetry.py
@@ -100,6 +100,82 @@ def _extract_latency_ms(metadata: dict[str, Any] | None) -> float | None:
     return None
 
 
+# --- Outcome normalization ---
+_SUCCESS_OUTCOMES = frozenset(
+    {
+        "success",
+        "ok",
+        "completed",
+        "enrich",
+        "slm",
+        "llm",
+        "keyword",
+        "intelligent",
+        "provider_controlled",
+    }
+)
+_ERROR_OUTCOMES = frozenset(
+    {
+        "error",
+        "failed",
+        "failure",
+        "timeout",
+        "exception",
+    }
+)
+_SKIPPED_OUTCOMES = frozenset(
+    {
+        "skip",
+        "skip_no_gaps",
+        "skipped",
+        "no_upgrade",
+        "noop",
+        "missing_entity_id",
+        "product_not_found",
+    }
+)
+_DEGRADED_OUTCOMES = frozenset(
+    {
+        "degraded",
+        "fallback",
+        "partial",
+    }
+)
+_PENDING_OUTCOMES = frozenset(
+    {
+        "pending",
+        "start",
+        "queued",
+        "in_progress",
+    }
+)
+
+
+def _normalize_outcome_status(outcome: str) -> str:
+    """Map a semantic outcome string to a normalized status enum.
+
+    Returns one of: ``success``, ``error``, ``degraded``, ``skipped``, ``pending``.
+    Falls back to ``success`` for unknown positive-sounding outcomes (e.g. model
+    selection results like ``"slm"``, ``"llm_by_complexity"``).
+    """
+    lower = outcome.strip().lower()
+    if lower in _ERROR_OUTCOMES:
+        return "error"
+    if lower in _SKIPPED_OUTCOMES:
+        return "skipped"
+    if lower in _DEGRADED_OUTCOMES:
+        return "degraded"
+    if lower in _PENDING_OUTCOMES:
+        return "pending"
+    if lower in _SUCCESS_OUTCOMES:
+        return "success"
+    # Heuristic: outcomes containing "error" or "fail" are errors
+    if "error" in lower or "fail" in lower:
+        return "error"
+    # Default: treat unrecognized outcomes as success (model selections, etc.)
+    return "success"
+
+
 def _trace_id_from_otel() -> str | None:
     if not _OTEL_AVAILABLE:
         return None
@@ -258,6 +334,7 @@ class FoundryTracer:
             "type": event_type,
             "name": name,
             "outcome": outcome,
+            "outcome_status": _normalize_outcome_status(outcome),
             "metadata": event_metadata,
         }
         with self._lock:
@@ -271,6 +348,7 @@ class FoundryTracer:
         model: str,
         target: str,
         outcome: str,
+        model_tier: str | None = None,
         metadata: dict[str, Any] | None = None,
     ) -> None:
         self._record(
@@ -279,6 +357,7 @@ class FoundryTracer:
             outcome,
             {
                 "model": model,
+                "model_tier": model_tier or "unknown",
                 **(metadata or {}),
             },
         )

--- a/lib/tests/test_telemetry.py
+++ b/lib/tests/test_telemetry.py
@@ -174,3 +174,157 @@ class TestFoundryTracer:
         tracer_a = get_foundry_tracer("svc-singleton")
         tracer_b = get_foundry_tracer("svc-singleton")
         assert tracer_a is tracer_b
+
+
+class TestNormalizeOutcomeStatus:
+    """Tests for _normalize_outcome_status()."""
+
+    def test_success_outcomes(self):
+        from holiday_peak_lib.utils.telemetry import _normalize_outcome_status
+
+        for outcome in (
+            "success",
+            "ok",
+            "completed",
+            "enrich",
+            "slm",
+            "llm",
+            "keyword",
+            "intelligent",
+            "provider_controlled",
+        ):
+            assert _normalize_outcome_status(outcome) == "success", f"Failed for {outcome}"
+
+    def test_error_outcomes(self):
+        from holiday_peak_lib.utils.telemetry import _normalize_outcome_status
+
+        for outcome in ("error", "failed", "failure", "timeout", "exception"):
+            assert _normalize_outcome_status(outcome) == "error", f"Failed for {outcome}"
+
+    def test_skipped_outcomes(self):
+        from holiday_peak_lib.utils.telemetry import _normalize_outcome_status
+
+        for outcome in (
+            "skip",
+            "skip_no_gaps",
+            "skipped",
+            "no_upgrade",
+            "noop",
+            "missing_entity_id",
+            "product_not_found",
+        ):
+            assert _normalize_outcome_status(outcome) == "skipped", f"Failed for {outcome}"
+
+    def test_degraded_outcomes(self):
+        from holiday_peak_lib.utils.telemetry import _normalize_outcome_status
+
+        for outcome in ("degraded", "fallback", "partial"):
+            assert _normalize_outcome_status(outcome) == "degraded", f"Failed for {outcome}"
+
+    def test_pending_outcomes(self):
+        from holiday_peak_lib.utils.telemetry import _normalize_outcome_status
+
+        for outcome in ("pending", "start", "queued", "in_progress"):
+            assert _normalize_outcome_status(outcome) == "pending", f"Failed for {outcome}"
+
+    def test_heuristic_error_detection(self):
+        from holiday_peak_lib.utils.telemetry import _normalize_outcome_status
+
+        assert _normalize_outcome_status("connection_error") == "error"
+        assert _normalize_outcome_status("auth_failure") == "error"
+
+    def test_unknown_defaults_to_success(self):
+        from holiday_peak_lib.utils.telemetry import _normalize_outcome_status
+
+        assert _normalize_outcome_status("llm_by_complexity") == "success"
+        assert _normalize_outcome_status("llm_by_slm_upgrade") == "success"
+        assert _normalize_outcome_status("some_custom_value") == "success"
+
+    def test_case_insensitive(self):
+        from holiday_peak_lib.utils.telemetry import _normalize_outcome_status
+
+        assert _normalize_outcome_status("SUCCESS") == "success"
+        assert _normalize_outcome_status("Error") == "error"
+        assert _normalize_outcome_status(" PENDING ") == "pending"
+
+
+class TestOutcomeStatusInEvents:
+    """Tests that outcome_status appears in all traced events."""
+
+    def test_model_invocation_has_outcome_status(self, monkeypatch):
+        monkeypatch.setenv("FOUNDRY_TRACING_ENABLED", "true")
+        tracer = FoundryTracer("svc", max_events=5)
+        tracer.trace_model_invocation(
+            model="gpt-5",
+            target="rich",
+            outcome="success",
+            model_tier="llm",
+            metadata={"elapsed_ms": 10.0},
+        )
+        event = tracer.get_traces(limit=1)[0]
+        assert event["outcome_status"] == "success"
+        assert event["metadata"]["model_tier"] == "llm"
+
+    def test_model_invocation_error_outcome_status(self, monkeypatch):
+        monkeypatch.setenv("FOUNDRY_TRACING_ENABLED", "true")
+        tracer = FoundryTracer("svc", max_events=5)
+        tracer.trace_model_invocation(
+            model="gpt-5",
+            target="rich",
+            outcome="error",
+            metadata={"elapsed_ms": 5.0, "error": "timeout"},
+        )
+        event = tracer.get_traces(limit=1)[0]
+        assert event["outcome_status"] == "error"
+
+    def test_tool_call_has_outcome_status(self, monkeypatch):
+        monkeypatch.setenv("FOUNDRY_TRACING_ENABLED", "true")
+        tracer = FoundryTracer("svc", max_events=5)
+        tracer.trace_tool_call(tool_name="search", outcome="success", metadata={})
+        event = tracer.get_traces(limit=1)[0]
+        assert event["outcome_status"] == "success"
+
+    def test_decision_has_outcome_status(self, monkeypatch):
+        monkeypatch.setenv("FOUNDRY_TRACING_ENABLED", "true")
+        tracer = FoundryTracer("svc", max_events=5)
+        tracer.trace_decision(
+            decision="model_selection",
+            outcome="slm",
+            metadata={"reason": "no_upgrade"},
+        )
+        event = tracer.get_traces(limit=1)[0]
+        assert event["outcome_status"] == "success"
+
+    def test_decision_skipped_outcome_status(self, monkeypatch):
+        monkeypatch.setenv("FOUNDRY_TRACING_ENABLED", "true")
+        tracer = FoundryTracer("svc", max_events=5)
+        tracer.trace_decision(
+            decision="enrichment_decision",
+            outcome="skip_no_gaps",
+            metadata={"entity_id": "sku-1"},
+        )
+        event = tracer.get_traces(limit=1)[0]
+        assert event["outcome_status"] == "skipped"
+
+    def test_decision_pending_outcome_status(self, monkeypatch):
+        monkeypatch.setenv("FOUNDRY_TRACING_ENABLED", "true")
+        tracer = FoundryTracer("svc", max_events=5)
+        tracer.trace_decision(
+            decision="invoke_model",
+            outcome="start",
+            metadata={"has_slm": True, "has_llm": True},
+        )
+        event = tracer.get_traces(limit=1)[0]
+        assert event["outcome_status"] == "pending"
+
+    def test_model_tier_defaults_to_unknown(self, monkeypatch):
+        monkeypatch.setenv("FOUNDRY_TRACING_ENABLED", "true")
+        tracer = FoundryTracer("svc", max_events=5)
+        tracer.trace_model_invocation(
+            model="gpt-5",
+            target="rich",
+            outcome="success",
+            metadata={"elapsed_ms": 10.0},
+        )
+        event = tracer.get_traces(limit=1)[0]
+        assert event["metadata"]["model_tier"] == "unknown"


### PR DESCRIPTION
## Summary
Completes Phase 1 of the Live Demo Truth Program by normalizing Foundry trace event contracts and publishing the telemetry contract documentation.

### Changes

**telemetry.py** - Added outcome_status enum normalization and model_tier parameter
**base_agent.py** - Derives model_tier from SLM/LLM config in __invoke_target
**test_telemetry.py** - 15 new tests for normalization and event fields
**telemetry-envelope-v1.md** - Full spec with event catalog, endpoint contracts, onboarding checklist

### Tests
- lib/tests/test_telemetry.py: 28/28 passed
- lib/ full suite: 1029/1029 passed
- apps/ telemetry tests: 147/147 passed

Closes #517, closes #518
Refs #516