### PR TITLE
fix: implement isDevAuthMockEnabled env var checks (#524)

### DIFF
--- a/apps/ui/lib/auth/authCookie.ts
+++ b/apps/ui/lib/auth/authCookie.ts
@@ -88,6 +88,12 @@ async function getSigningKey(secret: string): Promise<CryptoKey> {
 }
 
 export function isDevAuthMockEnabled(): boolean {
+  const mockEnabled = process.env.DEV_AUTH_MOCK === 'true';
+  if (!mockEnabled) return false;
+
+  const isProduction = process.env.NODE_ENV === 'production';
+  if (isProduction && process.env.DEV_AUTH_MOCK_ALLOW_PROD !== 'true') return false;
+
   return true;
 }
 


### PR DESCRIPTION
## Summary
The `isDevAuthMockEnabled()` function in `authCookie.ts` was hardcoded to `return true`, breaking all mock auth tests in CI (`test/ui-quality`).

Closes #524

## Root Cause
The function was left as a stub during development, always returning `true` regardless of environment variables.

## Fix
Replaced with proper logic:
1. Return `false` if `DEV_AUTH_MOCK` is not `'true'`
2. Return `false` in production unless `DEV_AUTH_MOCK_ALLOW_PROD` is `'true'`
3. Otherwise return `true`

## Verification
- All 7 `mockAuthRoutes.test.ts` tests pass locally
- TypeScript compiles clean (`tsc --noEmit`)

## File Changed
- `apps/ui/lib/auth/authCookie.ts`