### PR TITLE
docs: add detailed business scenario workflow guides

### DIFF
--- a/docs/business_scenarios/01-order-to-fulfillment/README.md
+++ b/docs/business_scenarios/01-order-to-fulfillment/README.md
@@ -60,3 +60,7 @@ Checkout in this scenario runs on the live CRUD payment path (no stubbed success
 6. `GET /api/payments/{payment_id}` supports post-checkout payment retrieval (customer ownership, staff/admin override).
 
 Business impact: confirmation is tied to provider-backed payment state and auditable order/payment linkage, preserving payment-to-shipment continuity targets.
+
+## Detailed Walkthroughs
+
+- [Customer Cart, Checkout, and Order Confirmation](customer-cart-checkout-and-order-confirmation.md)

--- a/docs/business_scenarios/01-order-to-fulfillment/customer-cart-checkout-and-order-confirmation.md
+++ b/docs/business_scenarios/01-order-to-fulfillment/customer-cart-checkout-and-order-confirmation.md
@@ -1,0 +1,154 @@
+# Customer Cart, Checkout, and Order Confirmation
+
+## Purpose
+
+Use this walkthrough when you want to validate the current customer checkout experience from cart review through order confirmation.
+
+## Current State Summary
+
+| Item | Current behavior |
+| --- | --- |
+| Role required | `customer` |
+| Recommended entry point | `/cart` |
+| Main navigation access | Cart icon in the top-right header |
+| Checkout status | Implemented and working |
+| Important limitation | The current storefront `Add to Cart` buttons are not wired to the cart mutation yet. Start this walkthrough with a cart that already contains items. |
+
+## Before You Start
+
+1. Sign in as a customer.
+2. If development mock login is enabled, open `/auth/login` and click `Sign in as Customer`.
+3. Make sure the cart already contains at least one item. If it is empty, this walkthrough cannot continue from the UI alone.
+
+## Exact Click Path
+
+1. Click the cart icon in the header.
+2. On the `Cart` page, review the items table.
+3. Click `Proceed to checkout`.
+4. Complete the `Shipping Information` form.
+5. Click `Continue to Payment`.
+6. Choose a shipping method.
+7. Complete the Stripe payment form.
+8. Click `Pay & Place Order`.
+9. Wait for the redirect to the order details page.
+
+## Screen-by-Screen Walkthrough
+
+### Step 1: Open the cart
+
+1. Look at the header in the top-right area.
+2. Click the cart icon.
+3. Confirm you are on the `Cart` page.
+4. Verify the page shows a table with these columns:
+   - `Product`
+   - `Quantity`
+   - `Unit Price`
+   - `Line Total`
+   - `Actions`
+
+### Step 2: Review or clean up the cart
+
+1. If you want to remove one item, click `Remove` on that row.
+2. If you want to empty the entire cart, click `Clear cart` in the page header.
+3. Confirm the summary card at the bottom shows the `Total` value.
+4. If the cart is empty, stop here and load cart data before testing checkout.
+
+### Step 3: Enter shipping information
+
+1. Click `Proceed to checkout`.
+2. On the checkout screen, stay on `Step 1` with the title `Shipping Information`.
+3. Fill in every required field exactly once:
+   - `First Name (Required)`
+   - `Last Name (Required)`
+   - `Email Address (Required)`
+   - `Phone Number (Required)`
+   - `Street Address (Required)`
+   - `City (Required)`
+   - `State (Required)`
+   - `ZIP Code (Required)`
+4. Optionally enable `Save this address for future orders (Optional)`.
+5. If you intentionally leave a field blank, the screen should show a red validation message directly under that field.
+6. Click `Continue to Payment`.
+
+## What should happen after shipping submission
+
+1. The UI validates the form.
+2. The UI validates checkout readiness.
+3. The UI creates inventory reservations for the current cart items.
+4. The UI creates the order record.
+5. The UI creates a Stripe payment intent.
+6. The page advances to the payment step.
+
+If anything in that sequence fails before the order is created, the page should show a visible setup error message and keep you on the same screen.
+
+## Step 4: Review shipping method and order summary
+
+1. After the page advances, confirm you now see two cards in the main content area:
+   - `Shipping Method`
+   - `Payment Information`
+2. In `Shipping Method`, choose one option:
+   - `Standard Shipping`
+   - `Express Shipping`
+   - `Overnight Shipping`
+3. Watch the order summary on the right side.
+4. Confirm the summary updates these values:
+   - `Subtotal`
+   - `Shipping`
+   - `Tax`
+   - `Total`
+
+## Step 5: Use the inventory signals block
+
+1. In the order summary card, scroll to the section named `Scenario 04 Signals`.
+2. Review the helper information shown there:
+   - `Health`
+   - `Threshold breaches`
+   - `Replenishment triggers`
+   - `Reservation outcomes`
+3. If the helper services are temporarily unavailable, the page may show buttons such as:
+   - `Retry signal checks`
+   - `Continue without live signals`
+   - `Retry health check`
+   - `Retry reservation outcomes`
+4. Use `Continue without live signals` only when you want to continue the demo despite unavailable helper telemetry.
+
+## Step 6: Complete payment
+
+1. Move to the `Payment Information` card.
+2. Complete the Stripe payment element.
+3. Click `Pay & Place Order`.
+4. If the provider authorizes payment but final order completion fails, the screen may show `Retry Finalization`.
+5. If that button appears, click it once and wait for the result.
+
+## Step 7: Confirm the order was finalized
+
+1. After a successful payment and reservation confirmation, the UI redirects to `/order/{id}`.
+2. On the order detail screen, confirm you can see:
+   - the order ID
+   - the order status badge
+   - the ordered item table
+   - the total amount
+3. Treat that redirect as the success state for this workflow.
+
+## Expected Success Signals
+
+| Check | Expected result |
+| --- | --- |
+| Cart page | Items and totals render without error |
+| Shipping form | Required-field validation appears inline |
+| Payment step | Shipping method selector and Stripe payment element appear |
+| Finalization | Browser redirects to `/order/{id}` |
+| Order page | Order metadata and items are visible |
+
+## Troubleshooting
+
+| Symptom | What it means right now |
+| --- | --- |
+| `Your cart is empty` | The checkout UI is working, but the storefront does not yet populate the cart from product cards. |
+| `Cart could not be loaded` | Authentication or CRUD connectivity is failing. |
+| `Payments are currently unavailable` | `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` or payment backend configuration is missing. |
+| `Payment intent is not available` | Checkout setup failed before Stripe payment could be initialized. Go back to shipping and retry. |
+
+## Scope Boundary
+
+This walkthrough documents the current working checkout surface. It does not claim that cart population is fully user-drivable from the catalog UI yet.

--- a/docs/business_scenarios/02-product-discovery-enrichment/README.md
+++ b/docs/business_scenarios/02-product-discovery-enrichment/README.md
@@ -61,3 +61,8 @@ Implemented and operational in platform deployment/runtime paths:
 - Add vector embeddings + weighted hybrid query tuning (current path is keyword/SKU retrieval).
 - Add index relevance/load evaluation suites and SLO-driven alert thresholds.
 - Add stricter index/schema drift validation in CI pre-deploy checks.
+
+## Detailed Walkthroughs
+
+- [Intelligent Search and Agent Comparison](intelligent-search-and-agent-comparison.md)
+- [Category Browsing and Product Detail Exploration](category-browsing-and-product-detail.md)

--- a/docs/business_scenarios/02-product-discovery-enrichment/category-browsing-and-product-detail.md
+++ b/docs/business_scenarios/02-product-discovery-enrichment/category-browsing-and-product-detail.md
@@ -1,0 +1,96 @@
+# Category Browsing and Product Detail Exploration
+
+## Purpose
+
+Use this walkthrough to navigate from category discovery into a product detail page and exercise the current enrichment-focused controls on that screen.
+
+## Current State Summary
+
+| Item | Current behavior |
+| --- | --- |
+| Role required | Public or signed-in customer |
+| Main navigation access | `Catalog` in the top navigation |
+| Primary routes | `/categories`, `/category?slug=...`, `/product/{id}` |
+| Working status | Implemented and working |
+
+## Exact Click Path
+
+1. Click `Catalog` in the top navigation.
+2. On the category view, choose a category.
+3. On the category collection page, click a product card.
+4. On the product page, review the enrichment panels.
+5. Optionally run the fit-evaluation prompt.
+
+## Step 1: Open the category experience
+
+1. Click `Catalog` in the header.
+2. The application routes to `/category?slug=all`.
+3. If you want the category index instead, open `/categories` directly.
+4. On `/categories`, confirm you see category cards with:
+   - the category name
+   - the category description
+   - the `Agent-ready` badge
+5. If you are on the categories index, click any category card.
+
+## Step 2: Use the collection page
+
+1. On `/category?slug=...`, confirm you can see the product listing.
+2. Use the sort control to switch among options such as:
+   - relevance
+   - price ascending
+   - price descending
+   - rating
+   - newest
+3. Switch between grid view and list view if needed.
+4. Click any product card title or image.
+
+## Step 3: Review the product page layout
+
+1. Confirm the product page shows:
+   - breadcrumb navigation
+   - category buttons on the left side
+   - large product image
+   - `Agent Enriched` badge
+   - stock badge
+   - title, description, and price
+2. If available, confirm the `Enriched description` card appears.
+3. Review the enrichment-oriented rails:
+   - `UseCaseTags`
+   - `Complements`
+   - `Alternatives`
+
+## Step 4: Run the fit evaluation flow
+
+1. Click `Does this fits my case?`.
+2. Confirm a prompt card opens with the label `Describe your use case`.
+3. Enter a concrete scenario, for example: `I need this for business travel and long battery life.`
+4. Click `Evaluate fit`.
+5. Wait for the response card named `Use case evaluation`.
+6. Review the returned blocks:
+   - verdict badge such as `Fits`, `Partially fits`, or `Does not fit`
+   - confidence
+   - recommendation
+   - `Why it fits`
+   - `Possible constraints`
+7. Read the compact `AgentMessageDisplay` block at the bottom of the card.
+
+## Step 5: Use the visible enrichment trigger button carefully
+
+1. The product page currently exposes a `Trigger enrichment job` button.
+2. This is an operational control, not a normal customer-shopping control.
+3. Click it only if you are intentionally testing the enrichment pipeline.
+4. If the request succeeds, the page shows a message similar to `Queued at ...`.
+
+## Important caveat about cart behavior
+
+The product page displays an `Add to Cart` button, but in the current UI that button only tracks the click and does not populate the cart. Do not use that button as proof of a fully wired cart flow.
+
+## Success checklist
+
+| Check | Expected result |
+| --- | --- |
+| Category discovery | Category cards or full catalog collection render |
+| Product open | Product detail page loads without backend error |
+| Enrichment content | Use-case tags and related rails are visible when data exists |
+| Fit prompt | Use case evaluation renders after submission |
+| Trigger button | Optional queue confirmation appears if pipeline trigger succeeds |

--- a/docs/business_scenarios/02-product-discovery-enrichment/intelligent-search-and-agent-comparison.md
+++ b/docs/business_scenarios/02-product-discovery-enrichment/intelligent-search-and-agent-comparison.md
@@ -1,0 +1,102 @@
+# Intelligent Search and Agent Comparison
+
+## Purpose
+
+Use this walkthrough to test the current search experience, including keyword mode, intelligent mode, fallback behavior, and the popup comparison entry points.
+
+## Current State Summary
+
+| Item | Current behavior |
+| --- | --- |
+| Role required | Public or signed-in customer |
+| Main navigation access | `Search Demo` link in the top navigation, or the search box in the header |
+| Primary route | `/search` |
+| Agent comparison entry points | `Open popup comparison`, `Agent` button in the header, or `/search?agentChat=1` |
+| Working status | Implemented and working |
+
+## Exact Click Path
+
+1. Click `Search Demo` in the top navigation.
+2. Type a search query in `Search products...`.
+3. Press Enter.
+4. Choose a mode in the `SearchModeToggle` control.
+5. Watch the result cards, intent panels, and comparison scorecard update.
+6. Click any result card to open the product detail page.
+
+## Recommended Demo Flow
+
+1. Open `/search`.
+2. In the demo action bar near the top of the page, click `Run agent-friendly query`.
+3. Watch the page populate with the built-in `laptop` example.
+4. Confirm the screen shows these core areas:
+   - `Search` page title
+   - `SearchInput`
+   - search mode selector
+   - search mode indicator
+   - intent classification area
+   - result list
+
+## How to run a manual search
+
+1. Click inside the `Search products...` field.
+2. Type a natural-language query such as `best lightweight laptop for travel`.
+3. Press Enter.
+4. Confirm the URL changes to `/search?q=...`.
+5. Wait for the search results section to render.
+
+## How to switch search modes
+
+1. Look for the mode toggle directly under the main search box.
+2. Select each mode one at a time:
+   - `auto`
+   - `keyword`
+   - `intelligent`
+3. After each selection, wait for the results to refresh.
+4. Confirm the page shows a status pill similar to:
+   - `Intelligent Search • Source: Agent API`
+   - `Keyword Search • Source: CRUD Catalog`
+
+## What to look for in intelligent mode
+
+1. Confirm the `IntentClassificationDisplay` appears.
+2. Confirm the `IntentPanel` appears when the backend returns intent or subquery data.
+3. If reranking is active, the page should briefly show `Reranking baseline results in the background...`.
+4. Confirm the `SearchComparisonScorecard` appears after both baseline and reranked results are available.
+
+## How fallback behaves
+
+1. Keep the mode on `intelligent`.
+2. If the agent path is unavailable, the page should continue showing results from CRUD.
+3. In that case, confirm you see the warning box `Intelligent mode fell back to catalog`.
+4. If the proxy itself fails, confirm you see:
+   - a warning explaining catalog search is unavailable
+   - a `Retry search` button
+
+## How to use the popup comparison path
+
+1. From the top action bar on the search page, click `Open popup comparison`.
+2. You can also click the `Agent` pill in the site header.
+3. Both paths route to `/search?agentChat=1`.
+4. Use that variant when you want to demo the agent-focused search entry point without leaving the search experience.
+
+## How to inspect search trace links
+
+1. Run any non-empty search.
+2. Look for the trace link below the action bar.
+3. If the response includes a trace ID, the link label becomes `View search trace`.
+4. If no trace ID is returned, the fallback label is `View Agent Activity`.
+5. Click the link to move into the admin tracing surface.
+
+## Success checklist
+
+| Check | Expected result |
+| --- | --- |
+| Query submission | URL updates to `/search?q=...` |
+| Mode change | Search source and behavior update |
+| Intelligent mode | Intent UI and comparison scorecard appear when data is available |
+| Fallback mode | Results continue from CRUD with warning copy |
+| Result selection | Clicking a result opens the product page |
+
+## Notes about personalization and context
+
+If the user is signed in, the search request includes contextual fields such as user ID, session ID, stage, and recent query history. The user does not need to do anything special in the UI for that behavior.

--- a/docs/business_scenarios/03-returns-refund-processing/README.md
+++ b/docs/business_scenarios/03-returns-refund-processing/README.md
@@ -74,3 +74,7 @@ This scenario is implemented through CRUD lifecycle APIs and staff operations (n
 
 - Return lifecycle events are emitted to `return-events`: `ReturnRequested`, `ReturnApproved`, `ReturnRejected`, `ReturnReceived`, `ReturnRestocked`, `ReturnRefunded`
 - Refund issuance is emitted to `payment-events` as `RefundIssued`
+
+## Detailed Walkthroughs
+
+- [Customer Return Request and Refund Status](customer-return-request-and-refund-status.md)

--- a/docs/business_scenarios/03-returns-refund-processing/customer-return-request-and-refund-status.md
+++ b/docs/business_scenarios/03-returns-refund-processing/customer-return-request-and-refund-status.md
@@ -1,0 +1,95 @@
+# Customer Return Request and Refund Status
+
+## Purpose
+
+Use this walkthrough when you want to create a return from the customer surface and then follow the lifecycle through the order and orders pages.
+
+## Current State Summary
+
+| Item | Current behavior |
+| --- | --- |
+| Role required | `customer` |
+| Main navigation access | Order access is available from the profile dropdown under `My Orders` |
+| Primary routes | `/orders`, `/order/{id}` |
+| Working status | Implemented and working |
+
+## Exact Click Path
+
+1. Open the profile dropdown.
+2. Click `My Orders`.
+3. Choose an order.
+4. Click `Request Return` on the orders page, or submit the `Create Return` form on the order detail page.
+5. Revisit the same order and monitor the lifecycle table until staff completes the next steps.
+
+## Path A: Request a return from the orders list
+
+1. Open `/orders`.
+2. Use `Filter by order id or status` if you need to narrow the list.
+3. Locate the target order row.
+4. Click `Request Return`.
+5. Wait for the inline feedback under the button.
+6. A successful request shows a message like `Return {id} created with status requested.`
+7. If a return is already active, the row shows `Return lifecycle in progress: ...` and the button is disabled.
+
+## Path B: Request a return from the order detail page
+
+1. On `/orders`, click the order ID link.
+2. On `/order/{id}`, scroll to the `Create Return` card.
+3. Read the lifecycle note explaining the sequence:
+   - requested
+   - approved or rejected
+   - received
+   - restocked
+   - refunded
+4. In `Reason for return`, enter a customer-friendly reason.
+5. Click `Create Return`.
+6. Wait for one of these messages:
+   - success: `Return request created. Staff review SLA target is 24 hours.`
+   - failure: `Return could not be created. Verify order ownership and lifecycle constraints.`
+
+## How to read return status on the order page
+
+1. Stay on `/order/{id}`.
+2. Scroll to `Returns for this order`.
+3. Review the table columns:
+   - `Return`
+   - `Status`
+   - `Refund`
+   - `Requested`
+   - `Approved`
+   - `Received`
+   - `Restocked`
+   - `Refunded`
+4. Read the status detail text under the lifecycle state.
+5. Read the refund detail text under the refund column.
+
+## What each lifecycle state means in the current UI
+
+| Status | What the customer should understand |
+| --- | --- |
+| `requested` | The return was submitted and is waiting for staff review. |
+| `approved` | Staff approved the return and is waiting for the item to be received. |
+| `received` | The item was received and is waiting for warehouse verification. |
+| `restocked` | The item is back in stock and refund processing can proceed. |
+| `refunded` | The money was issued back to the original payment method. |
+| `rejected` | The request was closed without refund eligibility. |
+
+## How to verify the same request from the orders list
+
+1. Go back to `/orders`.
+2. Find the same order.
+3. Confirm the return area now shows the active lifecycle state.
+4. Use this page when you want the quick portfolio view of all orders, not the detailed timestamp history.
+
+## Success checklist
+
+| Check | Expected result |
+| --- | --- |
+| Orders page | `Request Return` button is available for eligible orders |
+| Order detail page | `Create Return` form accepts a reason |
+| Success state | A new return record appears in the returns table |
+| Lifecycle tracking | Timestamp columns fill in as staff transitions the return |
+
+## Scope Boundary
+
+Customer pages do not move the lifecycle beyond the initial request. Staff users must perform approval, receipt, restock, and refund transitions.

--- a/docs/business_scenarios/04-inventory-optimization/README.md
+++ b/docs/business_scenarios/04-inventory-optimization/README.md
@@ -59,3 +59,7 @@ State model implemented in CRUD:
 - `created -> released` (rollback/abandonment)
 - `confirmed` and `released` are terminal states
 - Invalid transitions (`released -> confirmed`, `confirmed -> released`) return `409`
+
+## Detailed Walkthroughs
+
+- [Checkout Inventory Signals and Reservation Protection](checkout-inventory-signals-and-reservations.md)

--- a/docs/business_scenarios/04-inventory-optimization/checkout-inventory-signals-and-reservations.md
+++ b/docs/business_scenarios/04-inventory-optimization/checkout-inventory-signals-and-reservations.md
@@ -1,0 +1,93 @@
+# Checkout Inventory Signals and Reservation Protection
+
+## Purpose
+
+Use this walkthrough to verify the inventory-assistance portion of checkout: health signals, reservation creation, reservation outcomes, and safe fallback behavior when helper services are unavailable.
+
+## Current State Summary
+
+| Item | Current behavior |
+| --- | --- |
+| Role required | `customer` |
+| Entry point | `/checkout` with a non-empty cart |
+| Main UI location | Right-side order summary card in checkout |
+| Working status | Implemented and working |
+
+## Before You Start
+
+1. Sign in as a customer.
+2. Open checkout with items already present in the cart.
+3. Reach the checkout page and advance to the payment step.
+
+## Exact Click Path
+
+1. Open checkout.
+2. Complete the shipping form.
+3. Click `Continue to Payment`.
+4. Review the `Scenario 04 Signals` section in the order summary.
+5. If needed, use the retry buttons or `Continue without live signals`.
+6. Complete payment and confirm the order redirect.
+
+## What this section is proving
+
+The `Scenario 04 Signals` block is the customer-visible evidence that checkout is consulting the inventory helper surfaces while still allowing the transaction to continue when those helpers are temporarily unavailable.
+
+## What to look for in the `Scenario 04 Signals` block
+
+1. `Health: X healthy • Y low • Z out`
+2. `Threshold breaches`
+3. `Replenishment triggers`
+4. A `Reservation outcomes` subsection
+
+## Normal path walkthrough
+
+1. Complete Step 1 of checkout.
+2. Click `Continue to Payment`.
+3. Wait for the payment step to load.
+4. In the right-side summary, verify the helper block is visible.
+5. If the health call succeeds, confirm you see live counts for healthy, low, and out-of-stock products.
+6. If reservations have already been created for the checkout attempt, confirm the reservation outcome area lists lines such as `SKU: created`.
+7. Complete payment.
+8. After finalization, reservations should move from temporary holds into confirmed holds behind the scenes.
+
+## Unavailable-helper fallback walkthrough
+
+1. If helper endpoints are unavailable, the block will show a red warning message.
+2. Read the guidance before clicking anything.
+3. Use `Retry signal checks` first.
+4. If the warning persists and you still want to continue the demo, click `Continue without live signals`.
+5. Confirm the status text changes to `Continuing without live assistant signals. Checkout remains available.`
+6. Proceed with payment only after you confirm this fallback message is visible.
+
+## Reservation-specific troubleshooting buttons
+
+Use these buttons only when the checkout sidebar presents them:
+
+1. `Retry health check`
+   - Use when the inventory health call failed.
+2. `Retry reservation outcomes`
+   - Use when reservation state lookup failed.
+3. `Retry signal checks`
+   - Use when you want to refresh both helper areas together.
+
+## What the reservation messages mean
+
+| Message type | Meaning |
+| --- | --- |
+| `No reservation outcomes yet` | You have not created item holds yet for the current checkout attempt. |
+| `SKU: created` | A hold exists, but payment is not finalized yet. |
+| `SKU: confirmed` | Payment completed and the reservation was finalized. |
+| `SKU: released` | The hold was rolled back or the checkout attempt was abandoned. |
+
+## Expected success signals
+
+| Check | Expected result |
+| --- | --- |
+| Payment step opens | Checkout setup completed successfully |
+| Sidebar helper block appears | Inventory helper UI is active |
+| Retry path exists | The page remains resilient when helper data is unavailable |
+| Successful completion | Checkout redirects to the order detail page |
+
+## Scope Boundary
+
+This walkthrough documents the customer-visible inventory controls inside checkout. Staff-side replenishment or warehouse action screens are not part of the current customer UI.

--- a/docs/business_scenarios/05-shipment-delivery-tracking/README.md
+++ b/docs/business_scenarios/05-shipment-delivery-tracking/README.md
@@ -45,3 +45,8 @@ flowchart LR
    class G,H,I,J b
    class F c
 ```
+
+## Detailed Walkthroughs
+
+- [Customer Order Tracking and Logistics Enrichment](customer-order-tracking-and-logistics-enrichment.md)
+- [Staff Logistics Tracking Console](staff-logistics-tracking-console.md)

--- a/docs/business_scenarios/05-shipment-delivery-tracking/customer-order-tracking-and-logistics-enrichment.md
+++ b/docs/business_scenarios/05-shipment-delivery-tracking/customer-order-tracking-and-logistics-enrichment.md
@@ -1,0 +1,54 @@
+# Customer Order Tracking and Logistics Enrichment
+
+## Purpose
+
+Use this walkthrough to inspect the current customer-facing logistics view for an order, including tracking data, ETA data, and carrier information when those enrichments are present.
+
+## Current State Summary
+
+| Item | Current behavior |
+| --- | --- |
+| Role required | `customer` |
+| Primary route | `/order/{id}` |
+| Main navigation access | `My Orders` from the profile dropdown |
+| Working status | Implemented and working |
+
+## Exact Click Path
+
+1. Open the profile dropdown.
+2. Click `My Orders`.
+3. Click an order ID.
+4. Review the order summary and the `Agent Enrichment` card.
+
+## Step-by-step walkthrough
+
+1. Open `/orders`.
+2. Find the order you want to inspect.
+3. Click the order ID link in the first column.
+4. Confirm the order detail screen shows:
+   - the `Order Details` heading
+   - the order ID
+   - the status badge
+   - the ordered items table
+5. Scroll to the card labeled `Agent Enrichment`.
+6. Review each logistics payload block that is present:
+   - `tracking`
+   - `eta`
+   - `carrier`
+7. If a block is missing, the page leaves that section out instead of inventing placeholder data.
+
+## What the logistics area is for
+
+The current customer tracking experience is intentionally transparent. It shows raw enrichment payloads in formatted JSON blocks so the user or tester can confirm the backend is attaching tracking, ETA, and carrier context to the order.
+
+## What success looks like
+
+| Check | Expected result |
+| --- | --- |
+| Order open | Order details load without access error |
+| Logistics data present | JSON blocks appear in `Agent Enrichment` |
+| Logistics data absent | The page states `No tracking enrichment available.` or simply omits empty payloads |
+
+## Important note
+
+This page is both a customer tracking surface and a diagnostic surface. It is not yet a polished parcel-tracking timeline UI.

--- a/docs/business_scenarios/05-shipment-delivery-tracking/staff-logistics-tracking-console.md
+++ b/docs/business_scenarios/05-shipment-delivery-tracking/staff-logistics-tracking-console.md
@@ -1,0 +1,58 @@
+# Staff Logistics Tracking Console
+
+## Purpose
+
+Use this walkthrough to operate the current staff shipment-monitoring screen.
+
+## Current State Summary
+
+| Item | Current behavior |
+| --- | --- |
+| Role required | `staff` or `admin` |
+| Primary route | `/staff/logistics` |
+| Main navigation access | No direct main-navbar link today |
+| Recommended access method | Open the route directly after signing in as staff |
+| Working status | Implemented and working |
+
+## Before You Start
+
+1. Sign in as `staff`.
+2. If development mock login is enabled, open `/auth/login` and click `Sign in as Staff`.
+3. Open `/staff/logistics` directly in the browser.
+
+## Exact Workflow
+
+1. Load `/staff/logistics`.
+2. Wait for the shipment table to populate.
+3. Use the filter box to narrow the list.
+4. Review shipment status across the visible columns.
+
+## Step-by-step walkthrough
+
+1. Confirm the page header shows `Logistics Tracking`.
+2. Click inside the filter field with the placeholder `Filter by shipment id, order id, tracking number or status`.
+3. Type one search term at a time, for example:
+   - a shipment ID
+   - an order ID
+   - a carrier tracking number
+   - a status such as `in_transit`
+4. Watch the table update live without a submit button.
+5. Review these columns:
+   - `Shipment`
+   - `Order`
+   - `Carrier`
+   - `Tracking`
+   - `Status`
+   - `Created`
+
+## What success looks like
+
+| Check | Expected result |
+| --- | --- |
+| Page load | Shipment table renders |
+| Filtering | Rows update as you type |
+| Data quality | IDs, carrier, tracking number, status, and timestamps are visible |
+
+## Current limitation
+
+This screen is a monitoring table only. It does not expose shipment editing or exception resolution controls yet.

--- a/docs/business_scenarios/06-customer-360-personalization/README.md
+++ b/docs/business_scenarios/06-customer-360-personalization/README.md
@@ -52,12 +52,14 @@ Brand-shopping personalization in the UI now runs entirely through CRUD-owned co
 5. `POST /api/recommendations/compose`
 
 Execution model used by the dashboard personalization flow:
+
 - UI fetches product and customer profile first.
 - UI requests deterministic offer computation for the selected SKU and quantity.
 - UI submits ranked candidates for recommendation scoring.
 - UI composes final recommendation cards from ranked items.
 
 Versioning strategy for these contracts:
+
 - Current contract surface is `v1` on `/api` with additive-only changes.
 - Breaking schema/path changes must introduce a new versioned path (for example `/api/v2/...`) and run in parallel during migration.
 
@@ -67,3 +69,8 @@ Versioning strategy for these contracts:
 - Remaining fabricated dashboard/profile values were removed.
 - Where no backend contract exists (for example rewards points/progress, saved addresses, payment methods, and related profile tabs), the UI renders explicit unavailable/unsupported states instead of hardcoded placeholders.
 - Scope claim is intentionally limited to supported dashboard/profile data paths and explicit no-contract states.
+
+## Detailed Walkthroughs
+
+- [Customer Dashboard Personalization](customer-dashboard-personalization.md)
+- [Profile Management](profile-management.md)

--- a/docs/business_scenarios/06-customer-360-personalization/customer-dashboard-personalization.md
+++ b/docs/business_scenarios/06-customer-360-personalization/customer-dashboard-personalization.md
@@ -1,0 +1,73 @@
+# Customer Dashboard Personalization
+
+## Purpose
+
+Use this walkthrough to validate the current dashboard experience, especially the live recommendation flow that combines customer profile, product, pricing, ranking, and compose endpoints.
+
+## Current State Summary
+
+| Item | Current behavior |
+| --- | --- |
+| Role required | `customer` |
+| Main navigation access | `Dashboard` in the top navigation |
+| Primary route | `/dashboard` |
+| Working status | Implemented and working |
+
+## Exact Click Path
+
+1. Sign in as a customer.
+2. Click `Dashboard` in the top navigation.
+3. Review recent orders.
+4. Use the `Recommended for You` card.
+5. Optionally refresh recommendations with a different customer ID and SKU.
+
+## Step-by-step walkthrough
+
+1. Open `/dashboard`.
+2. Confirm the page header says `My Dashboard`.
+3. Review the four stat cards at the top.
+4. Note the current behavior of those cards:
+   - `Total Orders` is live
+   - `Wishlist Items` shows `Unavailable`
+   - `Saved Addresses` shows `Unavailable`
+   - `Rewards Points` shows `Unavailable`
+5. In `Recent Orders`, click `View All` if you want to move to the orders portfolio.
+6. Move to the `Recommended for You` card.
+7. Confirm the explanatory text says this flow uses catalog, profile, pricing, ranking, and compose endpoints.
+
+## How to run the personalization flow
+
+1. Look for the two input fields above the button row:
+   - `Customer ID`
+   - `Product SKU`
+2. If the page seeded those fields automatically from recent order history, keep the values.
+3. If the fields are empty, enter a valid customer ID and product SKU.
+4. Click `Refresh Recommendations`.
+5. Wait for the results grid to populate.
+6. If pricing data is returned, confirm the `Offer preview` line appears.
+7. Review the personalized recommendation cards shown below.
+
+## How to interpret the current status messages
+
+| Status | Meaning |
+| --- | --- |
+| `Loading personalized recommendations.` | The orchestration call is still running. |
+| `Showing X personalized recommendation(s).` | The request succeeded and returned results. |
+| `No recommendations available for this customer and SKU.` | The flow completed successfully but returned no ranked items. |
+| Error message with backend status | The request failed and exposed the API error state. |
+
+## Quick actions area
+
+The right-side `Quick Actions` card gives you fast links to:
+
+1. `View All Orders`
+2. `Edit Profile`
+3. `My Wishlist`
+4. `Browse Categories`
+
+## Current limitations you should document honestly
+
+1. Rewards progress is not backed by a live contract yet.
+2. Saved addresses are not backed by a live contract yet.
+3. Wishlist persistence is not backed by a live contract yet.
+4. The page correctly shows unavailable states instead of fabricated values.

--- a/docs/business_scenarios/06-customer-360-personalization/profile-management.md
+++ b/docs/business_scenarios/06-customer-360-personalization/profile-management.md
@@ -1,0 +1,57 @@
+# Profile Management
+
+## Purpose
+
+Use this walkthrough to edit the currently supported customer profile fields and to understand which profile tabs are intentionally unavailable.
+
+## Current State Summary
+
+| Item | Current behavior |
+| --- | --- |
+| Role required | `customer` |
+| Main navigation access | Profile dropdown -> `My Profile` |
+| Primary route | `/profile` |
+| Working status | Partially implemented by design |
+
+## Exact Click Path
+
+1. Open the profile dropdown in the header.
+2. Click `My Profile`.
+3. Click `Edit Profile`.
+4. Update `Full Name` or `Phone Number`.
+5. Click `Save Changes`.
+
+## Step-by-step walkthrough
+
+1. Open `/profile`.
+2. Confirm the page title is `My Profile`.
+3. In the `Personal Information` tab, verify you can see:
+   - initials avatar
+   - full name
+   - email address
+   - member-since date
+4. Click `Edit Profile`.
+5. Update `Full Name`.
+6. Optionally update `Phone Number`.
+7. Leave `Email Address` alone because it is intentionally read-only.
+8. Click `Save Changes`.
+9. Confirm the form returns to view mode on success.
+
+## What the other tabs mean today
+
+The following tabs are present but intentionally show unsupported-state cards:
+
+1. `Addresses`
+2. `Payment Methods`
+3. `Security`
+4. `Preferences`
+
+When you click one of those tabs, the page should say `Feature unavailable` and explain that the current API contract does not support that area yet.
+
+## Success checklist
+
+| Check | Expected result |
+| --- | --- |
+| Edit mode | `Save Changes` and `Cancel` buttons appear |
+| Save flow | The page exits edit mode after a successful mutation |
+| Unsupported tabs | Explicit unavailable messages render instead of fake data |

--- a/docs/business_scenarios/07-product-lifecycle-management/README.md
+++ b/docs/business_scenarios/07-product-lifecycle-management/README.md
@@ -45,3 +45,10 @@ flowchart LR
    class E c
    class G d
 ```
+
+## Detailed Walkthroughs
+
+- [Admin Enrichment Trigger and Monitor](admin-enrichment-trigger-and-monitor.md)
+- [Staff HITL Review and Decisioning](staff-hitl-review-and-decisioning.md)
+- [Admin Schema and Tenant Configuration](admin-schema-and-tenant-configuration.md)
+- [Admin Truth Analytics and Observability](admin-truth-analytics-and-observability.md)

--- a/docs/business_scenarios/07-product-lifecycle-management/admin-enrichment-trigger-and-monitor.md
+++ b/docs/business_scenarios/07-product-lifecycle-management/admin-enrichment-trigger-and-monitor.md
@@ -1,0 +1,84 @@
+# Admin Enrichment Trigger and Monitor
+
+## Purpose
+
+Use this walkthrough to manually queue product enrichment, monitor pipeline activity, and inspect an individual enrichment record.
+
+## Current State Summary
+
+| Item | Current behavior |
+| --- | --- |
+| Role required | `admin` |
+| Main navigation access | `Admin` in the top navigation |
+| Primary routes | `/admin`, `/admin/ecommerce/products`, `/admin/enrichment-monitor`, `/admin/enrichment-monitor/{entityId}` |
+| Working status | Implemented and working |
+
+## Exact Click Path
+
+1. Click `Admin` in the main navigation.
+2. In `E-Commerce Services`, click `Product Enrichment`.
+3. Select a product and click `Trigger enrichment`.
+4. Return to `Admin` and click `Enrichment Monitor`.
+5. Click an entity ID in the active jobs table.
+
+## Step 1: Queue an enrichment job
+
+1. Open `/admin`.
+2. In the `E-Commerce Services` section, click `Product Enrichment`.
+3. Confirm the page title ends with `Products Service`.
+4. In the trigger card, find:
+   - the `Product ID` selector
+   - the `Trigger enrichment` button
+5. Pick a product from the dropdown.
+6. Click `Trigger enrichment`.
+7. Wait for the green confirmation message `Queued at ...`.
+
+## Step 2: Review the service dashboard
+
+1. Stay on the same screen for a moment.
+2. Review the service status cards.
+3. Review the `Activity` table.
+4. Review the `Model usage` table.
+5. Use the `Time range` selector if you want to narrow the window.
+6. Use `Refresh` if you want to force an update after the trigger call.
+
+## Step 3: Monitor the enrichment pipeline
+
+1. Return to `/admin`.
+2. Click `Enrichment Monitor`.
+3. On the dashboard, confirm the top area shows:
+   - status cards
+   - `Active jobs`
+   - `Throughput`
+   - `Error log`
+4. If the active-jobs table contains your entity, click the entity ID.
+
+## Step 4: Inspect a specific entity
+
+1. On `/admin/enrichment-monitor/{entityId}`, review the header for:
+   - title
+   - entity ID
+   - pipeline status badge
+   - confidence percentage
+2. Use the quick-action buttons as needed:
+   - `Open HITL queue`
+   - `Review this entity`
+   - `Quick approve`
+   - `Quick reject`
+3. Scroll down and inspect:
+   - `Attribute differences`
+   - image evidence
+   - reasoning panel
+4. Use `Related Trace` if you want to jump into agent observability.
+
+## Success checklist
+
+| Check | Expected result |
+| --- | --- |
+| Trigger action | `Queued at ...` confirmation appears |
+| Monitor page | Active jobs and status cards render |
+| Detail page | Attribute diffs, evidence, and reasoning are visible |
+
+## Scope Boundary
+
+This guide is about operational control and monitoring. Human review decisioning is documented separately.

--- a/docs/business_scenarios/07-product-lifecycle-management/admin-schema-and-tenant-configuration.md
+++ b/docs/business_scenarios/07-product-lifecycle-management/admin-schema-and-tenant-configuration.md
@@ -1,0 +1,64 @@
+# Admin Schema and Tenant Configuration
+
+## Purpose
+
+Use this walkthrough to manage the Product Truth Layer governance screens that are currently implemented but not linked from the main admin landing page.
+
+## Current State Summary
+
+| Item | Current behavior |
+| --- | --- |
+| Role required | `admin` |
+| Primary routes | `/admin/schemas`, `/admin/config` |
+| Main navigation access | Direct route entry is required today |
+| Working status | Implemented and working |
+
+## Important note about navigation
+
+These screens exist and work, but they are not exposed as tiles on the main admin portal yet. Open them directly in the browser after signing in as admin.
+
+## Workflow A: Manage schemas on `/admin/schemas`
+
+1. Open `/admin/schemas`.
+2. Confirm the page title is `Schema Management`.
+3. To create a schema, click `+ New Schema`.
+4. Complete the top-level fields:
+   - `Category`
+   - `Version`
+5. Click `+ Add Field` for each schema field you need.
+6. For each field row, complete:
+   - `Field name`
+   - type selector
+   - `Description (optional)`
+   - `Required` checkbox if needed
+7. Click `Save Schema`.
+8. To edit an existing schema, click `Edit` on that schema card.
+9. To delete a schema, click `Delete` and confirm the browser prompt.
+
+## Workflow B: Manage tenant configuration on `/admin/config`
+
+1. Open `/admin/config`.
+2. Confirm the page title is `Tenant Configuration`.
+3. Review or update `Auto-Approve Threshold (0–1)`.
+4. Review the toggle section and set each one intentionally:
+   - `Enrichment Enabled`
+   - `HITL Review Enabled`
+   - `PIM Writeback Enabled`
+   - `Writeback Dry Run` when writeback is enabled
+5. Review the `Feature Flags` section.
+6. To add a new flag:
+   - enter the flag key
+   - click `Add Flag`
+7. To toggle an existing flag, click its checkbox.
+8. To remove an existing flag, click `Remove`.
+9. Click `Save Configuration`.
+10. Confirm the success banner `Configuration saved successfully.` appears.
+
+## Success checklist
+
+| Check | Expected result |
+| --- | --- |
+| Schema creation | New schema card appears after save |
+| Schema edit | Existing schema reflects updated fields |
+| Config save | Success banner appears |
+| Feature flags | Added, toggled, and removed flags persist after save |

--- a/docs/business_scenarios/07-product-lifecycle-management/admin-truth-analytics-and-observability.md
+++ b/docs/business_scenarios/07-product-lifecycle-management/admin-truth-analytics-and-observability.md
@@ -1,0 +1,55 @@
+# Admin Truth Analytics and Observability
+
+## Purpose
+
+Use this walkthrough to inspect truth-layer KPIs, throughput, tracing, model usage, and retry/error signals.
+
+## Current State Summary
+
+| Item | Current behavior |
+| --- | --- |
+| Role required | `admin` |
+| Main navigation access | `Admin` -> `Truth Analytics` or `Agent Activity` |
+| Primary routes | `/admin/truth-analytics`, `/admin/agent-activity` |
+| Working status | Implemented and working |
+
+## Workflow A: Truth analytics dashboard
+
+1. Open `/admin`.
+2. In `E-Commerce Services`, click `Truth Analytics`.
+3. Confirm the dashboard shows KPI cards such as:
+   - `Overall Completeness`
+   - `Enrichment Jobs`
+   - `HITL Queue Pending`
+   - `Exports`
+4. Review the queue breakdown cards.
+5. Review the pipeline flow diagram.
+6. Scroll down to inspect:
+   - completeness by category
+   - pipeline throughput chart
+
+## Workflow B: Agent activity dashboard
+
+1. Return to `/admin`.
+2. Click `Agent Activity`.
+3. Use the `Time range` selector.
+4. Review the top summary cards:
+   - `Tracing`
+   - `Active traces`
+   - `Needs retry`
+   - `Recovered`
+5. Review the `Agent health cards` section.
+6. Review the `Trace feed` table.
+7. Review the `Model usage` table.
+8. Review the `Error / retry log` section.
+9. If tracing is unavailable, confirm the warning card explains that tracing must be enabled.
+10. If you want evaluation coverage, click `View evaluations`.
+
+## Success checklist
+
+| Check | Expected result |
+| --- | --- |
+| Truth analytics | KPI cards and charts load |
+| Agent activity | Time-range filter refreshes the observability view |
+| Trace feed | Trace IDs link to deeper trace pages when available |
+| Error visibility | Failed or retried traces show up in the retry log |

--- a/docs/business_scenarios/07-product-lifecycle-management/staff-hitl-review-and-decisioning.md
+++ b/docs/business_scenarios/07-product-lifecycle-management/staff-hitl-review-and-decisioning.md
@@ -1,0 +1,86 @@
+# Staff HITL Review and Decisioning
+
+## Purpose
+
+Use this walkthrough to review AI-proposed product changes, approve or reject them, edit proposed values, and inspect audit history.
+
+## Current State Summary
+
+| Item | Current behavior |
+| --- | --- |
+| Role required | `staff` or `admin` |
+| Primary routes | `/staff/review`, `/staff/review/{entityId}` |
+| Main navigation access | Best entry point is from `Enrichment Monitor` or direct URL |
+| Working status | Implemented and working |
+
+## Exact Click Path
+
+1. Open `Enrichment Monitor` and click `Open HITL review queue`, or go directly to `/staff/review`.
+2. Filter or sort the queue.
+3. Click `Review` on the target row.
+4. Approve, edit, or reject the proposed attributes.
+
+## Step 1: Work the review queue
+
+1. Open `/staff/review`.
+2. Confirm the page title is `AI Review Queue`.
+3. Review the summary cards:
+   - `Pending`
+   - `Approved Today`
+   - `Rejected Today`
+   - `Avg Confidence`
+4. Use any of the filters:
+   - `Filter by category`
+   - `Min confidence (0–1)`
+   - `Max confidence (0–1)`
+   - `Filter by source`
+5. Use the `Sort by` dropdown above the table.
+6. In the table, review these columns:
+   - `Product`
+   - `Category`
+   - `Field`
+   - `Proposed Value`
+   - `Confidence`
+   - `Source`
+   - `Proposed At`
+   - `Action`
+7. Click `Review` for the entity you want.
+
+## Step 2: Review a single entity
+
+1. Confirm the detail screen shows the product image, title, category, and entity ID.
+2. Review the completeness bar.
+3. In the right-side `Bulk Actions` card, note the buttons:
+   - `Approve All`
+   - `Reject All`
+   - `Back to Queue`
+4. Scroll to `Proposed Attributes`.
+
+## Step 3: Decide proposal by proposal
+
+For each proposal card:
+
+1. Compare `Original value` with `Enriched value`.
+2. Review confidence and source badges.
+3. Read any intent, reasoning, and evidence sections.
+4. Choose one action:
+   - `Approve`
+   - `Edit`
+   - `Reject`
+5. If you choose `Edit`, change the text in `Edited value` and click `Save Edit`.
+6. If you choose `Reject`, enter a `Rejection reason` and click `Confirm Reject`.
+
+## Step 4: Validate the audit trail
+
+1. Scroll to `Audit History`.
+2. Confirm the timeline reflects the actions you just took.
+3. Use this section as the final verification point that the review action persisted.
+
+## Success checklist
+
+| Check | Expected result |
+| --- | --- |
+| Queue page | Filters, stats, and rows all render |
+| Review page | Proposed attributes and audit history are visible |
+| Approve/Edit/Reject | Action controls update proposal state |
+| Audit history | New review decisions appear in the timeline |

--- a/docs/business_scenarios/08-customer-support-resolution/README.md
+++ b/docs/business_scenarios/08-customer-support-resolution/README.md
@@ -24,20 +24,16 @@ AI-first support resolution loop that compresses response time, improves first-c
 
 ## Current API Readiness (Issue #220)
 
-- Staff resolution loop now has CRUD lifecycle coverage with role enforcement:
-   - `POST /api/staff/tickets`
-   - `PATCH /api/staff/tickets/{id}`
-   - `POST /api/staff/tickets/{id}/escalate`
-   - `POST /api/staff/tickets/{id}/resolve`
+- Staff resolution loop now has CRUD lifecycle coverage with role enforcement.
+   Supported routes: `POST /api/staff/tickets`, `PATCH /api/staff/tickets/{id}`, `POST /api/staff/tickets/{id}/escalate`, and `POST /api/staff/tickets/{id}/resolve`.
 - Ticket mutation responses now include auditable lifecycle metadata (`status_history`, `audit_log`, actor, timestamp, reason).
 - Payment context retrieval is now available through `GET /api/payments/{payment_id}` for support workflows (ownership + staff/admin access checks).
 - Remaining scenario gap: customer/self-service ticket creation route is still not implemented in CRUD (`/api/tickets` equivalent remains pending).
 
 ## Demo Access Enablement (Issue #214)
 
-- Support scenario demos run with role-based access in both auth modes:
-   - Entra mode: role claims from sign-in token (`customer`, `staff`, `admin`).
-   - Dev fail-safe mode: role-selectable mock login at `/auth/login` (non-production only).
+- Support scenario demos run with role-based access in both auth modes.
+   Entra mode uses role claims from the sign-in token (`customer`, `staff`, `admin`). Dev fail-safe mode uses role-selectable mock login at `/auth/login` in non-production environments only.
 - Staff resolution operations continue to require `staff|admin`; admin-only routes still require `admin`.
 - Production safeguard: mock login endpoints return `403` when mock mode is disabled and are never enabled in production runtime.
 
@@ -65,3 +61,7 @@ flowchart LR
    class C c
    class G,H d
 ```
+
+## Detailed Walkthroughs
+
+- [Staff Ticket Resolution and Escalation](staff-ticket-resolution-and-escalation.md)

--- a/docs/business_scenarios/08-customer-support-resolution/staff-ticket-resolution-and-escalation.md
+++ b/docs/business_scenarios/08-customer-support-resolution/staff-ticket-resolution-and-escalation.md
@@ -1,0 +1,90 @@
+# Staff Ticket Resolution and Escalation
+
+## Purpose
+
+Use this walkthrough to create support tickets, update status, assign ownership, escalate complex work, and resolve tickets from the staff console.
+
+## Current State Summary
+
+| Item | Current behavior |
+| --- | --- |
+| Role required | `staff` or `admin` |
+| Primary route | `/staff/requests` |
+| Main navigation access | Direct route entry is required today |
+| Working status | Implemented and working |
+
+## Before You Start
+
+1. Sign in as `staff`.
+2. If development mock login is enabled, use `/auth/login` and click `Sign in as Staff`.
+3. Open `/staff/requests` directly.
+
+## Exact Click Path
+
+1. Open `/staff/requests`.
+2. Stay on the `Tickets` tab.
+3. Use `Create Ticket` to open a new request.
+4. Use `Ticket Actions` to update, escalate, or resolve an existing ticket.
+
+## Step 1: Filter the shared staff workspace
+
+1. Confirm the page title is `Customer Requests`.
+2. In the global filter box, type an ID, status, subject, or order reference if you want to narrow the lists.
+3. Keep the `Tickets` tab selected for this workflow.
+
+## Step 2: Create a ticket
+
+1. In the `Create Ticket` card, complete:
+   - `User ID *`
+   - `Subject *`
+   - `Priority`
+   - `Description`
+2. Click `Create Ticket`.
+3. If you miss a required field, the screen shows validation guidance under the form.
+4. On success, the newly created ticket becomes selectable in the action area.
+
+## Step 3: Select a ticket for action
+
+1. In `Ticket Actions`, open the `Ticket *` dropdown.
+2. Select the ticket you want to work on.
+3. Confirm the screen populates the current status and assignee automatically.
+
+## Step 4: Update the ticket
+
+1. Change `Status` if needed.
+2. Change `Assignee ID` if the ticket needs to move to a different owner.
+3. Optionally fill `Reason`.
+4. Click `Update`.
+5. Wait for the blue status text `Updating...` to disappear.
+
+## Step 5: Escalate the ticket
+
+1. Keep the ticket selected.
+2. Enter a non-empty value in `Reason`.
+3. Click `Escalate`.
+4. Confirm the UI no longer shows the hint `Escalate requires a reason.`
+5. Wait for the action to complete.
+
+## Step 6: Resolve the ticket
+
+1. Enter an optional `Resolution note`.
+2. Optionally keep a `Reason` value.
+3. Click `Resolve`.
+4. Wait for the completion state.
+
+## Step 7: Confirm the result in the tickets table
+
+1. Scroll to the tickets table.
+2. Locate the ticket row.
+3. Confirm the row now reflects the updated status and assignee.
+4. Review the table columns:
+   - `Ticket`
+   - `Subject`
+   - `Priority`
+   - `Status`
+   - `Assignee`
+   - `Created`
+
+## Important scope note
+
+The `Returns` tab on the same page belongs to the reverse-logistics workflow and should be documented using the returns scenario, not this support-ticket guide.

--- a/docs/business_scenarios/README.md
+++ b/docs/business_scenarios/README.md
@@ -2,10 +2,15 @@
 
 Executive scenario playbook for Holiday Peak Hub: each scenario is a value stream, each capability is mapped to a primary business outcome, and each flow is represented with a visual executive narrative.
 
+This folder now serves two different documentation needs:
+
+1. Each scenario `README.md` remains the executive overview.
+2. The additional walkthrough files in each scenario folder are the current-state, click-by-click operating guides for the UI that exists today.
+
 ## Scenario Portfolio
 
 | # | Scenario | Outcome Theme | Flow Model |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | 1 | [Order-to-Fulfillment](01-order-to-fulfillment/) | Revenue Protection + Fulfillment Velocity | SAGA Orchestration |
 | 2 | [Product Discovery & Enrichment](02-product-discovery-enrichment/) | Conversion Acceleration + Catalog Intelligence | Hybrid Sync/Async |
 | 3 | [Returns & Refund Processing](03-returns-refund-processing/) | Margin Recovery + Trust Retention | Event-Driven Reverse Logistics |
@@ -18,7 +23,7 @@ Executive scenario playbook for Holiday Peak Hub: each scenario is a value strea
 ## Capability-to-Scenario Mapping
 
 | Capability Cluster | Primary Scenario | Supporting Platforms |
-|---|---|---|
+| --- | --- | --- |
 | CRUD transactional core | 1 | APIM, PostgreSQL, Event Hubs |
 | Catalog search + enrichment | 2 | Azure AI Search, Foundry, Redis |
 | Returns + refund automation | 3 | Logistics agents, payment flow, support context |
@@ -34,21 +39,68 @@ Executive scenario playbook for Holiday Peak Hub: each scenario is a value strea
 - Developer fail-safe mode: dev mock login can be enabled only outside production for role-based walkthroughs.
 - Production safeguard: mock auth routes are disabled in production and role checks remain enforced by UI middleware.
 
+## Walkthrough Entry Notes
+
+| Access mode | Use this when |
+| --- | --- |
+| Main navigation | The workflow is exposed from the current storefront or admin portal. |
+| Direct route entry | The screen exists and works today, but is not yet linked from the main navigation. |
+
+## Detailed Walkthrough Index
+
+### 01 Order-to-Fulfillment
+
+- [Customer Cart, Checkout, and Order Confirmation](01-order-to-fulfillment/customer-cart-checkout-and-order-confirmation.md)
+
+### 02 Product Discovery & Enrichment
+
+- [Intelligent Search and Agent Comparison](02-product-discovery-enrichment/intelligent-search-and-agent-comparison.md)
+- [Category Browsing and Product Detail Exploration](02-product-discovery-enrichment/category-browsing-and-product-detail.md)
+
+### 03 Returns & Refund Processing
+
+- [Customer Return Request and Refund Status](03-returns-refund-processing/customer-return-request-and-refund-status.md)
+
+### 04 Inventory Optimization
+
+- [Checkout Inventory Signals and Reservation Protection](04-inventory-optimization/checkout-inventory-signals-and-reservations.md)
+
+### 05 Shipment & Delivery Tracking
+
+- [Customer Order Tracking and Logistics Enrichment](05-shipment-delivery-tracking/customer-order-tracking-and-logistics-enrichment.md)
+- [Staff Logistics Tracking Console](05-shipment-delivery-tracking/staff-logistics-tracking-console.md)
+
+### 06 Customer 360 & Personalization
+
+- [Customer Dashboard Personalization](06-customer-360-personalization/customer-dashboard-personalization.md)
+- [Profile Management](06-customer-360-personalization/profile-management.md)
+
+### 07 Product Lifecycle Management
+
+- [Admin Enrichment Trigger and Monitor](07-product-lifecycle-management/admin-enrichment-trigger-and-monitor.md)
+- [Staff HITL Review and Decisioning](07-product-lifecycle-management/staff-hitl-review-and-decisioning.md)
+- [Admin Schema and Tenant Configuration](07-product-lifecycle-management/admin-schema-and-tenant-configuration.md)
+- [Admin Truth Analytics and Observability](07-product-lifecycle-management/admin-truth-analytics-and-observability.md)
+
+### 08 Customer Support Resolution
+
+- [Staff Ticket Resolution and Escalation](08-customer-support-resolution/staff-ticket-resolution-and-escalation.md)
+
 ## Executive Flow Map
 
 ```mermaid
 flowchart LR
-	A[Digital Demand Signals] --> B[Scenario Value Streams]
-	B --> C[Agentic Decision Layer]
-	C --> D[Operational Systems of Record]
-	D --> E[Executive Outcomes Dashboard]
+A[Digital Demand Signals] --> B[Scenario Value Streams]
+B --> C[Agentic Decision Layer]
+C --> D[Operational Systems of Record]
+D --> E[Executive Outcomes Dashboard]
 
-	classDef c1 fill:#0B84F3,color:#fff,stroke:#085ea8
-	classDef c2 fill:#00A88F,color:#fff,stroke:#0b6e5f
-	classDef c3 fill:#F39C12,color:#fff,stroke:#af6f0c
-	classDef c4 fill:#8E44AD,color:#fff,stroke:#5b2a70
-	class A,B c1
-	class C c2
-	class D c3
-	class E c4
+classDef c1 fill:#0B84F3,color:#fff,stroke:#085ea8
+classDef c2 fill:#00A88F,color:#fff,stroke:#0b6e5f
+classDef c3 fill:#F39C12,color:#fff,stroke:#af6f0c
+classDef c4 fill:#8E44AD,color:#fff,stroke:#5b2a70
+class A,B c1
+class C c2
+class D c3
+class E c4
 ```


### PR DESCRIPTION
## What
- add detailed click-by-click walkthroughs for the implemented business-scenario UI flows
- link each scenario README to its detailed guides
- update the business-scenarios hub to separate executive summaries from operator walkthroughs
- document current limitations explicitly where the UI is partial or route-only

## Validation
- verified markdown diagnostics for docs/business_scenarios are clean
- no code paths changed

Closes #562