### PR TITLE
fix: complete ui-quality test fixes (#524)

### DIFF
--- a/apps/ui/lib/auth/msalConfig.ts
+++ b/apps/ui/lib/auth/msalConfig.ts
@@ -6,7 +6,15 @@ const entraClientId = process.env.NEXT_PUBLIC_ENTRA_CLIENT_ID || '';
 const entraTenantId = process.env.NEXT_PUBLIC_ENTRA_TENANT_ID || '';
 
 export const isEntraConfigured = Boolean(entraClientId && entraTenantId);
-export const isDevAuthMockUiEnabled = true;
+export const isDevAuthMockUiEnabled = (() => {
+  const mockEnabled = process.env.NEXT_PUBLIC_DEV_AUTH_MOCK === 'true';
+  if (!mockEnabled) return false;
+
+  const isProduction = process.env.NODE_ENV === 'production';
+  if (isProduction && process.env.NEXT_PUBLIC_DEV_AUTH_MOCK_ALLOW_PROD !== 'true') return false;
+
+  return true;
+})();
 
 export const getMissingEntraConfigKeys = (): string[] => {
   const missing: string[] = [];

--- a/apps/ui/tests/unit/SearchPage.test.tsx
+++ b/apps/ui/tests/unit/SearchPage.test.tsx
@@ -29,6 +29,14 @@ jest.mock('../../components/atoms/ThemeToggle', () => ({
   ThemeToggle: () => <div data-testid="theme-toggle" />,
 }));
 
+jest.mock('../../components/organisms/Navigation', () => ({
+  Navigation: ({ onSearch }: { onSearch?: (query: string) => void }) => (
+    <nav data-testid="navigation-mock">
+      {onSearch && <button onClick={() => onSearch('test')}>search</button>}
+    </nav>
+  ),
+}));
+
 describe('SearchPage', () => {
   const setPreference = jest.fn();
 

--- a/apps/ui/tests/unit/pagesRender.test.tsx
+++ b/apps/ui/tests/unit/pagesRender.test.tsx
@@ -77,6 +77,10 @@ jest.mock('../../lib/hooks/useProducts', () => ({
     isLoading: false,
     isError: false,
   }),
+  useTriggerProductEnrichment: () => ({
+    mutateAsync: jest.fn().mockResolvedValue({ queued_at: new Date().toISOString() }),
+    isPending: false,
+  }),
 }));
 
 jest.mock('../../lib/hooks/useOrders', () => ({
@@ -482,6 +486,22 @@ jest.mock('../../lib/hooks/useTruth', () => ({
   useReviewAction: () => ({ mutate: jest.fn(), isPending: false }),
 }));
 
+jest.mock('../../components/organisms/ProductGraphCanvas', () => ({
+  ProductGraphCanvas: () => <div data-testid="product-graph" />,
+}));
+
+jest.mock('../../components/organisms/Navigation', () => ({
+  Navigation: ({ onSearch }: { onSearch?: (query: string) => void }) => (
+    <nav data-testid="navigation-mock">
+      {onSearch && <button onClick={() => onSearch('test')}>search</button>}
+    </nav>
+  ),
+}));
+
+jest.mock('../../lib/hooks/useRelatedProducts', () => ({
+  useRelatedProducts: () => ({ data: {} }),
+}));
+
 jest.mock('@/components/templates/MainLayout', () => ({
   MainLayout: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="main-layout">{children}</div>
@@ -507,11 +527,9 @@ describe('Page rendering smoke tests', () => {
     });
   });
 
-  it('renders the home page hero', () => {
+  it('renders the home page', () => {
     render(<HomePage />);
-    expect(
-      screen.getByText('Plan Your Peak Weekend Cart')
-    ).toBeInTheDocument();
+    expect(screen.getByTestId('main-layout')).toBeInTheDocument();
   });
 
   it('renders categories page heading', () => {


### PR DESCRIPTION
## Summary
Follows PR #525 which fixed `isDevAuthMockEnabled()` in `authCookie.ts`. This PR fixes the remaining `test/ui-quality` failures.

## Changes
### `apps/ui/lib/auth/msalConfig.ts`
- Replace hardcoded `isDevAuthMockUiEnabled = true` with env var logic
- Uses `NEXT_PUBLIC_DEV_AUTH_MOCK` + `NEXT_PUBLIC_DEV_AUTH_MOCK_ALLOW_PROD` (client-side counterpart of server-side `authCookie.ts`)

### `apps/ui/tests/unit/SearchPage.test.tsx`
- Add missing `Navigation` component mock (prevents `useAuth()` outside `AuthProvider` crash)

### `apps/ui/tests/unit/pagesRender.test.tsx`
- Add missing mocks: `Navigation`, `ProductGraphCanvas`, `useRelatedProducts`, `useTriggerProductEnrichment`
- Update home page test assertion (hero text removed in redesign)

## Verification
- All 29 UI test suites pass (144 tests)
- TypeScript compiles clean