### PR TITLE
chore: add --forceExit to jest CI to prevent worker leak

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Run UI type-check
         run: yarn type-check
       - name: Run UI unit tests
-        run: yarn test --ci --coverage --testPathIgnorePatterns=tests/unit/pagesRender.test.tsx
+        run: yarn test --ci --coverage --forceExit --testPathIgnorePatterns=tests/unit/pagesRender.test.tsx
       - name: Install Playwright browser
         run: yarn playwright install --with-deps chromium
       - name: Run UI E2E smoke tests


### PR DESCRIPTION
## Summary
Jest worker processes fail to exit gracefully due to lingering timers/handles in React test teardown, causing exit code 1 even when all 28 test suites pass.

Adding `--forceExit` to the CI jest command resolves the false failure.

## File Changed
- `.github/workflows/test.yml`