### PR TITLE
docs: standardize standalone deployment guidance for agent services

### DIFF
--- a/apps/crm-campaign-intelligence/README.md
+++ b/apps/crm-campaign-intelligence/README.md
@@ -25,3 +25,118 @@ python -m pytest ../tests
 - Uses Foundry model settings (`PROJECT_ENDPOINT` or `FOUNDRY_ENDPOINT`, fast/rich model identifiers).
 - Supports Redis/Cosmos/Blob memory configuration via shared memory settings.
 - Requires Event Hub namespace and consumer configuration for background jobs.
+
+---
+
+## Standalone Deployment - azd-first (ACR -> AKS)
+
+This service supports standalone deployment to an existing Holiday Peak Hub Azure environment.
+Use azd as the primary deployment path. Use the manual ACR -> AKS path only when you need isolated rollout or troubleshooting outside the standard workflow.
+
+### Prerequisites
+
+| Tool | Why it is needed |
+|------|------------------|
+| az CLI | Azure authentication and resource operations |
+| azd | Environment selection and service deploy |
+| docker (or az acr build) | Build and push the container image |
+| kubectl + helm | Manual AKS deployment and validation |
+
+### 1. Set service variables
+
+```bash
+SERVICE_NAME="crm-campaign-intelligence"
+APP_PATH="apps/crm-campaign-intelligence/src"
+DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
+AZD_ENV_NAME="dev"
+K8S_NAMESPACE="holiday-peak"
+IMAGE_TAG="$(git rev-parse --short HEAD)"
+```
+
+### 2. Configure required environment variables
+
+Set these in the selected azd environment (recommended) or in your manual Helm values file:
+
+| Variable | Required | Notes |
+|----------|----------|-------|
+| PROJECT_ENDPOINT or FOUNDRY_ENDPOINT | Yes | Azure AI Foundry project endpoint |
+| FOUNDRY_AGENT_ID_FAST | Yes | Fast-path model agent id |
+| MODEL_DEPLOYMENT_NAME_FAST | Yes | Fast-path deployment name |
+| FOUNDRY_AGENT_ID_RICH | Yes | Rich-path model agent id |
+| MODEL_DEPLOYMENT_NAME_RICH | Yes | Rich-path deployment name |
+| EVENT_HUB_NAMESPACE or EVENTHUB_NAMESPACE | Yes | Event Hub namespace FQDN |
+| EVENT_HUB_CONNECTION_STRING or EVENTHUB_CONNECTION_STRING | Usually | Needed when workload identity is not used |
+| APP_NAME | Recommended | Set to crm-campaign-intelligence |
+| CRUD_SERVICE_URL | Service-dependent | Required when this service calls CRUD APIs |
+| REDIS_URL / COSMOS_* / BLOB_* | Optional | Three-tier memory; service degrades gracefully when absent |
+| APPLICATIONINSIGHTS_CONNECTION_STRING | Optional | App telemetry |
+
+Example azd env commands:
+
+```bash
+azd env select "${AZD_ENV_NAME}"
+azd env set APP_NAME "crm-campaign-intelligence"
+# repeat azd env set for the required values above
+```
+
+### 3. Build and push image
+
+```bash
+ACR_NAME="<existing-acr-name>"
+az acr login --name "${ACR_NAME}"
+ACR_LOGIN_SERVER="$(az acr show --name "${ACR_NAME}" --query loginServer -o tsv)"
+IMAGE_REPO="${ACR_LOGIN_SERVER}/${SERVICE_NAME}"
+docker build --target prod --tag "${IMAGE_REPO}:${IMAGE_TAG}" --tag "${IMAGE_REPO}:latest" -f "${DOCKERFILE_PATH}" "${APP_PATH}"
+docker push "${IMAGE_REPO}:${IMAGE_TAG}"
+docker push "${IMAGE_REPO}:latest"
+```
+
+ACR remote build alternative:
+
+```bash
+az acr build --registry "${ACR_NAME}" --image "${SERVICE_NAME}:${IMAGE_TAG}" --file "${DOCKERFILE_PATH}" "${APP_PATH}"
+```
+
+### 4. Render and deploy
+
+Preferred (azd-first):
+
+```bash
+azd deploy --service "${SERVICE_NAME}" -e "${AZD_ENV_NAME}" --no-prompt
+```
+
+Manual render/deploy path:
+
+```bash
+SERVICE_NAME="${SERVICE_NAME}" IMAGE_PREFIX="${ACR_LOGIN_SERVER}" IMAGE_TAG="${IMAGE_TAG}" K8S_NAMESPACE="${K8S_NAMESPACE}" KEDA_ENABLED="false" PUBLICATION_MODE="none" .infra/azd/hooks/render-helm.sh crm-campaign-intelligence
+helm upgrade --install crm-campaign-intelligence .kubernetes/chart --namespace "${K8S_NAMESPACE}" --create-namespace --set serviceName=crm-campaign-intelligence --set "image.repository=${IMAGE_REPO}" --set "image.tag=${IMAGE_TAG}" --wait --timeout 5m
+```
+
+If you deploy manually, provide env values through a local values file and do not commit secrets.
+
+### 5. Validate deployment
+
+```bash
+kubectl rollout status deployment/crm-campaign-intelligence -n "${K8S_NAMESPACE}" --timeout=5m
+kubectl get pods -n "${K8S_NAMESPACE}" -l app=crm-campaign-intelligence
+kubectl logs -n "${K8S_NAMESPACE}" -l app=crm-campaign-intelligence --tail=100
+kubectl port-forward -n "${K8S_NAMESPACE}" deployment/crm-campaign-intelligence 8080:8000
+curl -s http://localhost:8080/health
+curl -s http://localhost:8080/ready
+```
+
+### 6. Teardown
+
+Standalone service cleanup:
+
+```bash
+helm uninstall crm-campaign-intelligence -n "${K8S_NAMESPACE}" || true
+kubectl delete configmap crm-campaign-intelligence-config -n "${K8S_NAMESPACE}" --ignore-not-found
+kubectl delete secret crm-campaign-intelligence-secrets -n "${K8S_NAMESPACE}" --ignore-not-found
+```
+
+Full environment cleanup (destructive, use only when intended):
+
+```bash
+azd down -e "${AZD_ENV_NAME}" --purge --force
+```

--- a/apps/crm-profile-aggregation/README.md
+++ b/apps/crm-profile-aggregation/README.md
@@ -25,3 +25,118 @@ python -m pytest ../tests
 - Uses Foundry model settings (`PROJECT_ENDPOINT` or `FOUNDRY_ENDPOINT`, fast/rich model identifiers).
 - Supports Redis/Cosmos/Blob memory configuration via shared memory settings.
 - Requires Event Hub namespace and consumer configuration for background jobs.
+
+---
+
+## Standalone Deployment - azd-first (ACR -> AKS)
+
+This service supports standalone deployment to an existing Holiday Peak Hub Azure environment.
+Use azd as the primary deployment path. Use the manual ACR -> AKS path only when you need isolated rollout or troubleshooting outside the standard workflow.
+
+### Prerequisites
+
+| Tool | Why it is needed |
+|------|------------------|
+| az CLI | Azure authentication and resource operations |
+| azd | Environment selection and service deploy |
+| docker (or az acr build) | Build and push the container image |
+| kubectl + helm | Manual AKS deployment and validation |
+
+### 1. Set service variables
+
+```bash
+SERVICE_NAME="crm-profile-aggregation"
+APP_PATH="apps/crm-profile-aggregation/src"
+DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
+AZD_ENV_NAME="dev"
+K8S_NAMESPACE="holiday-peak"
+IMAGE_TAG="$(git rev-parse --short HEAD)"
+```
+
+### 2. Configure required environment variables
+
+Set these in the selected azd environment (recommended) or in your manual Helm values file:
+
+| Variable | Required | Notes |
+|----------|----------|-------|
+| PROJECT_ENDPOINT or FOUNDRY_ENDPOINT | Yes | Azure AI Foundry project endpoint |
+| FOUNDRY_AGENT_ID_FAST | Yes | Fast-path model agent id |
+| MODEL_DEPLOYMENT_NAME_FAST | Yes | Fast-path deployment name |
+| FOUNDRY_AGENT_ID_RICH | Yes | Rich-path model agent id |
+| MODEL_DEPLOYMENT_NAME_RICH | Yes | Rich-path deployment name |
+| EVENT_HUB_NAMESPACE or EVENTHUB_NAMESPACE | Yes | Event Hub namespace FQDN |
+| EVENT_HUB_CONNECTION_STRING or EVENTHUB_CONNECTION_STRING | Usually | Needed when workload identity is not used |
+| APP_NAME | Recommended | Set to crm-profile-aggregation |
+| CRUD_SERVICE_URL | Service-dependent | Required when this service calls CRUD APIs |
+| REDIS_URL / COSMOS_* / BLOB_* | Optional | Three-tier memory; service degrades gracefully when absent |
+| APPLICATIONINSIGHTS_CONNECTION_STRING | Optional | App telemetry |
+
+Example azd env commands:
+
+```bash
+azd env select "${AZD_ENV_NAME}"
+azd env set APP_NAME "crm-profile-aggregation"
+# repeat azd env set for the required values above
+```
+
+### 3. Build and push image
+
+```bash
+ACR_NAME="<existing-acr-name>"
+az acr login --name "${ACR_NAME}"
+ACR_LOGIN_SERVER="$(az acr show --name "${ACR_NAME}" --query loginServer -o tsv)"
+IMAGE_REPO="${ACR_LOGIN_SERVER}/${SERVICE_NAME}"
+docker build --target prod --tag "${IMAGE_REPO}:${IMAGE_TAG}" --tag "${IMAGE_REPO}:latest" -f "${DOCKERFILE_PATH}" "${APP_PATH}"
+docker push "${IMAGE_REPO}:${IMAGE_TAG}"
+docker push "${IMAGE_REPO}:latest"
+```
+
+ACR remote build alternative:
+
+```bash
+az acr build --registry "${ACR_NAME}" --image "${SERVICE_NAME}:${IMAGE_TAG}" --file "${DOCKERFILE_PATH}" "${APP_PATH}"
+```
+
+### 4. Render and deploy
+
+Preferred (azd-first):
+
+```bash
+azd deploy --service "${SERVICE_NAME}" -e "${AZD_ENV_NAME}" --no-prompt
+```
+
+Manual render/deploy path:
+
+```bash
+SERVICE_NAME="${SERVICE_NAME}" IMAGE_PREFIX="${ACR_LOGIN_SERVER}" IMAGE_TAG="${IMAGE_TAG}" K8S_NAMESPACE="${K8S_NAMESPACE}" KEDA_ENABLED="false" PUBLICATION_MODE="none" .infra/azd/hooks/render-helm.sh crm-profile-aggregation
+helm upgrade --install crm-profile-aggregation .kubernetes/chart --namespace "${K8S_NAMESPACE}" --create-namespace --set serviceName=crm-profile-aggregation --set "image.repository=${IMAGE_REPO}" --set "image.tag=${IMAGE_TAG}" --wait --timeout 5m
+```
+
+If you deploy manually, provide env values through a local values file and do not commit secrets.
+
+### 5. Validate deployment
+
+```bash
+kubectl rollout status deployment/crm-profile-aggregation -n "${K8S_NAMESPACE}" --timeout=5m
+kubectl get pods -n "${K8S_NAMESPACE}" -l app=crm-profile-aggregation
+kubectl logs -n "${K8S_NAMESPACE}" -l app=crm-profile-aggregation --tail=100
+kubectl port-forward -n "${K8S_NAMESPACE}" deployment/crm-profile-aggregation 8080:8000
+curl -s http://localhost:8080/health
+curl -s http://localhost:8080/ready
+```
+
+### 6. Teardown
+
+Standalone service cleanup:
+
+```bash
+helm uninstall crm-profile-aggregation -n "${K8S_NAMESPACE}" || true
+kubectl delete configmap crm-profile-aggregation-config -n "${K8S_NAMESPACE}" --ignore-not-found
+kubectl delete secret crm-profile-aggregation-secrets -n "${K8S_NAMESPACE}" --ignore-not-found
+```
+
+Full environment cleanup (destructive, use only when intended):
+
+```bash
+azd down -e "${AZD_ENV_NAME}" --purge --force
+```

--- a/apps/crm-segmentation-personalization/README.md
+++ b/apps/crm-segmentation-personalization/README.md
@@ -25,3 +25,118 @@ python -m pytest ../tests
 - Uses Foundry model settings (`PROJECT_ENDPOINT` or `FOUNDRY_ENDPOINT`, fast/rich model identifiers).
 - Supports Redis/Cosmos/Blob memory configuration via shared memory settings.
 - Requires Event Hub namespace and consumer configuration for background jobs.
+
+---
+
+## Standalone Deployment - azd-first (ACR -> AKS)
+
+This service supports standalone deployment to an existing Holiday Peak Hub Azure environment.
+Use azd as the primary deployment path. Use the manual ACR -> AKS path only when you need isolated rollout or troubleshooting outside the standard workflow.
+
+### Prerequisites
+
+| Tool | Why it is needed |
+|------|------------------|
+| az CLI | Azure authentication and resource operations |
+| azd | Environment selection and service deploy |
+| docker (or az acr build) | Build and push the container image |
+| kubectl + helm | Manual AKS deployment and validation |
+
+### 1. Set service variables
+
+```bash
+SERVICE_NAME="crm-segmentation-personalization"
+APP_PATH="apps/crm-segmentation-personalization/src"
+DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
+AZD_ENV_NAME="dev"
+K8S_NAMESPACE="holiday-peak"
+IMAGE_TAG="$(git rev-parse --short HEAD)"
+```
+
+### 2. Configure required environment variables
+
+Set these in the selected azd environment (recommended) or in your manual Helm values file:
+
+| Variable | Required | Notes |
+|----------|----------|-------|
+| PROJECT_ENDPOINT or FOUNDRY_ENDPOINT | Yes | Azure AI Foundry project endpoint |
+| FOUNDRY_AGENT_ID_FAST | Yes | Fast-path model agent id |
+| MODEL_DEPLOYMENT_NAME_FAST | Yes | Fast-path deployment name |
+| FOUNDRY_AGENT_ID_RICH | Yes | Rich-path model agent id |
+| MODEL_DEPLOYMENT_NAME_RICH | Yes | Rich-path deployment name |
+| EVENT_HUB_NAMESPACE or EVENTHUB_NAMESPACE | Yes | Event Hub namespace FQDN |
+| EVENT_HUB_CONNECTION_STRING or EVENTHUB_CONNECTION_STRING | Usually | Needed when workload identity is not used |
+| APP_NAME | Recommended | Set to crm-segmentation-personalization |
+| CRUD_SERVICE_URL | Service-dependent | Required when this service calls CRUD APIs |
+| REDIS_URL / COSMOS_* / BLOB_* | Optional | Three-tier memory; service degrades gracefully when absent |
+| APPLICATIONINSIGHTS_CONNECTION_STRING | Optional | App telemetry |
+
+Example azd env commands:
+
+```bash
+azd env select "${AZD_ENV_NAME}"
+azd env set APP_NAME "crm-segmentation-personalization"
+# repeat azd env set for the required values above
+```
+
+### 3. Build and push image
+
+```bash
+ACR_NAME="<existing-acr-name>"
+az acr login --name "${ACR_NAME}"
+ACR_LOGIN_SERVER="$(az acr show --name "${ACR_NAME}" --query loginServer -o tsv)"
+IMAGE_REPO="${ACR_LOGIN_SERVER}/${SERVICE_NAME}"
+docker build --target prod --tag "${IMAGE_REPO}:${IMAGE_TAG}" --tag "${IMAGE_REPO}:latest" -f "${DOCKERFILE_PATH}" "${APP_PATH}"
+docker push "${IMAGE_REPO}:${IMAGE_TAG}"
+docker push "${IMAGE_REPO}:latest"
+```
+
+ACR remote build alternative:
+
+```bash
+az acr build --registry "${ACR_NAME}" --image "${SERVICE_NAME}:${IMAGE_TAG}" --file "${DOCKERFILE_PATH}" "${APP_PATH}"
+```
+
+### 4. Render and deploy
+
+Preferred (azd-first):
+
+```bash
+azd deploy --service "${SERVICE_NAME}" -e "${AZD_ENV_NAME}" --no-prompt
+```
+
+Manual render/deploy path:
+
+```bash
+SERVICE_NAME="${SERVICE_NAME}" IMAGE_PREFIX="${ACR_LOGIN_SERVER}" IMAGE_TAG="${IMAGE_TAG}" K8S_NAMESPACE="${K8S_NAMESPACE}" KEDA_ENABLED="false" PUBLICATION_MODE="none" .infra/azd/hooks/render-helm.sh crm-segmentation-personalization
+helm upgrade --install crm-segmentation-personalization .kubernetes/chart --namespace "${K8S_NAMESPACE}" --create-namespace --set serviceName=crm-segmentation-personalization --set "image.repository=${IMAGE_REPO}" --set "image.tag=${IMAGE_TAG}" --wait --timeout 5m
+```
+
+If you deploy manually, provide env values through a local values file and do not commit secrets.
+
+### 5. Validate deployment
+
+```bash
+kubectl rollout status deployment/crm-segmentation-personalization -n "${K8S_NAMESPACE}" --timeout=5m
+kubectl get pods -n "${K8S_NAMESPACE}" -l app=crm-segmentation-personalization
+kubectl logs -n "${K8S_NAMESPACE}" -l app=crm-segmentation-personalization --tail=100
+kubectl port-forward -n "${K8S_NAMESPACE}" deployment/crm-segmentation-personalization 8080:8000
+curl -s http://localhost:8080/health
+curl -s http://localhost:8080/ready
+```
+
+### 6. Teardown
+
+Standalone service cleanup:
+
+```bash
+helm uninstall crm-segmentation-personalization -n "${K8S_NAMESPACE}" || true
+kubectl delete configmap crm-segmentation-personalization-config -n "${K8S_NAMESPACE}" --ignore-not-found
+kubectl delete secret crm-segmentation-personalization-secrets -n "${K8S_NAMESPACE}" --ignore-not-found
+```
+
+Full environment cleanup (destructive, use only when intended):
+
+```bash
+azd down -e "${AZD_ENV_NAME}" --purge --force
+```

--- a/apps/crm-support-assistance/README.md
+++ b/apps/crm-support-assistance/README.md
@@ -25,3 +25,118 @@ python -m pytest ../tests
 - Uses Foundry model settings (`PROJECT_ENDPOINT` or `FOUNDRY_ENDPOINT`, fast/rich model identifiers).
 - Supports Redis/Cosmos/Blob memory configuration via shared memory settings.
 - Requires Event Hub namespace and consumer configuration for background jobs.
+
+---
+
+## Standalone Deployment - azd-first (ACR -> AKS)
+
+This service supports standalone deployment to an existing Holiday Peak Hub Azure environment.
+Use azd as the primary deployment path. Use the manual ACR -> AKS path only when you need isolated rollout or troubleshooting outside the standard workflow.
+
+### Prerequisites
+
+| Tool | Why it is needed |
+|------|------------------|
+| az CLI | Azure authentication and resource operations |
+| azd | Environment selection and service deploy |
+| docker (or az acr build) | Build and push the container image |
+| kubectl + helm | Manual AKS deployment and validation |
+
+### 1. Set service variables
+
+```bash
+SERVICE_NAME="crm-support-assistance"
+APP_PATH="apps/crm-support-assistance/src"
+DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
+AZD_ENV_NAME="dev"
+K8S_NAMESPACE="holiday-peak"
+IMAGE_TAG="$(git rev-parse --short HEAD)"
+```
+
+### 2. Configure required environment variables
+
+Set these in the selected azd environment (recommended) or in your manual Helm values file:
+
+| Variable | Required | Notes |
+|----------|----------|-------|
+| PROJECT_ENDPOINT or FOUNDRY_ENDPOINT | Yes | Azure AI Foundry project endpoint |
+| FOUNDRY_AGENT_ID_FAST | Yes | Fast-path model agent id |
+| MODEL_DEPLOYMENT_NAME_FAST | Yes | Fast-path deployment name |
+| FOUNDRY_AGENT_ID_RICH | Yes | Rich-path model agent id |
+| MODEL_DEPLOYMENT_NAME_RICH | Yes | Rich-path deployment name |
+| EVENT_HUB_NAMESPACE or EVENTHUB_NAMESPACE | Yes | Event Hub namespace FQDN |
+| EVENT_HUB_CONNECTION_STRING or EVENTHUB_CONNECTION_STRING | Usually | Needed when workload identity is not used |
+| APP_NAME | Recommended | Set to crm-support-assistance |
+| CRUD_SERVICE_URL | Service-dependent | Required when this service calls CRUD APIs |
+| REDIS_URL / COSMOS_* / BLOB_* | Optional | Three-tier memory; service degrades gracefully when absent |
+| APPLICATIONINSIGHTS_CONNECTION_STRING | Optional | App telemetry |
+
+Example azd env commands:
+
+```bash
+azd env select "${AZD_ENV_NAME}"
+azd env set APP_NAME "crm-support-assistance"
+# repeat azd env set for the required values above
+```
+
+### 3. Build and push image
+
+```bash
+ACR_NAME="<existing-acr-name>"
+az acr login --name "${ACR_NAME}"
+ACR_LOGIN_SERVER="$(az acr show --name "${ACR_NAME}" --query loginServer -o tsv)"
+IMAGE_REPO="${ACR_LOGIN_SERVER}/${SERVICE_NAME}"
+docker build --target prod --tag "${IMAGE_REPO}:${IMAGE_TAG}" --tag "${IMAGE_REPO}:latest" -f "${DOCKERFILE_PATH}" "${APP_PATH}"
+docker push "${IMAGE_REPO}:${IMAGE_TAG}"
+docker push "${IMAGE_REPO}:latest"
+```
+
+ACR remote build alternative:
+
+```bash
+az acr build --registry "${ACR_NAME}" --image "${SERVICE_NAME}:${IMAGE_TAG}" --file "${DOCKERFILE_PATH}" "${APP_PATH}"
+```
+
+### 4. Render and deploy
+
+Preferred (azd-first):
+
+```bash
+azd deploy --service "${SERVICE_NAME}" -e "${AZD_ENV_NAME}" --no-prompt
+```
+
+Manual render/deploy path:
+
+```bash
+SERVICE_NAME="${SERVICE_NAME}" IMAGE_PREFIX="${ACR_LOGIN_SERVER}" IMAGE_TAG="${IMAGE_TAG}" K8S_NAMESPACE="${K8S_NAMESPACE}" KEDA_ENABLED="false" PUBLICATION_MODE="none" .infra/azd/hooks/render-helm.sh crm-support-assistance
+helm upgrade --install crm-support-assistance .kubernetes/chart --namespace "${K8S_NAMESPACE}" --create-namespace --set serviceName=crm-support-assistance --set "image.repository=${IMAGE_REPO}" --set "image.tag=${IMAGE_TAG}" --wait --timeout 5m
+```
+
+If you deploy manually, provide env values through a local values file and do not commit secrets.
+
+### 5. Validate deployment
+
+```bash
+kubectl rollout status deployment/crm-support-assistance -n "${K8S_NAMESPACE}" --timeout=5m
+kubectl get pods -n "${K8S_NAMESPACE}" -l app=crm-support-assistance
+kubectl logs -n "${K8S_NAMESPACE}" -l app=crm-support-assistance --tail=100
+kubectl port-forward -n "${K8S_NAMESPACE}" deployment/crm-support-assistance 8080:8000
+curl -s http://localhost:8080/health
+curl -s http://localhost:8080/ready
+```
+
+### 6. Teardown
+
+Standalone service cleanup:
+
+```bash
+helm uninstall crm-support-assistance -n "${K8S_NAMESPACE}" || true
+kubectl delete configmap crm-support-assistance-config -n "${K8S_NAMESPACE}" --ignore-not-found
+kubectl delete secret crm-support-assistance-secrets -n "${K8S_NAMESPACE}" --ignore-not-found
+```
+
+Full environment cleanup (destructive, use only when intended):
+
+```bash
+azd down -e "${AZD_ENV_NAME}" --purge --force
+```

--- a/apps/ecommerce-cart-intelligence/README.md
+++ b/apps/ecommerce-cart-intelligence/README.md
@@ -25,3 +25,118 @@ python -m pytest ../tests
 - Uses Foundry model settings (`PROJECT_ENDPOINT` or `FOUNDRY_ENDPOINT`, fast/rich model identifiers).
 - Supports Redis/Cosmos/Blob memory configuration via shared memory settings.
 - Requires Event Hub namespace and consumer configuration for background jobs.
+
+---
+
+## Standalone Deployment - azd-first (ACR -> AKS)
+
+This service supports standalone deployment to an existing Holiday Peak Hub Azure environment.
+Use azd as the primary deployment path. Use the manual ACR -> AKS path only when you need isolated rollout or troubleshooting outside the standard workflow.
+
+### Prerequisites
+
+| Tool | Why it is needed |
+|------|------------------|
+| az CLI | Azure authentication and resource operations |
+| azd | Environment selection and service deploy |
+| docker (or az acr build) | Build and push the container image |
+| kubectl + helm | Manual AKS deployment and validation |
+
+### 1. Set service variables
+
+```bash
+SERVICE_NAME="ecommerce-cart-intelligence"
+APP_PATH="apps/ecommerce-cart-intelligence/src"
+DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
+AZD_ENV_NAME="dev"
+K8S_NAMESPACE="holiday-peak"
+IMAGE_TAG="$(git rev-parse --short HEAD)"
+```
+
+### 2. Configure required environment variables
+
+Set these in the selected azd environment (recommended) or in your manual Helm values file:
+
+| Variable | Required | Notes |
+|----------|----------|-------|
+| PROJECT_ENDPOINT or FOUNDRY_ENDPOINT | Yes | Azure AI Foundry project endpoint |
+| FOUNDRY_AGENT_ID_FAST | Yes | Fast-path model agent id |
+| MODEL_DEPLOYMENT_NAME_FAST | Yes | Fast-path deployment name |
+| FOUNDRY_AGENT_ID_RICH | Yes | Rich-path model agent id |
+| MODEL_DEPLOYMENT_NAME_RICH | Yes | Rich-path deployment name |
+| EVENT_HUB_NAMESPACE or EVENTHUB_NAMESPACE | Yes | Event Hub namespace FQDN |
+| EVENT_HUB_CONNECTION_STRING or EVENTHUB_CONNECTION_STRING | Usually | Needed when workload identity is not used |
+| APP_NAME | Recommended | Set to ecommerce-cart-intelligence |
+| CRUD_SERVICE_URL | Service-dependent | Required when this service calls CRUD APIs |
+| REDIS_URL / COSMOS_* / BLOB_* | Optional | Three-tier memory; service degrades gracefully when absent |
+| APPLICATIONINSIGHTS_CONNECTION_STRING | Optional | App telemetry |
+
+Example azd env commands:
+
+```bash
+azd env select "${AZD_ENV_NAME}"
+azd env set APP_NAME "ecommerce-cart-intelligence"
+# repeat azd env set for the required values above
+```
+
+### 3. Build and push image
+
+```bash
+ACR_NAME="<existing-acr-name>"
+az acr login --name "${ACR_NAME}"
+ACR_LOGIN_SERVER="$(az acr show --name "${ACR_NAME}" --query loginServer -o tsv)"
+IMAGE_REPO="${ACR_LOGIN_SERVER}/${SERVICE_NAME}"
+docker build --target prod --tag "${IMAGE_REPO}:${IMAGE_TAG}" --tag "${IMAGE_REPO}:latest" -f "${DOCKERFILE_PATH}" "${APP_PATH}"
+docker push "${IMAGE_REPO}:${IMAGE_TAG}"
+docker push "${IMAGE_REPO}:latest"
+```
+
+ACR remote build alternative:
+
+```bash
+az acr build --registry "${ACR_NAME}" --image "${SERVICE_NAME}:${IMAGE_TAG}" --file "${DOCKERFILE_PATH}" "${APP_PATH}"
+```
+
+### 4. Render and deploy
+
+Preferred (azd-first):
+
+```bash
+azd deploy --service "${SERVICE_NAME}" -e "${AZD_ENV_NAME}" --no-prompt
+```
+
+Manual render/deploy path:
+
+```bash
+SERVICE_NAME="${SERVICE_NAME}" IMAGE_PREFIX="${ACR_LOGIN_SERVER}" IMAGE_TAG="${IMAGE_TAG}" K8S_NAMESPACE="${K8S_NAMESPACE}" KEDA_ENABLED="false" PUBLICATION_MODE="none" .infra/azd/hooks/render-helm.sh ecommerce-cart-intelligence
+helm upgrade --install ecommerce-cart-intelligence .kubernetes/chart --namespace "${K8S_NAMESPACE}" --create-namespace --set serviceName=ecommerce-cart-intelligence --set "image.repository=${IMAGE_REPO}" --set "image.tag=${IMAGE_TAG}" --wait --timeout 5m
+```
+
+If you deploy manually, provide env values through a local values file and do not commit secrets.
+
+### 5. Validate deployment
+
+```bash
+kubectl rollout status deployment/ecommerce-cart-intelligence -n "${K8S_NAMESPACE}" --timeout=5m
+kubectl get pods -n "${K8S_NAMESPACE}" -l app=ecommerce-cart-intelligence
+kubectl logs -n "${K8S_NAMESPACE}" -l app=ecommerce-cart-intelligence --tail=100
+kubectl port-forward -n "${K8S_NAMESPACE}" deployment/ecommerce-cart-intelligence 8080:8000
+curl -s http://localhost:8080/health
+curl -s http://localhost:8080/ready
+```
+
+### 6. Teardown
+
+Standalone service cleanup:
+
+```bash
+helm uninstall ecommerce-cart-intelligence -n "${K8S_NAMESPACE}" || true
+kubectl delete configmap ecommerce-cart-intelligence-config -n "${K8S_NAMESPACE}" --ignore-not-found
+kubectl delete secret ecommerce-cart-intelligence-secrets -n "${K8S_NAMESPACE}" --ignore-not-found
+```
+
+Full environment cleanup (destructive, use only when intended):
+
+```bash
+azd down -e "${AZD_ENV_NAME}" --purge --force
+```

--- a/apps/ecommerce-catalog-search/README.md
+++ b/apps/ecommerce-catalog-search/README.md
@@ -28,384 +28,115 @@ python -m pytest ../tests
 
 ---
 
-## Deployment Guide — ACR → AKS
+## Standalone Deployment - azd-first (ACR -> AKS)
 
-This guide covers a **manual, step-by-step deployment** of this agent from source to a running pod in AKS.  
-No KeyVault agent is required; environment variables are injected directly into the cluster.
+This service supports standalone deployment to an existing Holiday Peak Hub Azure environment.
+Use azd as the primary deployment path. Use the manual ACR -> AKS path only when you need isolated rollout or troubleshooting outside the standard workflow.
 
 ### Prerequisites
 
-| Tool | Purpose |
-|------|---------|
-| `az` CLI ≥ 2.60 | Azure CLI for ACR and AKS operations |
-| `docker` or `az acr build` | Build and push the container image |
-| `helm` ≥ 3.14 | Render and install the Helm chart |
-| `kubectl` | Apply rendered manifests to AKS |
+| Tool | Why it is needed |
+|------|------------------|
+| az CLI | Azure authentication and resource operations |
+| azd | Environment selection and service deploy |
+| docker (or az acr build) | Build and push the container image |
+| kubectl + helm | Manual AKS deployment and validation |
+
+### 1. Set service variables
 
 ```bash
-# Verify versions
-az version
-docker version
-helm version --short
-kubectl version --client --short
-```
-
----
-
-### Step 1 — Set shell variables
-
-Replace the placeholder values to match your environment before running any subsequent step.
-
-```bash
-# ── Project identifiers ──────────────────────────────────────────────────────
-SUBSCRIPTION_ID="<your-subscription-id>"
-RESOURCE_GROUP="rg-holidaypeakhub405-dev"
-ENVIRONMENT="dev"                                   # dev | staging | prod
-PROJECT_NAME="holidaypeakhub405"
-
-# ── ACR ──────────────────────────────────────────────────────────────────────
-ACR_NAME="${PROJECT_NAME}${ENVIRONMENT}acr"         # e.g. holidaypeakhub405devacr
-ACR_LOGIN_SERVER="${ACR_NAME}.azurecr.io"
-
-# ── Service ──────────────────────────────────────────────────────────────────
 SERVICE_NAME="ecommerce-catalog-search"
-IMAGE_TAG="$(git rev-parse --short HEAD)"           # or any explicit tag, e.g. "1.0.0"
-IMAGE_REPO="${ACR_LOGIN_SERVER}/${SERVICE_NAME}"
-
-# ── AKS ──────────────────────────────────────────────────────────────────────
-AKS_CLUSTER="aks-holidaypeakhub405-${ENVIRONMENT}"
+APP_PATH="apps/ecommerce-catalog-search/src"
+DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
+AZD_ENV_NAME="dev"
 K8S_NAMESPACE="holiday-peak"
+IMAGE_TAG="$(git rev-parse --short HEAD)"
 ```
 
----
+### 2. Configure required environment variables
 
-### Step 2 — Authenticate
+Set these in the selected azd environment (recommended) or in your manual Helm values file:
+
+| Variable | Required | Notes |
+|----------|----------|-------|
+| PROJECT_ENDPOINT or FOUNDRY_ENDPOINT | Yes | Azure AI Foundry project endpoint |
+| FOUNDRY_AGENT_ID_FAST | Yes | Fast-path model agent id |
+| MODEL_DEPLOYMENT_NAME_FAST | Yes | Fast-path deployment name |
+| FOUNDRY_AGENT_ID_RICH | Yes | Rich-path model agent id |
+| MODEL_DEPLOYMENT_NAME_RICH | Yes | Rich-path deployment name |
+| EVENT_HUB_NAMESPACE or EVENTHUB_NAMESPACE | Yes | Event Hub namespace FQDN |
+| EVENT_HUB_CONNECTION_STRING or EVENTHUB_CONNECTION_STRING | Usually | Needed when workload identity is not used |
+| APP_NAME | Recommended | Set to ecommerce-catalog-search |
+| CRUD_SERVICE_URL | Service-dependent | Required when this service calls CRUD APIs |
+| REDIS_URL / COSMOS_* / BLOB_* | Optional | Three-tier memory; service degrades gracefully when absent |
+| APPLICATIONINSIGHTS_CONNECTION_STRING | Optional | App telemetry |
+
+Example azd env commands:
 
 ```bash
-# Log in to Azure
-az login
-az account set --subscription "$SUBSCRIPTION_ID"
-
-# Attach ACR credentials to the local Docker daemon (one-time per session)
-az acr login --name "$ACR_NAME"
-
-# Merge AKS credentials into the local kubeconfig
-az aks get-credentials \
-  --resource-group "$RESOURCE_GROUP" \
-  --name "$AKS_CLUSTER" \
-  --overwrite-existing
-
-# Verify cluster access
-kubectl get nodes
+azd env select "${AZD_ENV_NAME}"
+azd env set APP_NAME "ecommerce-catalog-search"
+# repeat azd env set for the required values above
 ```
 
----
-
-### Step 3 — Build and push the image to ACR
-
-Build from the repository root so that all source files are available in the build context.
+### 3. Build and push image
 
 ```bash
-# From the repository root
-docker build \
-  --target prod \
-  --tag "${IMAGE_REPO}:${IMAGE_TAG}" \
-  --tag "${IMAGE_REPO}:latest" \
-  -f apps/ecommerce-catalog-search/src/Dockerfile \
-  apps/ecommerce-catalog-search/src
-
-# Push both tags
+ACR_NAME="<existing-acr-name>"
+az acr login --name "${ACR_NAME}"
+ACR_LOGIN_SERVER="$(az acr show --name "${ACR_NAME}" --query loginServer -o tsv)"
+IMAGE_REPO="${ACR_LOGIN_SERVER}/${SERVICE_NAME}"
+docker build --target prod --tag "${IMAGE_REPO}:${IMAGE_TAG}" --tag "${IMAGE_REPO}:latest" -f "${DOCKERFILE_PATH}" "${APP_PATH}"
 docker push "${IMAGE_REPO}:${IMAGE_TAG}"
 docker push "${IMAGE_REPO}:latest"
 ```
 
-> **Alternative — build directly inside ACR** (removes the need for a local Docker daemon):
-> ```bash
-> az acr build \
->   --registry "$ACR_NAME" \
->   --image "${SERVICE_NAME}:${IMAGE_TAG}" \
->   --file apps/ecommerce-catalog-search/src/Dockerfile \
->   apps/ecommerce-catalog-search/src
-> ```
-
-Verify the image is available in the registry:
+ACR remote build alternative:
 
 ```bash
-az acr repository show-tags \
-  --name "$ACR_NAME" \
-  --repository "$SERVICE_NAME" \
-  --orderby time_desc \
-  --output table
+az acr build --registry "${ACR_NAME}" --image "${SERVICE_NAME}:${IMAGE_TAG}" --file "${DOCKERFILE_PATH}" "${APP_PATH}"
 ```
 
----
+### 4. Render and deploy
 
-### Step 4 — Create the Kubernetes namespace
+Preferred (azd-first):
 
 ```bash
-kubectl get namespace "$K8S_NAMESPACE" &>/dev/null \
-  || kubectl create namespace "$K8S_NAMESPACE"
+azd deploy --service "${SERVICE_NAME}" -e "${AZD_ENV_NAME}" --no-prompt
 ```
 
----
-
-### Step 5 — Inject environment variables into the cluster
-
-Environment variables are split into two manifests: a **ConfigMap** for non-sensitive settings and a **Secret** for credentials.  
-Neither manifest should be committed to source control.
-
-#### 5a — ConfigMap (non-sensitive)
+Manual render/deploy path:
 
 ```bash
-kubectl create configmap ecommerce-catalog-search-config \
-  --namespace "$K8S_NAMESPACE" \
-  --from-literal=APP_NAME="ecommerce-catalog-search" \
-  --from-literal=PROJECT_ENDPOINT="https://<foundry-project>.api.azureml.ms" \
-  --from-literal=FOUNDRY_ENDPOINT="https://<foundry-project>.api.azureml.ms" \
-  --from-literal=FOUNDRY_AGENT_ID_FAST="<fast-agent-id>" \
-  --from-literal=MODEL_DEPLOYMENT_NAME_FAST="gpt-4o-mini" \
-  --from-literal=FOUNDRY_AGENT_ID_RICH="<rich-agent-id>" \
-  --from-literal=MODEL_DEPLOYMENT_NAME_RICH="gpt-4o" \
-  --from-literal=FOUNDRY_STREAM="false" \
-  --from-literal=AI_SEARCH_ENDPOINT="https://<search-service>.search.windows.net" \
-  --from-literal=AI_SEARCH_INDEX="products-index" \
-  --from-literal=AI_SEARCH_VECTOR_INDEX="products-vector-index" \
-  --from-literal=AI_SEARCH_VECTOR_FIELD="content_vector" \
-  --from-literal=AI_SEARCH_AUTH_MODE="managed_identity" \
-  --from-literal=EMBEDDING_DEPLOYMENT_NAME="text-embedding-3-small" \
-  --from-literal=CRUD_SERVICE_URL="http://crud-service.holiday-peak.svc.cluster.local" \
-  --from-literal=EVENT_HUB_NAMESPACE="<eventhub-namespace>.servicebus.windows.net" \
-  --from-literal=COSMOS_ACCOUNT_URI="https://<cosmos-account>.documents.azure.com:443/" \
-  --from-literal=COSMOS_DATABASE="holiday-peak" \
-  --from-literal=COSMOS_CONTAINER="memory" \
-  --from-literal=BLOB_ACCOUNT_URL="https://<storage-account>.blob.core.windows.net" \
-  --from-literal=BLOB_CONTAINER="agent-memory" \
-  --dry-run=client -o yaml | kubectl apply -f -
+SERVICE_NAME="${SERVICE_NAME}" IMAGE_PREFIX="${ACR_LOGIN_SERVER}" IMAGE_TAG="${IMAGE_TAG}" K8S_NAMESPACE="${K8S_NAMESPACE}" KEDA_ENABLED="false" PUBLICATION_MODE="none" .infra/azd/hooks/render-helm.sh ecommerce-catalog-search
+helm upgrade --install ecommerce-catalog-search .kubernetes/chart --namespace "${K8S_NAMESPACE}" --create-namespace --set serviceName=ecommerce-catalog-search --set "image.repository=${IMAGE_REPO}" --set "image.tag=${IMAGE_TAG}" --wait --timeout 5m
 ```
 
-> Re-running `--dry-run=client -o yaml | kubectl apply -f -` is idempotent and safe to repeat on updates.
+If you deploy manually, provide env values through a local values file and do not commit secrets.
 
-#### 5b — Secret (sensitive credentials)
+### 5. Validate deployment
 
 ```bash
-kubectl create secret generic ecommerce-catalog-search-secrets \
-  --namespace "$K8S_NAMESPACE" \
-  --from-literal=AI_SEARCH_KEY="<ai-search-admin-key>" \
-  --from-literal=EVENT_HUB_CONNECTION_STRING="Endpoint=sb://<ns>.servicebus.windows.net/;SharedAccessKeyName=...;SharedAccessKey=..." \
-  --from-literal=REDIS_URL="rediss://:<password>@<redis-host>:6380/0" \
-  --from-literal=APPLICATIONINSIGHTS_CONNECTION_STRING="InstrumentationKey=...;IngestionEndpoint=..." \
-  --dry-run=client -o yaml | kubectl apply -f -
+kubectl rollout status deployment/ecommerce-catalog-search -n "${K8S_NAMESPACE}" --timeout=5m
+kubectl get pods -n "${K8S_NAMESPACE}" -l app=ecommerce-catalog-search
+kubectl logs -n "${K8S_NAMESPACE}" -l app=ecommerce-catalog-search --tail=100
+kubectl port-forward -n "${K8S_NAMESPACE}" deployment/ecommerce-catalog-search 8080:8000
+curl -s http://localhost:8080/health
+curl -s http://localhost:8080/ready
 ```
 
-> **Prefer managed identity over static keys when available.** Set `AI_SEARCH_AUTH_MODE=managed_identity` and omit `AI_SEARCH_KEY` if the pod's workload identity has the *Search Index Data Reader* role on the search service.
+### 6. Teardown
 
-#### 5c — Verify
+Standalone service cleanup:
 
 ```bash
-kubectl describe configmap ecommerce-catalog-search-config -n "$K8S_NAMESPACE"
-kubectl describe secret ecommerce-catalog-search-secrets -n "$K8S_NAMESPACE"
+helm uninstall ecommerce-catalog-search -n "${K8S_NAMESPACE}" || true
+kubectl delete configmap ecommerce-catalog-search-config -n "${K8S_NAMESPACE}" --ignore-not-found
+kubectl delete secret ecommerce-catalog-search-secrets -n "${K8S_NAMESPACE}" --ignore-not-found
 ```
 
----
-
-### Step 6 — Render the Helm chart
-
-The render hook produces a `kubectl`-ready manifest under `.kubernetes/rendered/`.
+Full environment cleanup (destructive, use only when intended):
 
 ```bash
-# From the repository root
-SERVICE_NAME="ecommerce-catalog-search" \
-IMAGE_PREFIX="${ACR_LOGIN_SERVER}" \
-IMAGE_TAG="${IMAGE_TAG}" \
-K8S_NAMESPACE="${K8S_NAMESPACE}" \
-KEDA_ENABLED="false" \
-PUBLICATION_MODE="none" \
-  .infra/azd/hooks/render-helm.sh ecommerce-catalog-search
-```
-
-Inspect the rendered output before applying:
-
-```bash
-cat .kubernetes/rendered/ecommerce-catalog-search/*.yaml
-```
-
----
-
-### Step 7 — Inject env vars into the rendered manifest
-
-The Helm chart exposes environment variables via `--set env.<KEY>=<VALUE>`. To pass all values from your ConfigMap and Secret without exposing them in shell history, create a local `values-env.yaml` file (**do not commit this file**).
-
-```yaml
-# values-env.yaml  — LOCAL FILE, add to .gitignore
-env:
-  # ConfigMap values
-  APP_NAME: "ecommerce-catalog-search"
-  PROJECT_ENDPOINT: "https://<foundry-project>.api.azureml.ms"
-  FOUNDRY_AGENT_ID_FAST: "<fast-agent-id>"
-  MODEL_DEPLOYMENT_NAME_FAST: "gpt-4o-mini"
-  FOUNDRY_AGENT_ID_RICH: "<rich-agent-id>"
-  MODEL_DEPLOYMENT_NAME_RICH: "gpt-4o"
-  FOUNDRY_STREAM: "false"
-  AI_SEARCH_ENDPOINT: "https://<search-service>.search.windows.net"
-  AI_SEARCH_INDEX: "products-index"
-  AI_SEARCH_VECTOR_INDEX: "products-vector-index"
-  AI_SEARCH_VECTOR_FIELD: "content_vector"
-  AI_SEARCH_AUTH_MODE: "managed_identity"
-  EMBEDDING_DEPLOYMENT_NAME: "text-embedding-3-small"
-  CRUD_SERVICE_URL: "http://crud-service.holiday-peak.svc.cluster.local"
-  EVENT_HUB_NAMESPACE: "<eventhub-namespace>.servicebus.windows.net"
-  COSMOS_ACCOUNT_URI: "https://<cosmos-account>.documents.azure.com:443/"
-  COSMOS_DATABASE: "holiday-peak"
-  COSMOS_CONTAINER: "memory"
-  BLOB_ACCOUNT_URL: "https://<storage-account>.blob.core.windows.net"
-  BLOB_CONTAINER: "agent-memory"
-  # Sensitive values — keep this file out of version control
-  AI_SEARCH_KEY: "<ai-search-admin-key>"
-  EVENT_HUB_CONNECTION_STRING: "Endpoint=sb://..."
-  REDIS_URL: "rediss://:<password>@<host>:6380/0"
-  APPLICATIONINSIGHTS_CONNECTION_STRING: "InstrumentationKey=..."
-```
-
-Then install or upgrade:
-
-```bash
-helm upgrade --install ecommerce-catalog-search \
-  .kubernetes/chart \
-  --namespace "$K8S_NAMESPACE" \
-  --create-namespace \
-  --set serviceName=ecommerce-catalog-search \
-  --set "image.repository=${IMAGE_REPO}" \
-  --set "image.tag=${IMAGE_TAG}" \
-  --set nodeSelector.agentpool=agents \
-  --set tolerations[0].key=workload \
-  --set tolerations[0].operator=Equal \
-  --set tolerations[0].value=agents \
-  --set tolerations[0].effect=NoSchedule \
-  --values values-env.yaml \
-  --wait \
-  --timeout 5m
-```
-
----
-
-### Step 8 — Validate the deployment
-
-```bash
-# Watch rollout progress
-kubectl rollout status deployment/ecommerce-catalog-search \
-  --namespace "$K8S_NAMESPACE" \
-  --timeout=5m
-
-# Inspect the running pods
-kubectl get pods -n "$K8S_NAMESPACE" -l app=ecommerce-catalog-search
-
-# Stream logs from the first pod
-kubectl logs -n "$K8S_NAMESPACE" \
-  -l app=ecommerce-catalog-search \
-  --follow --tail=100
-
-# Smoke-test the health endpoint via port-forward
-kubectl port-forward \
-  -n "$K8S_NAMESPACE" \
-  deployment/ecommerce-catalog-search 8080:8000 &
-
-curl -s http://localhost:8080/health | python3 -m json.tool
-curl -s http://localhost:8080/ready  | python3 -m json.tool
-```
-
----
-
-### Environment Variable Reference
-
-#### Azure AI Foundry (required)
-
-| Variable | Description | Example |
-|----------|-------------|---------|
-| `PROJECT_ENDPOINT` / `FOUNDRY_ENDPOINT` | Azure AI Foundry project endpoint | `https://<project>.api.azureml.ms` |
-| `FOUNDRY_AGENT_ID_FAST` | SLM agent ID for low-complexity requests | `asst_abc123` |
-| `MODEL_DEPLOYMENT_NAME_FAST` | SLM deployment name | `gpt-4o-mini` |
-| `FOUNDRY_AGENT_ID_RICH` | LLM agent ID for complex requests | `asst_xyz456` |
-| `MODEL_DEPLOYMENT_NAME_RICH` | LLM deployment name | `gpt-4o` |
-| `FOUNDRY_STREAM` | Enable streaming responses | `false` |
-
-#### Azure AI Search (required)
-
-| Variable | Description | Default | Example |
-|----------|-------------|---------|---------|
-| `AI_SEARCH_ENDPOINT` | Search service URL | — | `https://<name>.search.windows.net` |
-| `AI_SEARCH_INDEX` | Primary keyword/full-text index name | — | `products-index` |
-| `AI_SEARCH_VECTOR_INDEX` | Vector index name | Falls back to `AI_SEARCH_INDEX` | `products-vector-index` |
-| `AI_SEARCH_VECTOR_FIELD` | Vector field inside the index | `content_vector` | `content_vector` |
-| `AI_SEARCH_AUTH_MODE` | `managed_identity` or `api_key` | `managed_identity` | `managed_identity` |
-| `AI_SEARCH_KEY` | API key (only when `AUTH_MODE=api_key`) | — | `<secret>` |
-| `EMBEDDING_DEPLOYMENT_NAME` | Embedding model deployment name | — | `text-embedding-3-small` |
-
-#### CRUD Service (required)
-
-| Variable | Description | Example |
-|----------|-------------|---------|
-| `CRUD_SERVICE_URL` | Internal URL of the CRUD service | `http://crud-service.holiday-peak.svc.cluster.local` |
-
-#### Azure Event Hub (required)
-
-| Variable | Description | Example |
-|----------|-------------|---------|
-| `EVENT_HUB_CONNECTION_STRING` / `EVENTHUB_CONNECTION_STRING` | Connection string with *Listen* rights on the `product-events` hub | `Endpoint=sb://...` |
-| `EVENT_HUB_NAMESPACE` / `EVENTHUB_NAMESPACE` | Namespace FQDN (used when workload identity replaces connection strings) | `<ns>.servicebus.windows.net` |
-| `AZURE_CLIENT_ID` | Managed identity client ID for Event Hub auth via workload identity | `<uuid>` |
-
-#### Three-tier Memory (optional — degrades gracefully when absent)
-
-| Variable | Description | Example |
-|----------|-------------|---------|
-| `REDIS_URL` | Hot memory — Redis connection string | `rediss://:<password>@<host>:6380/0` |
-| `COSMOS_ACCOUNT_URI` | Warm memory — Cosmos DB account endpoint | `https://<account>.documents.azure.com:443/` |
-| `COSMOS_DATABASE` | Cosmos DB database name | `holiday-peak` |
-| `COSMOS_CONTAINER` | Cosmos DB container name | `memory` |
-| `BLOB_ACCOUNT_URL` | Cold memory — Blob Storage account URL | `https://<account>.blob.core.windows.net` |
-| `BLOB_CONTAINER` | Blob container name | `agent-memory` |
-
-#### Observability (optional)
-
-| Variable | Description | Example |
-|----------|-------------|---------|
-| `APPLICATIONINSIGHTS_CONNECTION_STRING` / `APPINSIGHTS_CONNECTION_STRING` | Application Insights telemetry connection string | `InstrumentationKey=...;IngestionEndpoint=...` |
-| `FOUNDRY_TRACING_ENABLED` | Enable Foundry trace capture | `true` |
-| `FOUNDRY_TRACING_MAX_EVENTS` | Max events buffered per trace | `500` |
-
----
-
-### Updating the deployment
-
-To deploy a new image version without replacing env vars:
-
-```bash
-IMAGE_TAG="<new-tag>"
-
-kubectl set image deployment/ecommerce-catalog-search \
-  ecommerce-catalog-search="${IMAGE_REPO}:${IMAGE_TAG}" \
-  --namespace "$K8S_NAMESPACE"
-
-kubectl rollout status deployment/ecommerce-catalog-search \
-  --namespace "$K8S_NAMESPACE" --timeout=5m
-```
-
-To update a single environment variable without a full redeploy:
-
-```bash
-# Edit the ConfigMap directly
-kubectl edit configmap ecommerce-catalog-search-config -n "$K8S_NAMESPACE"
-
-# Then trigger a rolling restart to pick up the changes
-kubectl rollout restart deployment/ecommerce-catalog-search -n "$K8S_NAMESPACE"
-```
-
----
-
-### Teardown
-
-```bash
-helm uninstall ecommerce-catalog-search --namespace "$K8S_NAMESPACE"
-kubectl delete configmap ecommerce-catalog-search-config -n "$K8S_NAMESPACE"
-kubectl delete secret ecommerce-catalog-search-secrets -n "$K8S_NAMESPACE"
+azd down -e "${AZD_ENV_NAME}" --purge --force
 ```

--- a/apps/ecommerce-checkout-support/README.md
+++ b/apps/ecommerce-checkout-support/README.md
@@ -25,3 +25,118 @@ python -m pytest ../tests
 - Uses Foundry model settings (`PROJECT_ENDPOINT` or `FOUNDRY_ENDPOINT`, fast/rich model identifiers).
 - Supports Redis/Cosmos/Blob memory configuration via shared memory settings.
 - Requires Event Hub namespace and consumer configuration for background jobs.
+
+---
+
+## Standalone Deployment - azd-first (ACR -> AKS)
+
+This service supports standalone deployment to an existing Holiday Peak Hub Azure environment.
+Use azd as the primary deployment path. Use the manual ACR -> AKS path only when you need isolated rollout or troubleshooting outside the standard workflow.
+
+### Prerequisites
+
+| Tool | Why it is needed |
+|------|------------------|
+| az CLI | Azure authentication and resource operations |
+| azd | Environment selection and service deploy |
+| docker (or az acr build) | Build and push the container image |
+| kubectl + helm | Manual AKS deployment and validation |
+
+### 1. Set service variables
+
+```bash
+SERVICE_NAME="ecommerce-checkout-support"
+APP_PATH="apps/ecommerce-checkout-support/src"
+DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
+AZD_ENV_NAME="dev"
+K8S_NAMESPACE="holiday-peak"
+IMAGE_TAG="$(git rev-parse --short HEAD)"
+```
+
+### 2. Configure required environment variables
+
+Set these in the selected azd environment (recommended) or in your manual Helm values file:
+
+| Variable | Required | Notes |
+|----------|----------|-------|
+| PROJECT_ENDPOINT or FOUNDRY_ENDPOINT | Yes | Azure AI Foundry project endpoint |
+| FOUNDRY_AGENT_ID_FAST | Yes | Fast-path model agent id |
+| MODEL_DEPLOYMENT_NAME_FAST | Yes | Fast-path deployment name |
+| FOUNDRY_AGENT_ID_RICH | Yes | Rich-path model agent id |
+| MODEL_DEPLOYMENT_NAME_RICH | Yes | Rich-path deployment name |
+| EVENT_HUB_NAMESPACE or EVENTHUB_NAMESPACE | Yes | Event Hub namespace FQDN |
+| EVENT_HUB_CONNECTION_STRING or EVENTHUB_CONNECTION_STRING | Usually | Needed when workload identity is not used |
+| APP_NAME | Recommended | Set to ecommerce-checkout-support |
+| CRUD_SERVICE_URL | Service-dependent | Required when this service calls CRUD APIs |
+| REDIS_URL / COSMOS_* / BLOB_* | Optional | Three-tier memory; service degrades gracefully when absent |
+| APPLICATIONINSIGHTS_CONNECTION_STRING | Optional | App telemetry |
+
+Example azd env commands:
+
+```bash
+azd env select "${AZD_ENV_NAME}"
+azd env set APP_NAME "ecommerce-checkout-support"
+# repeat azd env set for the required values above
+```
+
+### 3. Build and push image
+
+```bash
+ACR_NAME="<existing-acr-name>"
+az acr login --name "${ACR_NAME}"
+ACR_LOGIN_SERVER="$(az acr show --name "${ACR_NAME}" --query loginServer -o tsv)"
+IMAGE_REPO="${ACR_LOGIN_SERVER}/${SERVICE_NAME}"
+docker build --target prod --tag "${IMAGE_REPO}:${IMAGE_TAG}" --tag "${IMAGE_REPO}:latest" -f "${DOCKERFILE_PATH}" "${APP_PATH}"
+docker push "${IMAGE_REPO}:${IMAGE_TAG}"
+docker push "${IMAGE_REPO}:latest"
+```
+
+ACR remote build alternative:
+
+```bash
+az acr build --registry "${ACR_NAME}" --image "${SERVICE_NAME}:${IMAGE_TAG}" --file "${DOCKERFILE_PATH}" "${APP_PATH}"
+```
+
+### 4. Render and deploy
+
+Preferred (azd-first):
+
+```bash
+azd deploy --service "${SERVICE_NAME}" -e "${AZD_ENV_NAME}" --no-prompt
+```
+
+Manual render/deploy path:
+
+```bash
+SERVICE_NAME="${SERVICE_NAME}" IMAGE_PREFIX="${ACR_LOGIN_SERVER}" IMAGE_TAG="${IMAGE_TAG}" K8S_NAMESPACE="${K8S_NAMESPACE}" KEDA_ENABLED="false" PUBLICATION_MODE="none" .infra/azd/hooks/render-helm.sh ecommerce-checkout-support
+helm upgrade --install ecommerce-checkout-support .kubernetes/chart --namespace "${K8S_NAMESPACE}" --create-namespace --set serviceName=ecommerce-checkout-support --set "image.repository=${IMAGE_REPO}" --set "image.tag=${IMAGE_TAG}" --wait --timeout 5m
+```
+
+If you deploy manually, provide env values through a local values file and do not commit secrets.
+
+### 5. Validate deployment
+
+```bash
+kubectl rollout status deployment/ecommerce-checkout-support -n "${K8S_NAMESPACE}" --timeout=5m
+kubectl get pods -n "${K8S_NAMESPACE}" -l app=ecommerce-checkout-support
+kubectl logs -n "${K8S_NAMESPACE}" -l app=ecommerce-checkout-support --tail=100
+kubectl port-forward -n "${K8S_NAMESPACE}" deployment/ecommerce-checkout-support 8080:8000
+curl -s http://localhost:8080/health
+curl -s http://localhost:8080/ready
+```
+
+### 6. Teardown
+
+Standalone service cleanup:
+
+```bash
+helm uninstall ecommerce-checkout-support -n "${K8S_NAMESPACE}" || true
+kubectl delete configmap ecommerce-checkout-support-config -n "${K8S_NAMESPACE}" --ignore-not-found
+kubectl delete secret ecommerce-checkout-support-secrets -n "${K8S_NAMESPACE}" --ignore-not-found
+```
+
+Full environment cleanup (destructive, use only when intended):
+
+```bash
+azd down -e "${AZD_ENV_NAME}" --purge --force
+```

--- a/apps/ecommerce-order-status/README.md
+++ b/apps/ecommerce-order-status/README.md
@@ -25,3 +25,118 @@ python -m pytest ../tests
 - Uses Foundry model settings (`PROJECT_ENDPOINT` or `FOUNDRY_ENDPOINT`, fast/rich model identifiers).
 - Supports Redis/Cosmos/Blob memory configuration via shared memory settings.
 - Requires Event Hub namespace and consumer configuration for background jobs.
+
+---
+
+## Standalone Deployment - azd-first (ACR -> AKS)
+
+This service supports standalone deployment to an existing Holiday Peak Hub Azure environment.
+Use azd as the primary deployment path. Use the manual ACR -> AKS path only when you need isolated rollout or troubleshooting outside the standard workflow.
+
+### Prerequisites
+
+| Tool | Why it is needed |
+|------|------------------|
+| az CLI | Azure authentication and resource operations |
+| azd | Environment selection and service deploy |
+| docker (or az acr build) | Build and push the container image |
+| kubectl + helm | Manual AKS deployment and validation |
+
+### 1. Set service variables
+
+```bash
+SERVICE_NAME="ecommerce-order-status"
+APP_PATH="apps/ecommerce-order-status/src"
+DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
+AZD_ENV_NAME="dev"
+K8S_NAMESPACE="holiday-peak"
+IMAGE_TAG="$(git rev-parse --short HEAD)"
+```
+
+### 2. Configure required environment variables
+
+Set these in the selected azd environment (recommended) or in your manual Helm values file:
+
+| Variable | Required | Notes |
+|----------|----------|-------|
+| PROJECT_ENDPOINT or FOUNDRY_ENDPOINT | Yes | Azure AI Foundry project endpoint |
+| FOUNDRY_AGENT_ID_FAST | Yes | Fast-path model agent id |
+| MODEL_DEPLOYMENT_NAME_FAST | Yes | Fast-path deployment name |
+| FOUNDRY_AGENT_ID_RICH | Yes | Rich-path model agent id |
+| MODEL_DEPLOYMENT_NAME_RICH | Yes | Rich-path deployment name |
+| EVENT_HUB_NAMESPACE or EVENTHUB_NAMESPACE | Yes | Event Hub namespace FQDN |
+| EVENT_HUB_CONNECTION_STRING or EVENTHUB_CONNECTION_STRING | Usually | Needed when workload identity is not used |
+| APP_NAME | Recommended | Set to ecommerce-order-status |
+| CRUD_SERVICE_URL | Service-dependent | Required when this service calls CRUD APIs |
+| REDIS_URL / COSMOS_* / BLOB_* | Optional | Three-tier memory; service degrades gracefully when absent |
+| APPLICATIONINSIGHTS_CONNECTION_STRING | Optional | App telemetry |
+
+Example azd env commands:
+
+```bash
+azd env select "${AZD_ENV_NAME}"
+azd env set APP_NAME "ecommerce-order-status"
+# repeat azd env set for the required values above
+```
+
+### 3. Build and push image
+
+```bash
+ACR_NAME="<existing-acr-name>"
+az acr login --name "${ACR_NAME}"
+ACR_LOGIN_SERVER="$(az acr show --name "${ACR_NAME}" --query loginServer -o tsv)"
+IMAGE_REPO="${ACR_LOGIN_SERVER}/${SERVICE_NAME}"
+docker build --target prod --tag "${IMAGE_REPO}:${IMAGE_TAG}" --tag "${IMAGE_REPO}:latest" -f "${DOCKERFILE_PATH}" "${APP_PATH}"
+docker push "${IMAGE_REPO}:${IMAGE_TAG}"
+docker push "${IMAGE_REPO}:latest"
+```
+
+ACR remote build alternative:
+
+```bash
+az acr build --registry "${ACR_NAME}" --image "${SERVICE_NAME}:${IMAGE_TAG}" --file "${DOCKERFILE_PATH}" "${APP_PATH}"
+```
+
+### 4. Render and deploy
+
+Preferred (azd-first):
+
+```bash
+azd deploy --service "${SERVICE_NAME}" -e "${AZD_ENV_NAME}" --no-prompt
+```
+
+Manual render/deploy path:
+
+```bash
+SERVICE_NAME="${SERVICE_NAME}" IMAGE_PREFIX="${ACR_LOGIN_SERVER}" IMAGE_TAG="${IMAGE_TAG}" K8S_NAMESPACE="${K8S_NAMESPACE}" KEDA_ENABLED="false" PUBLICATION_MODE="none" .infra/azd/hooks/render-helm.sh ecommerce-order-status
+helm upgrade --install ecommerce-order-status .kubernetes/chart --namespace "${K8S_NAMESPACE}" --create-namespace --set serviceName=ecommerce-order-status --set "image.repository=${IMAGE_REPO}" --set "image.tag=${IMAGE_TAG}" --wait --timeout 5m
+```
+
+If you deploy manually, provide env values through a local values file and do not commit secrets.
+
+### 5. Validate deployment
+
+```bash
+kubectl rollout status deployment/ecommerce-order-status -n "${K8S_NAMESPACE}" --timeout=5m
+kubectl get pods -n "${K8S_NAMESPACE}" -l app=ecommerce-order-status
+kubectl logs -n "${K8S_NAMESPACE}" -l app=ecommerce-order-status --tail=100
+kubectl port-forward -n "${K8S_NAMESPACE}" deployment/ecommerce-order-status 8080:8000
+curl -s http://localhost:8080/health
+curl -s http://localhost:8080/ready
+```
+
+### 6. Teardown
+
+Standalone service cleanup:
+
+```bash
+helm uninstall ecommerce-order-status -n "${K8S_NAMESPACE}" || true
+kubectl delete configmap ecommerce-order-status-config -n "${K8S_NAMESPACE}" --ignore-not-found
+kubectl delete secret ecommerce-order-status-secrets -n "${K8S_NAMESPACE}" --ignore-not-found
+```
+
+Full environment cleanup (destructive, use only when intended):
+
+```bash
+azd down -e "${AZD_ENV_NAME}" --purge --force
+```

--- a/apps/ecommerce-product-detail-enrichment/README.md
+++ b/apps/ecommerce-product-detail-enrichment/README.md
@@ -25,3 +25,118 @@ python -m pytest ../tests
 - Uses Foundry model settings (`PROJECT_ENDPOINT` or `FOUNDRY_ENDPOINT`, fast/rich model identifiers).
 - Supports Redis/Cosmos/Blob memory configuration via shared memory settings.
 - Requires Event Hub namespace and consumer configuration for background jobs.
+
+---
+
+## Standalone Deployment - azd-first (ACR -> AKS)
+
+This service supports standalone deployment to an existing Holiday Peak Hub Azure environment.
+Use azd as the primary deployment path. Use the manual ACR -> AKS path only when you need isolated rollout or troubleshooting outside the standard workflow.
+
+### Prerequisites
+
+| Tool | Why it is needed |
+|------|------------------|
+| az CLI | Azure authentication and resource operations |
+| azd | Environment selection and service deploy |
+| docker (or az acr build) | Build and push the container image |
+| kubectl + helm | Manual AKS deployment and validation |
+
+### 1. Set service variables
+
+```bash
+SERVICE_NAME="ecommerce-product-detail-enrichment"
+APP_PATH="apps/ecommerce-product-detail-enrichment/src"
+DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
+AZD_ENV_NAME="dev"
+K8S_NAMESPACE="holiday-peak"
+IMAGE_TAG="$(git rev-parse --short HEAD)"
+```
+
+### 2. Configure required environment variables
+
+Set these in the selected azd environment (recommended) or in your manual Helm values file:
+
+| Variable | Required | Notes |
+|----------|----------|-------|
+| PROJECT_ENDPOINT or FOUNDRY_ENDPOINT | Yes | Azure AI Foundry project endpoint |
+| FOUNDRY_AGENT_ID_FAST | Yes | Fast-path model agent id |
+| MODEL_DEPLOYMENT_NAME_FAST | Yes | Fast-path deployment name |
+| FOUNDRY_AGENT_ID_RICH | Yes | Rich-path model agent id |
+| MODEL_DEPLOYMENT_NAME_RICH | Yes | Rich-path deployment name |
+| EVENT_HUB_NAMESPACE or EVENTHUB_NAMESPACE | Yes | Event Hub namespace FQDN |
+| EVENT_HUB_CONNECTION_STRING or EVENTHUB_CONNECTION_STRING | Usually | Needed when workload identity is not used |
+| APP_NAME | Recommended | Set to ecommerce-product-detail-enrichment |
+| CRUD_SERVICE_URL | Service-dependent | Required when this service calls CRUD APIs |
+| REDIS_URL / COSMOS_* / BLOB_* | Optional | Three-tier memory; service degrades gracefully when absent |
+| APPLICATIONINSIGHTS_CONNECTION_STRING | Optional | App telemetry |
+
+Example azd env commands:
+
+```bash
+azd env select "${AZD_ENV_NAME}"
+azd env set APP_NAME "ecommerce-product-detail-enrichment"
+# repeat azd env set for the required values above
+```
+
+### 3. Build and push image
+
+```bash
+ACR_NAME="<existing-acr-name>"
+az acr login --name "${ACR_NAME}"
+ACR_LOGIN_SERVER="$(az acr show --name "${ACR_NAME}" --query loginServer -o tsv)"
+IMAGE_REPO="${ACR_LOGIN_SERVER}/${SERVICE_NAME}"
+docker build --target prod --tag "${IMAGE_REPO}:${IMAGE_TAG}" --tag "${IMAGE_REPO}:latest" -f "${DOCKERFILE_PATH}" "${APP_PATH}"
+docker push "${IMAGE_REPO}:${IMAGE_TAG}"
+docker push "${IMAGE_REPO}:latest"
+```
+
+ACR remote build alternative:
+
+```bash
+az acr build --registry "${ACR_NAME}" --image "${SERVICE_NAME}:${IMAGE_TAG}" --file "${DOCKERFILE_PATH}" "${APP_PATH}"
+```
+
+### 4. Render and deploy
+
+Preferred (azd-first):
+
+```bash
+azd deploy --service "${SERVICE_NAME}" -e "${AZD_ENV_NAME}" --no-prompt
+```
+
+Manual render/deploy path:
+
+```bash
+SERVICE_NAME="${SERVICE_NAME}" IMAGE_PREFIX="${ACR_LOGIN_SERVER}" IMAGE_TAG="${IMAGE_TAG}" K8S_NAMESPACE="${K8S_NAMESPACE}" KEDA_ENABLED="false" PUBLICATION_MODE="none" .infra/azd/hooks/render-helm.sh ecommerce-product-detail-enrichment
+helm upgrade --install ecommerce-product-detail-enrichment .kubernetes/chart --namespace "${K8S_NAMESPACE}" --create-namespace --set serviceName=ecommerce-product-detail-enrichment --set "image.repository=${IMAGE_REPO}" --set "image.tag=${IMAGE_TAG}" --wait --timeout 5m
+```
+
+If you deploy manually, provide env values through a local values file and do not commit secrets.
+
+### 5. Validate deployment
+
+```bash
+kubectl rollout status deployment/ecommerce-product-detail-enrichment -n "${K8S_NAMESPACE}" --timeout=5m
+kubectl get pods -n "${K8S_NAMESPACE}" -l app=ecommerce-product-detail-enrichment
+kubectl logs -n "${K8S_NAMESPACE}" -l app=ecommerce-product-detail-enrichment --tail=100
+kubectl port-forward -n "${K8S_NAMESPACE}" deployment/ecommerce-product-detail-enrichment 8080:8000
+curl -s http://localhost:8080/health
+curl -s http://localhost:8080/ready
+```
+
+### 6. Teardown
+
+Standalone service cleanup:
+
+```bash
+helm uninstall ecommerce-product-detail-enrichment -n "${K8S_NAMESPACE}" || true
+kubectl delete configmap ecommerce-product-detail-enrichment-config -n "${K8S_NAMESPACE}" --ignore-not-found
+kubectl delete secret ecommerce-product-detail-enrichment-secrets -n "${K8S_NAMESPACE}" --ignore-not-found
+```
+
+Full environment cleanup (destructive, use only when intended):
+
+```bash
+azd down -e "${AZD_ENV_NAME}" --purge --force
+```

--- a/apps/inventory-alerts-triggers/README.md
+++ b/apps/inventory-alerts-triggers/README.md
@@ -25,3 +25,118 @@ python -m pytest ../tests
 - Uses Foundry model settings (`PROJECT_ENDPOINT` or `FOUNDRY_ENDPOINT`, fast/rich model identifiers).
 - Supports Redis/Cosmos/Blob memory configuration via shared memory settings.
 - Requires Event Hub namespace and consumer configuration for background jobs.
+
+---
+
+## Standalone Deployment - azd-first (ACR -> AKS)
+
+This service supports standalone deployment to an existing Holiday Peak Hub Azure environment.
+Use azd as the primary deployment path. Use the manual ACR -> AKS path only when you need isolated rollout or troubleshooting outside the standard workflow.
+
+### Prerequisites
+
+| Tool | Why it is needed |
+|------|------------------|
+| az CLI | Azure authentication and resource operations |
+| azd | Environment selection and service deploy |
+| docker (or az acr build) | Build and push the container image |
+| kubectl + helm | Manual AKS deployment and validation |
+
+### 1. Set service variables
+
+```bash
+SERVICE_NAME="inventory-alerts-triggers"
+APP_PATH="apps/inventory-alerts-triggers/src"
+DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
+AZD_ENV_NAME="dev"
+K8S_NAMESPACE="holiday-peak"
+IMAGE_TAG="$(git rev-parse --short HEAD)"
+```
+
+### 2. Configure required environment variables
+
+Set these in the selected azd environment (recommended) or in your manual Helm values file:
+
+| Variable | Required | Notes |
+|----------|----------|-------|
+| PROJECT_ENDPOINT or FOUNDRY_ENDPOINT | Yes | Azure AI Foundry project endpoint |
+| FOUNDRY_AGENT_ID_FAST | Yes | Fast-path model agent id |
+| MODEL_DEPLOYMENT_NAME_FAST | Yes | Fast-path deployment name |
+| FOUNDRY_AGENT_ID_RICH | Yes | Rich-path model agent id |
+| MODEL_DEPLOYMENT_NAME_RICH | Yes | Rich-path deployment name |
+| EVENT_HUB_NAMESPACE or EVENTHUB_NAMESPACE | Yes | Event Hub namespace FQDN |
+| EVENT_HUB_CONNECTION_STRING or EVENTHUB_CONNECTION_STRING | Usually | Needed when workload identity is not used |
+| APP_NAME | Recommended | Set to inventory-alerts-triggers |
+| CRUD_SERVICE_URL | Service-dependent | Required when this service calls CRUD APIs |
+| REDIS_URL / COSMOS_* / BLOB_* | Optional | Three-tier memory; service degrades gracefully when absent |
+| APPLICATIONINSIGHTS_CONNECTION_STRING | Optional | App telemetry |
+
+Example azd env commands:
+
+```bash
+azd env select "${AZD_ENV_NAME}"
+azd env set APP_NAME "inventory-alerts-triggers"
+# repeat azd env set for the required values above
+```
+
+### 3. Build and push image
+
+```bash
+ACR_NAME="<existing-acr-name>"
+az acr login --name "${ACR_NAME}"
+ACR_LOGIN_SERVER="$(az acr show --name "${ACR_NAME}" --query loginServer -o tsv)"
+IMAGE_REPO="${ACR_LOGIN_SERVER}/${SERVICE_NAME}"
+docker build --target prod --tag "${IMAGE_REPO}:${IMAGE_TAG}" --tag "${IMAGE_REPO}:latest" -f "${DOCKERFILE_PATH}" "${APP_PATH}"
+docker push "${IMAGE_REPO}:${IMAGE_TAG}"
+docker push "${IMAGE_REPO}:latest"
+```
+
+ACR remote build alternative:
+
+```bash
+az acr build --registry "${ACR_NAME}" --image "${SERVICE_NAME}:${IMAGE_TAG}" --file "${DOCKERFILE_PATH}" "${APP_PATH}"
+```
+
+### 4. Render and deploy
+
+Preferred (azd-first):
+
+```bash
+azd deploy --service "${SERVICE_NAME}" -e "${AZD_ENV_NAME}" --no-prompt
+```
+
+Manual render/deploy path:
+
+```bash
+SERVICE_NAME="${SERVICE_NAME}" IMAGE_PREFIX="${ACR_LOGIN_SERVER}" IMAGE_TAG="${IMAGE_TAG}" K8S_NAMESPACE="${K8S_NAMESPACE}" KEDA_ENABLED="false" PUBLICATION_MODE="none" .infra/azd/hooks/render-helm.sh inventory-alerts-triggers
+helm upgrade --install inventory-alerts-triggers .kubernetes/chart --namespace "${K8S_NAMESPACE}" --create-namespace --set serviceName=inventory-alerts-triggers --set "image.repository=${IMAGE_REPO}" --set "image.tag=${IMAGE_TAG}" --wait --timeout 5m
+```
+
+If you deploy manually, provide env values through a local values file and do not commit secrets.
+
+### 5. Validate deployment
+
+```bash
+kubectl rollout status deployment/inventory-alerts-triggers -n "${K8S_NAMESPACE}" --timeout=5m
+kubectl get pods -n "${K8S_NAMESPACE}" -l app=inventory-alerts-triggers
+kubectl logs -n "${K8S_NAMESPACE}" -l app=inventory-alerts-triggers --tail=100
+kubectl port-forward -n "${K8S_NAMESPACE}" deployment/inventory-alerts-triggers 8080:8000
+curl -s http://localhost:8080/health
+curl -s http://localhost:8080/ready
+```
+
+### 6. Teardown
+
+Standalone service cleanup:
+
+```bash
+helm uninstall inventory-alerts-triggers -n "${K8S_NAMESPACE}" || true
+kubectl delete configmap inventory-alerts-triggers-config -n "${K8S_NAMESPACE}" --ignore-not-found
+kubectl delete secret inventory-alerts-triggers-secrets -n "${K8S_NAMESPACE}" --ignore-not-found
+```
+
+Full environment cleanup (destructive, use only when intended):
+
+```bash
+azd down -e "${AZD_ENV_NAME}" --purge --force
+```

--- a/apps/inventory-health-check/README.md
+++ b/apps/inventory-health-check/README.md
@@ -25,3 +25,118 @@ python -m pytest ../tests
 - Uses Foundry model settings (`PROJECT_ENDPOINT` or `FOUNDRY_ENDPOINT`, fast/rich model identifiers).
 - Supports Redis/Cosmos/Blob memory configuration via shared memory settings.
 - Requires Event Hub namespace and consumer configuration for background jobs.
+
+---
+
+## Standalone Deployment - azd-first (ACR -> AKS)
+
+This service supports standalone deployment to an existing Holiday Peak Hub Azure environment.
+Use azd as the primary deployment path. Use the manual ACR -> AKS path only when you need isolated rollout or troubleshooting outside the standard workflow.
+
+### Prerequisites
+
+| Tool | Why it is needed |
+|------|------------------|
+| az CLI | Azure authentication and resource operations |
+| azd | Environment selection and service deploy |
+| docker (or az acr build) | Build and push the container image |
+| kubectl + helm | Manual AKS deployment and validation |
+
+### 1. Set service variables
+
+```bash
+SERVICE_NAME="inventory-health-check"
+APP_PATH="apps/inventory-health-check/src"
+DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
+AZD_ENV_NAME="dev"
+K8S_NAMESPACE="holiday-peak"
+IMAGE_TAG="$(git rev-parse --short HEAD)"
+```
+
+### 2. Configure required environment variables
+
+Set these in the selected azd environment (recommended) or in your manual Helm values file:
+
+| Variable | Required | Notes |
+|----------|----------|-------|
+| PROJECT_ENDPOINT or FOUNDRY_ENDPOINT | Yes | Azure AI Foundry project endpoint |
+| FOUNDRY_AGENT_ID_FAST | Yes | Fast-path model agent id |
+| MODEL_DEPLOYMENT_NAME_FAST | Yes | Fast-path deployment name |
+| FOUNDRY_AGENT_ID_RICH | Yes | Rich-path model agent id |
+| MODEL_DEPLOYMENT_NAME_RICH | Yes | Rich-path deployment name |
+| EVENT_HUB_NAMESPACE or EVENTHUB_NAMESPACE | Yes | Event Hub namespace FQDN |
+| EVENT_HUB_CONNECTION_STRING or EVENTHUB_CONNECTION_STRING | Usually | Needed when workload identity is not used |
+| APP_NAME | Recommended | Set to inventory-health-check |
+| CRUD_SERVICE_URL | Service-dependent | Required when this service calls CRUD APIs |
+| REDIS_URL / COSMOS_* / BLOB_* | Optional | Three-tier memory; service degrades gracefully when absent |
+| APPLICATIONINSIGHTS_CONNECTION_STRING | Optional | App telemetry |
+
+Example azd env commands:
+
+```bash
+azd env select "${AZD_ENV_NAME}"
+azd env set APP_NAME "inventory-health-check"
+# repeat azd env set for the required values above
+```
+
+### 3. Build and push image
+
+```bash
+ACR_NAME="<existing-acr-name>"
+az acr login --name "${ACR_NAME}"
+ACR_LOGIN_SERVER="$(az acr show --name "${ACR_NAME}" --query loginServer -o tsv)"
+IMAGE_REPO="${ACR_LOGIN_SERVER}/${SERVICE_NAME}"
+docker build --target prod --tag "${IMAGE_REPO}:${IMAGE_TAG}" --tag "${IMAGE_REPO}:latest" -f "${DOCKERFILE_PATH}" "${APP_PATH}"
+docker push "${IMAGE_REPO}:${IMAGE_TAG}"
+docker push "${IMAGE_REPO}:latest"
+```
+
+ACR remote build alternative:
+
+```bash
+az acr build --registry "${ACR_NAME}" --image "${SERVICE_NAME}:${IMAGE_TAG}" --file "${DOCKERFILE_PATH}" "${APP_PATH}"
+```
+
+### 4. Render and deploy
+
+Preferred (azd-first):
+
+```bash
+azd deploy --service "${SERVICE_NAME}" -e "${AZD_ENV_NAME}" --no-prompt
+```
+
+Manual render/deploy path:
+
+```bash
+SERVICE_NAME="${SERVICE_NAME}" IMAGE_PREFIX="${ACR_LOGIN_SERVER}" IMAGE_TAG="${IMAGE_TAG}" K8S_NAMESPACE="${K8S_NAMESPACE}" KEDA_ENABLED="false" PUBLICATION_MODE="none" .infra/azd/hooks/render-helm.sh inventory-health-check
+helm upgrade --install inventory-health-check .kubernetes/chart --namespace "${K8S_NAMESPACE}" --create-namespace --set serviceName=inventory-health-check --set "image.repository=${IMAGE_REPO}" --set "image.tag=${IMAGE_TAG}" --wait --timeout 5m
+```
+
+If you deploy manually, provide env values through a local values file and do not commit secrets.
+
+### 5. Validate deployment
+
+```bash
+kubectl rollout status deployment/inventory-health-check -n "${K8S_NAMESPACE}" --timeout=5m
+kubectl get pods -n "${K8S_NAMESPACE}" -l app=inventory-health-check
+kubectl logs -n "${K8S_NAMESPACE}" -l app=inventory-health-check --tail=100
+kubectl port-forward -n "${K8S_NAMESPACE}" deployment/inventory-health-check 8080:8000
+curl -s http://localhost:8080/health
+curl -s http://localhost:8080/ready
+```
+
+### 6. Teardown
+
+Standalone service cleanup:
+
+```bash
+helm uninstall inventory-health-check -n "${K8S_NAMESPACE}" || true
+kubectl delete configmap inventory-health-check-config -n "${K8S_NAMESPACE}" --ignore-not-found
+kubectl delete secret inventory-health-check-secrets -n "${K8S_NAMESPACE}" --ignore-not-found
+```
+
+Full environment cleanup (destructive, use only when intended):
+
+```bash
+azd down -e "${AZD_ENV_NAME}" --purge --force
+```

--- a/apps/inventory-jit-replenishment/README.md
+++ b/apps/inventory-jit-replenishment/README.md
@@ -25,3 +25,118 @@ python -m pytest ../tests
 - Uses Foundry model settings (`PROJECT_ENDPOINT` or `FOUNDRY_ENDPOINT`, fast/rich model identifiers).
 - Supports Redis/Cosmos/Blob memory configuration via shared memory settings.
 - Requires Event Hub namespace and consumer configuration for background jobs.
+
+---
+
+## Standalone Deployment - azd-first (ACR -> AKS)
+
+This service supports standalone deployment to an existing Holiday Peak Hub Azure environment.
+Use azd as the primary deployment path. Use the manual ACR -> AKS path only when you need isolated rollout or troubleshooting outside the standard workflow.
+
+### Prerequisites
+
+| Tool | Why it is needed |
+|------|------------------|
+| az CLI | Azure authentication and resource operations |
+| azd | Environment selection and service deploy |
+| docker (or az acr build) | Build and push the container image |
+| kubectl + helm | Manual AKS deployment and validation |
+
+### 1. Set service variables
+
+```bash
+SERVICE_NAME="inventory-jit-replenishment"
+APP_PATH="apps/inventory-jit-replenishment/src"
+DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
+AZD_ENV_NAME="dev"
+K8S_NAMESPACE="holiday-peak"
+IMAGE_TAG="$(git rev-parse --short HEAD)"
+```
+
+### 2. Configure required environment variables
+
+Set these in the selected azd environment (recommended) or in your manual Helm values file:
+
+| Variable | Required | Notes |
+|----------|----------|-------|
+| PROJECT_ENDPOINT or FOUNDRY_ENDPOINT | Yes | Azure AI Foundry project endpoint |
+| FOUNDRY_AGENT_ID_FAST | Yes | Fast-path model agent id |
+| MODEL_DEPLOYMENT_NAME_FAST | Yes | Fast-path deployment name |
+| FOUNDRY_AGENT_ID_RICH | Yes | Rich-path model agent id |
+| MODEL_DEPLOYMENT_NAME_RICH | Yes | Rich-path deployment name |
+| EVENT_HUB_NAMESPACE or EVENTHUB_NAMESPACE | Yes | Event Hub namespace FQDN |
+| EVENT_HUB_CONNECTION_STRING or EVENTHUB_CONNECTION_STRING | Usually | Needed when workload identity is not used |
+| APP_NAME | Recommended | Set to inventory-jit-replenishment |
+| CRUD_SERVICE_URL | Service-dependent | Required when this service calls CRUD APIs |
+| REDIS_URL / COSMOS_* / BLOB_* | Optional | Three-tier memory; service degrades gracefully when absent |
+| APPLICATIONINSIGHTS_CONNECTION_STRING | Optional | App telemetry |
+
+Example azd env commands:
+
+```bash
+azd env select "${AZD_ENV_NAME}"
+azd env set APP_NAME "inventory-jit-replenishment"
+# repeat azd env set for the required values above
+```
+
+### 3. Build and push image
+
+```bash
+ACR_NAME="<existing-acr-name>"
+az acr login --name "${ACR_NAME}"
+ACR_LOGIN_SERVER="$(az acr show --name "${ACR_NAME}" --query loginServer -o tsv)"
+IMAGE_REPO="${ACR_LOGIN_SERVER}/${SERVICE_NAME}"
+docker build --target prod --tag "${IMAGE_REPO}:${IMAGE_TAG}" --tag "${IMAGE_REPO}:latest" -f "${DOCKERFILE_PATH}" "${APP_PATH}"
+docker push "${IMAGE_REPO}:${IMAGE_TAG}"
+docker push "${IMAGE_REPO}:latest"
+```
+
+ACR remote build alternative:
+
+```bash
+az acr build --registry "${ACR_NAME}" --image "${SERVICE_NAME}:${IMAGE_TAG}" --file "${DOCKERFILE_PATH}" "${APP_PATH}"
+```
+
+### 4. Render and deploy
+
+Preferred (azd-first):
+
+```bash
+azd deploy --service "${SERVICE_NAME}" -e "${AZD_ENV_NAME}" --no-prompt
+```
+
+Manual render/deploy path:
+
+```bash
+SERVICE_NAME="${SERVICE_NAME}" IMAGE_PREFIX="${ACR_LOGIN_SERVER}" IMAGE_TAG="${IMAGE_TAG}" K8S_NAMESPACE="${K8S_NAMESPACE}" KEDA_ENABLED="false" PUBLICATION_MODE="none" .infra/azd/hooks/render-helm.sh inventory-jit-replenishment
+helm upgrade --install inventory-jit-replenishment .kubernetes/chart --namespace "${K8S_NAMESPACE}" --create-namespace --set serviceName=inventory-jit-replenishment --set "image.repository=${IMAGE_REPO}" --set "image.tag=${IMAGE_TAG}" --wait --timeout 5m
+```
+
+If you deploy manually, provide env values through a local values file and do not commit secrets.
+
+### 5. Validate deployment
+
+```bash
+kubectl rollout status deployment/inventory-jit-replenishment -n "${K8S_NAMESPACE}" --timeout=5m
+kubectl get pods -n "${K8S_NAMESPACE}" -l app=inventory-jit-replenishment
+kubectl logs -n "${K8S_NAMESPACE}" -l app=inventory-jit-replenishment --tail=100
+kubectl port-forward -n "${K8S_NAMESPACE}" deployment/inventory-jit-replenishment 8080:8000
+curl -s http://localhost:8080/health
+curl -s http://localhost:8080/ready
+```
+
+### 6. Teardown
+
+Standalone service cleanup:
+
+```bash
+helm uninstall inventory-jit-replenishment -n "${K8S_NAMESPACE}" || true
+kubectl delete configmap inventory-jit-replenishment-config -n "${K8S_NAMESPACE}" --ignore-not-found
+kubectl delete secret inventory-jit-replenishment-secrets -n "${K8S_NAMESPACE}" --ignore-not-found
+```
+
+Full environment cleanup (destructive, use only when intended):
+
+```bash
+azd down -e "${AZD_ENV_NAME}" --purge --force
+```

--- a/apps/inventory-reservation-validation/README.md
+++ b/apps/inventory-reservation-validation/README.md
@@ -25,3 +25,118 @@ python -m pytest ../tests
 - Uses Foundry model settings (`PROJECT_ENDPOINT` or `FOUNDRY_ENDPOINT`, fast/rich model identifiers).
 - Supports Redis/Cosmos/Blob memory configuration via shared memory settings.
 - Requires Event Hub namespace and consumer configuration for background jobs.
+
+---
+
+## Standalone Deployment - azd-first (ACR -> AKS)
+
+This service supports standalone deployment to an existing Holiday Peak Hub Azure environment.
+Use azd as the primary deployment path. Use the manual ACR -> AKS path only when you need isolated rollout or troubleshooting outside the standard workflow.
+
+### Prerequisites
+
+| Tool | Why it is needed |
+|------|------------------|
+| az CLI | Azure authentication and resource operations |
+| azd | Environment selection and service deploy |
+| docker (or az acr build) | Build and push the container image |
+| kubectl + helm | Manual AKS deployment and validation |
+
+### 1. Set service variables
+
+```bash
+SERVICE_NAME="inventory-reservation-validation"
+APP_PATH="apps/inventory-reservation-validation/src"
+DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
+AZD_ENV_NAME="dev"
+K8S_NAMESPACE="holiday-peak"
+IMAGE_TAG="$(git rev-parse --short HEAD)"
+```
+
+### 2. Configure required environment variables
+
+Set these in the selected azd environment (recommended) or in your manual Helm values file:
+
+| Variable | Required | Notes |
+|----------|----------|-------|
+| PROJECT_ENDPOINT or FOUNDRY_ENDPOINT | Yes | Azure AI Foundry project endpoint |
+| FOUNDRY_AGENT_ID_FAST | Yes | Fast-path model agent id |
+| MODEL_DEPLOYMENT_NAME_FAST | Yes | Fast-path deployment name |
+| FOUNDRY_AGENT_ID_RICH | Yes | Rich-path model agent id |
+| MODEL_DEPLOYMENT_NAME_RICH | Yes | Rich-path deployment name |
+| EVENT_HUB_NAMESPACE or EVENTHUB_NAMESPACE | Yes | Event Hub namespace FQDN |
+| EVENT_HUB_CONNECTION_STRING or EVENTHUB_CONNECTION_STRING | Usually | Needed when workload identity is not used |
+| APP_NAME | Recommended | Set to inventory-reservation-validation |
+| CRUD_SERVICE_URL | Service-dependent | Required when this service calls CRUD APIs |
+| REDIS_URL / COSMOS_* / BLOB_* | Optional | Three-tier memory; service degrades gracefully when absent |
+| APPLICATIONINSIGHTS_CONNECTION_STRING | Optional | App telemetry |
+
+Example azd env commands:
+
+```bash
+azd env select "${AZD_ENV_NAME}"
+azd env set APP_NAME "inventory-reservation-validation"
+# repeat azd env set for the required values above
+```
+
+### 3. Build and push image
+
+```bash
+ACR_NAME="<existing-acr-name>"
+az acr login --name "${ACR_NAME}"
+ACR_LOGIN_SERVER="$(az acr show --name "${ACR_NAME}" --query loginServer -o tsv)"
+IMAGE_REPO="${ACR_LOGIN_SERVER}/${SERVICE_NAME}"
+docker build --target prod --tag "${IMAGE_REPO}:${IMAGE_TAG}" --tag "${IMAGE_REPO}:latest" -f "${DOCKERFILE_PATH}" "${APP_PATH}"
+docker push "${IMAGE_REPO}:${IMAGE_TAG}"
+docker push "${IMAGE_REPO}:latest"
+```
+
+ACR remote build alternative:
+
+```bash
+az acr build --registry "${ACR_NAME}" --image "${SERVICE_NAME}:${IMAGE_TAG}" --file "${DOCKERFILE_PATH}" "${APP_PATH}"
+```
+
+### 4. Render and deploy
+
+Preferred (azd-first):
+
+```bash
+azd deploy --service "${SERVICE_NAME}" -e "${AZD_ENV_NAME}" --no-prompt
+```
+
+Manual render/deploy path:
+
+```bash
+SERVICE_NAME="${SERVICE_NAME}" IMAGE_PREFIX="${ACR_LOGIN_SERVER}" IMAGE_TAG="${IMAGE_TAG}" K8S_NAMESPACE="${K8S_NAMESPACE}" KEDA_ENABLED="false" PUBLICATION_MODE="none" .infra/azd/hooks/render-helm.sh inventory-reservation-validation
+helm upgrade --install inventory-reservation-validation .kubernetes/chart --namespace "${K8S_NAMESPACE}" --create-namespace --set serviceName=inventory-reservation-validation --set "image.repository=${IMAGE_REPO}" --set "image.tag=${IMAGE_TAG}" --wait --timeout 5m
+```
+
+If you deploy manually, provide env values through a local values file and do not commit secrets.
+
+### 5. Validate deployment
+
+```bash
+kubectl rollout status deployment/inventory-reservation-validation -n "${K8S_NAMESPACE}" --timeout=5m
+kubectl get pods -n "${K8S_NAMESPACE}" -l app=inventory-reservation-validation
+kubectl logs -n "${K8S_NAMESPACE}" -l app=inventory-reservation-validation --tail=100
+kubectl port-forward -n "${K8S_NAMESPACE}" deployment/inventory-reservation-validation 8080:8000
+curl -s http://localhost:8080/health
+curl -s http://localhost:8080/ready
+```
+
+### 6. Teardown
+
+Standalone service cleanup:
+
+```bash
+helm uninstall inventory-reservation-validation -n "${K8S_NAMESPACE}" || true
+kubectl delete configmap inventory-reservation-validation-config -n "${K8S_NAMESPACE}" --ignore-not-found
+kubectl delete secret inventory-reservation-validation-secrets -n "${K8S_NAMESPACE}" --ignore-not-found
+```
+
+Full environment cleanup (destructive, use only when intended):
+
+```bash
+azd down -e "${AZD_ENV_NAME}" --purge --force
+```

--- a/apps/logistics-carrier-selection/README.md
+++ b/apps/logistics-carrier-selection/README.md
@@ -25,3 +25,118 @@ python -m pytest ../tests
 - Uses Foundry model settings (`PROJECT_ENDPOINT` or `FOUNDRY_ENDPOINT`, fast/rich model identifiers).
 - Supports Redis/Cosmos/Blob memory configuration via shared memory settings.
 - Requires Event Hub namespace and consumer configuration for background jobs.
+
+---
+
+## Standalone Deployment - azd-first (ACR -> AKS)
+
+This service supports standalone deployment to an existing Holiday Peak Hub Azure environment.
+Use azd as the primary deployment path. Use the manual ACR -> AKS path only when you need isolated rollout or troubleshooting outside the standard workflow.
+
+### Prerequisites
+
+| Tool | Why it is needed |
+|------|------------------|
+| az CLI | Azure authentication and resource operations |
+| azd | Environment selection and service deploy |
+| docker (or az acr build) | Build and push the container image |
+| kubectl + helm | Manual AKS deployment and validation |
+
+### 1. Set service variables
+
+```bash
+SERVICE_NAME="logistics-carrier-selection"
+APP_PATH="apps/logistics-carrier-selection/src"
+DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
+AZD_ENV_NAME="dev"
+K8S_NAMESPACE="holiday-peak"
+IMAGE_TAG="$(git rev-parse --short HEAD)"
+```
+
+### 2. Configure required environment variables
+
+Set these in the selected azd environment (recommended) or in your manual Helm values file:
+
+| Variable | Required | Notes |
+|----------|----------|-------|
+| PROJECT_ENDPOINT or FOUNDRY_ENDPOINT | Yes | Azure AI Foundry project endpoint |
+| FOUNDRY_AGENT_ID_FAST | Yes | Fast-path model agent id |
+| MODEL_DEPLOYMENT_NAME_FAST | Yes | Fast-path deployment name |
+| FOUNDRY_AGENT_ID_RICH | Yes | Rich-path model agent id |
+| MODEL_DEPLOYMENT_NAME_RICH | Yes | Rich-path deployment name |
+| EVENT_HUB_NAMESPACE or EVENTHUB_NAMESPACE | Yes | Event Hub namespace FQDN |
+| EVENT_HUB_CONNECTION_STRING or EVENTHUB_CONNECTION_STRING | Usually | Needed when workload identity is not used |
+| APP_NAME | Recommended | Set to logistics-carrier-selection |
+| CRUD_SERVICE_URL | Service-dependent | Required when this service calls CRUD APIs |
+| REDIS_URL / COSMOS_* / BLOB_* | Optional | Three-tier memory; service degrades gracefully when absent |
+| APPLICATIONINSIGHTS_CONNECTION_STRING | Optional | App telemetry |
+
+Example azd env commands:
+
+```bash
+azd env select "${AZD_ENV_NAME}"
+azd env set APP_NAME "logistics-carrier-selection"
+# repeat azd env set for the required values above
+```
+
+### 3. Build and push image
+
+```bash
+ACR_NAME="<existing-acr-name>"
+az acr login --name "${ACR_NAME}"
+ACR_LOGIN_SERVER="$(az acr show --name "${ACR_NAME}" --query loginServer -o tsv)"
+IMAGE_REPO="${ACR_LOGIN_SERVER}/${SERVICE_NAME}"
+docker build --target prod --tag "${IMAGE_REPO}:${IMAGE_TAG}" --tag "${IMAGE_REPO}:latest" -f "${DOCKERFILE_PATH}" "${APP_PATH}"
+docker push "${IMAGE_REPO}:${IMAGE_TAG}"
+docker push "${IMAGE_REPO}:latest"
+```
+
+ACR remote build alternative:
+
+```bash
+az acr build --registry "${ACR_NAME}" --image "${SERVICE_NAME}:${IMAGE_TAG}" --file "${DOCKERFILE_PATH}" "${APP_PATH}"
+```
+
+### 4. Render and deploy
+
+Preferred (azd-first):
+
+```bash
+azd deploy --service "${SERVICE_NAME}" -e "${AZD_ENV_NAME}" --no-prompt
+```
+
+Manual render/deploy path:
+
+```bash
+SERVICE_NAME="${SERVICE_NAME}" IMAGE_PREFIX="${ACR_LOGIN_SERVER}" IMAGE_TAG="${IMAGE_TAG}" K8S_NAMESPACE="${K8S_NAMESPACE}" KEDA_ENABLED="false" PUBLICATION_MODE="none" .infra/azd/hooks/render-helm.sh logistics-carrier-selection
+helm upgrade --install logistics-carrier-selection .kubernetes/chart --namespace "${K8S_NAMESPACE}" --create-namespace --set serviceName=logistics-carrier-selection --set "image.repository=${IMAGE_REPO}" --set "image.tag=${IMAGE_TAG}" --wait --timeout 5m
+```
+
+If you deploy manually, provide env values through a local values file and do not commit secrets.
+
+### 5. Validate deployment
+
+```bash
+kubectl rollout status deployment/logistics-carrier-selection -n "${K8S_NAMESPACE}" --timeout=5m
+kubectl get pods -n "${K8S_NAMESPACE}" -l app=logistics-carrier-selection
+kubectl logs -n "${K8S_NAMESPACE}" -l app=logistics-carrier-selection --tail=100
+kubectl port-forward -n "${K8S_NAMESPACE}" deployment/logistics-carrier-selection 8080:8000
+curl -s http://localhost:8080/health
+curl -s http://localhost:8080/ready
+```
+
+### 6. Teardown
+
+Standalone service cleanup:
+
+```bash
+helm uninstall logistics-carrier-selection -n "${K8S_NAMESPACE}" || true
+kubectl delete configmap logistics-carrier-selection-config -n "${K8S_NAMESPACE}" --ignore-not-found
+kubectl delete secret logistics-carrier-selection-secrets -n "${K8S_NAMESPACE}" --ignore-not-found
+```
+
+Full environment cleanup (destructive, use only when intended):
+
+```bash
+azd down -e "${AZD_ENV_NAME}" --purge --force
+```

--- a/apps/logistics-eta-computation/README.md
+++ b/apps/logistics-eta-computation/README.md
@@ -25,3 +25,118 @@ python -m pytest ../tests
 - Uses Foundry model settings (`PROJECT_ENDPOINT` or `FOUNDRY_ENDPOINT`, fast/rich model identifiers).
 - Supports Redis/Cosmos/Blob memory configuration via shared memory settings.
 - Requires Event Hub namespace and consumer configuration for background jobs.
+
+---
+
+## Standalone Deployment - azd-first (ACR -> AKS)
+
+This service supports standalone deployment to an existing Holiday Peak Hub Azure environment.
+Use azd as the primary deployment path. Use the manual ACR -> AKS path only when you need isolated rollout or troubleshooting outside the standard workflow.
+
+### Prerequisites
+
+| Tool | Why it is needed |
+|------|------------------|
+| az CLI | Azure authentication and resource operations |
+| azd | Environment selection and service deploy |
+| docker (or az acr build) | Build and push the container image |
+| kubectl + helm | Manual AKS deployment and validation |
+
+### 1. Set service variables
+
+```bash
+SERVICE_NAME="logistics-eta-computation"
+APP_PATH="apps/logistics-eta-computation/src"
+DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
+AZD_ENV_NAME="dev"
+K8S_NAMESPACE="holiday-peak"
+IMAGE_TAG="$(git rev-parse --short HEAD)"
+```
+
+### 2. Configure required environment variables
+
+Set these in the selected azd environment (recommended) or in your manual Helm values file:
+
+| Variable | Required | Notes |
+|----------|----------|-------|
+| PROJECT_ENDPOINT or FOUNDRY_ENDPOINT | Yes | Azure AI Foundry project endpoint |
+| FOUNDRY_AGENT_ID_FAST | Yes | Fast-path model agent id |
+| MODEL_DEPLOYMENT_NAME_FAST | Yes | Fast-path deployment name |
+| FOUNDRY_AGENT_ID_RICH | Yes | Rich-path model agent id |
+| MODEL_DEPLOYMENT_NAME_RICH | Yes | Rich-path deployment name |
+| EVENT_HUB_NAMESPACE or EVENTHUB_NAMESPACE | Yes | Event Hub namespace FQDN |
+| EVENT_HUB_CONNECTION_STRING or EVENTHUB_CONNECTION_STRING | Usually | Needed when workload identity is not used |
+| APP_NAME | Recommended | Set to logistics-eta-computation |
+| CRUD_SERVICE_URL | Service-dependent | Required when this service calls CRUD APIs |
+| REDIS_URL / COSMOS_* / BLOB_* | Optional | Three-tier memory; service degrades gracefully when absent |
+| APPLICATIONINSIGHTS_CONNECTION_STRING | Optional | App telemetry |
+
+Example azd env commands:
+
+```bash
+azd env select "${AZD_ENV_NAME}"
+azd env set APP_NAME "logistics-eta-computation"
+# repeat azd env set for the required values above
+```
+
+### 3. Build and push image
+
+```bash
+ACR_NAME="<existing-acr-name>"
+az acr login --name "${ACR_NAME}"
+ACR_LOGIN_SERVER="$(az acr show --name "${ACR_NAME}" --query loginServer -o tsv)"
+IMAGE_REPO="${ACR_LOGIN_SERVER}/${SERVICE_NAME}"
+docker build --target prod --tag "${IMAGE_REPO}:${IMAGE_TAG}" --tag "${IMAGE_REPO}:latest" -f "${DOCKERFILE_PATH}" "${APP_PATH}"
+docker push "${IMAGE_REPO}:${IMAGE_TAG}"
+docker push "${IMAGE_REPO}:latest"
+```
+
+ACR remote build alternative:
+
+```bash
+az acr build --registry "${ACR_NAME}" --image "${SERVICE_NAME}:${IMAGE_TAG}" --file "${DOCKERFILE_PATH}" "${APP_PATH}"
+```
+
+### 4. Render and deploy
+
+Preferred (azd-first):
+
+```bash
+azd deploy --service "${SERVICE_NAME}" -e "${AZD_ENV_NAME}" --no-prompt
+```
+
+Manual render/deploy path:
+
+```bash
+SERVICE_NAME="${SERVICE_NAME}" IMAGE_PREFIX="${ACR_LOGIN_SERVER}" IMAGE_TAG="${IMAGE_TAG}" K8S_NAMESPACE="${K8S_NAMESPACE}" KEDA_ENABLED="false" PUBLICATION_MODE="none" .infra/azd/hooks/render-helm.sh logistics-eta-computation
+helm upgrade --install logistics-eta-computation .kubernetes/chart --namespace "${K8S_NAMESPACE}" --create-namespace --set serviceName=logistics-eta-computation --set "image.repository=${IMAGE_REPO}" --set "image.tag=${IMAGE_TAG}" --wait --timeout 5m
+```
+
+If you deploy manually, provide env values through a local values file and do not commit secrets.
+
+### 5. Validate deployment
+
+```bash
+kubectl rollout status deployment/logistics-eta-computation -n "${K8S_NAMESPACE}" --timeout=5m
+kubectl get pods -n "${K8S_NAMESPACE}" -l app=logistics-eta-computation
+kubectl logs -n "${K8S_NAMESPACE}" -l app=logistics-eta-computation --tail=100
+kubectl port-forward -n "${K8S_NAMESPACE}" deployment/logistics-eta-computation 8080:8000
+curl -s http://localhost:8080/health
+curl -s http://localhost:8080/ready
+```
+
+### 6. Teardown
+
+Standalone service cleanup:
+
+```bash
+helm uninstall logistics-eta-computation -n "${K8S_NAMESPACE}" || true
+kubectl delete configmap logistics-eta-computation-config -n "${K8S_NAMESPACE}" --ignore-not-found
+kubectl delete secret logistics-eta-computation-secrets -n "${K8S_NAMESPACE}" --ignore-not-found
+```
+
+Full environment cleanup (destructive, use only when intended):
+
+```bash
+azd down -e "${AZD_ENV_NAME}" --purge --force
+```

--- a/apps/logistics-returns-support/README.md
+++ b/apps/logistics-returns-support/README.md
@@ -25,3 +25,118 @@ python -m pytest ../tests
 - Uses Foundry model settings (`PROJECT_ENDPOINT` or `FOUNDRY_ENDPOINT`, fast/rich model identifiers).
 - Supports Redis/Cosmos/Blob memory configuration via shared memory settings.
 - Requires Event Hub namespace and consumer configuration for background jobs.
+
+---
+
+## Standalone Deployment - azd-first (ACR -> AKS)
+
+This service supports standalone deployment to an existing Holiday Peak Hub Azure environment.
+Use azd as the primary deployment path. Use the manual ACR -> AKS path only when you need isolated rollout or troubleshooting outside the standard workflow.
+
+### Prerequisites
+
+| Tool | Why it is needed |
+|------|------------------|
+| az CLI | Azure authentication and resource operations |
+| azd | Environment selection and service deploy |
+| docker (or az acr build) | Build and push the container image |
+| kubectl + helm | Manual AKS deployment and validation |
+
+### 1. Set service variables
+
+```bash
+SERVICE_NAME="logistics-returns-support"
+APP_PATH="apps/logistics-returns-support/src"
+DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
+AZD_ENV_NAME="dev"
+K8S_NAMESPACE="holiday-peak"
+IMAGE_TAG="$(git rev-parse --short HEAD)"
+```
+
+### 2. Configure required environment variables
+
+Set these in the selected azd environment (recommended) or in your manual Helm values file:
+
+| Variable | Required | Notes |
+|----------|----------|-------|
+| PROJECT_ENDPOINT or FOUNDRY_ENDPOINT | Yes | Azure AI Foundry project endpoint |
+| FOUNDRY_AGENT_ID_FAST | Yes | Fast-path model agent id |
+| MODEL_DEPLOYMENT_NAME_FAST | Yes | Fast-path deployment name |
+| FOUNDRY_AGENT_ID_RICH | Yes | Rich-path model agent id |
+| MODEL_DEPLOYMENT_NAME_RICH | Yes | Rich-path deployment name |
+| EVENT_HUB_NAMESPACE or EVENTHUB_NAMESPACE | Yes | Event Hub namespace FQDN |
+| EVENT_HUB_CONNECTION_STRING or EVENTHUB_CONNECTION_STRING | Usually | Needed when workload identity is not used |
+| APP_NAME | Recommended | Set to logistics-returns-support |
+| CRUD_SERVICE_URL | Service-dependent | Required when this service calls CRUD APIs |
+| REDIS_URL / COSMOS_* / BLOB_* | Optional | Three-tier memory; service degrades gracefully when absent |
+| APPLICATIONINSIGHTS_CONNECTION_STRING | Optional | App telemetry |
+
+Example azd env commands:
+
+```bash
+azd env select "${AZD_ENV_NAME}"
+azd env set APP_NAME "logistics-returns-support"
+# repeat azd env set for the required values above
+```
+
+### 3. Build and push image
+
+```bash
+ACR_NAME="<existing-acr-name>"
+az acr login --name "${ACR_NAME}"
+ACR_LOGIN_SERVER="$(az acr show --name "${ACR_NAME}" --query loginServer -o tsv)"
+IMAGE_REPO="${ACR_LOGIN_SERVER}/${SERVICE_NAME}"
+docker build --target prod --tag "${IMAGE_REPO}:${IMAGE_TAG}" --tag "${IMAGE_REPO}:latest" -f "${DOCKERFILE_PATH}" "${APP_PATH}"
+docker push "${IMAGE_REPO}:${IMAGE_TAG}"
+docker push "${IMAGE_REPO}:latest"
+```
+
+ACR remote build alternative:
+
+```bash
+az acr build --registry "${ACR_NAME}" --image "${SERVICE_NAME}:${IMAGE_TAG}" --file "${DOCKERFILE_PATH}" "${APP_PATH}"
+```
+
+### 4. Render and deploy
+
+Preferred (azd-first):
+
+```bash
+azd deploy --service "${SERVICE_NAME}" -e "${AZD_ENV_NAME}" --no-prompt
+```
+
+Manual render/deploy path:
+
+```bash
+SERVICE_NAME="${SERVICE_NAME}" IMAGE_PREFIX="${ACR_LOGIN_SERVER}" IMAGE_TAG="${IMAGE_TAG}" K8S_NAMESPACE="${K8S_NAMESPACE}" KEDA_ENABLED="false" PUBLICATION_MODE="none" .infra/azd/hooks/render-helm.sh logistics-returns-support
+helm upgrade --install logistics-returns-support .kubernetes/chart --namespace "${K8S_NAMESPACE}" --create-namespace --set serviceName=logistics-returns-support --set "image.repository=${IMAGE_REPO}" --set "image.tag=${IMAGE_TAG}" --wait --timeout 5m
+```
+
+If you deploy manually, provide env values through a local values file and do not commit secrets.
+
+### 5. Validate deployment
+
+```bash
+kubectl rollout status deployment/logistics-returns-support -n "${K8S_NAMESPACE}" --timeout=5m
+kubectl get pods -n "${K8S_NAMESPACE}" -l app=logistics-returns-support
+kubectl logs -n "${K8S_NAMESPACE}" -l app=logistics-returns-support --tail=100
+kubectl port-forward -n "${K8S_NAMESPACE}" deployment/logistics-returns-support 8080:8000
+curl -s http://localhost:8080/health
+curl -s http://localhost:8080/ready
+```
+
+### 6. Teardown
+
+Standalone service cleanup:
+
+```bash
+helm uninstall logistics-returns-support -n "${K8S_NAMESPACE}" || true
+kubectl delete configmap logistics-returns-support-config -n "${K8S_NAMESPACE}" --ignore-not-found
+kubectl delete secret logistics-returns-support-secrets -n "${K8S_NAMESPACE}" --ignore-not-found
+```
+
+Full environment cleanup (destructive, use only when intended):
+
+```bash
+azd down -e "${AZD_ENV_NAME}" --purge --force
+```

--- a/apps/logistics-route-issue-detection/README.md
+++ b/apps/logistics-route-issue-detection/README.md
@@ -25,3 +25,118 @@ python -m pytest ../tests
 - Uses Foundry model settings (`PROJECT_ENDPOINT` or `FOUNDRY_ENDPOINT`, fast/rich model identifiers).
 - Supports Redis/Cosmos/Blob memory configuration via shared memory settings.
 - Requires Event Hub namespace and consumer configuration for background jobs.
+
+---
+
+## Standalone Deployment - azd-first (ACR -> AKS)
+
+This service supports standalone deployment to an existing Holiday Peak Hub Azure environment.
+Use azd as the primary deployment path. Use the manual ACR -> AKS path only when you need isolated rollout or troubleshooting outside the standard workflow.
+
+### Prerequisites
+
+| Tool | Why it is needed |
+|------|------------------|
+| az CLI | Azure authentication and resource operations |
+| azd | Environment selection and service deploy |
+| docker (or az acr build) | Build and push the container image |
+| kubectl + helm | Manual AKS deployment and validation |
+
+### 1. Set service variables
+
+```bash
+SERVICE_NAME="logistics-route-issue-detection"
+APP_PATH="apps/logistics-route-issue-detection/src"
+DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
+AZD_ENV_NAME="dev"
+K8S_NAMESPACE="holiday-peak"
+IMAGE_TAG="$(git rev-parse --short HEAD)"
+```
+
+### 2. Configure required environment variables
+
+Set these in the selected azd environment (recommended) or in your manual Helm values file:
+
+| Variable | Required | Notes |
+|----------|----------|-------|
+| PROJECT_ENDPOINT or FOUNDRY_ENDPOINT | Yes | Azure AI Foundry project endpoint |
+| FOUNDRY_AGENT_ID_FAST | Yes | Fast-path model agent id |
+| MODEL_DEPLOYMENT_NAME_FAST | Yes | Fast-path deployment name |
+| FOUNDRY_AGENT_ID_RICH | Yes | Rich-path model agent id |
+| MODEL_DEPLOYMENT_NAME_RICH | Yes | Rich-path deployment name |
+| EVENT_HUB_NAMESPACE or EVENTHUB_NAMESPACE | Yes | Event Hub namespace FQDN |
+| EVENT_HUB_CONNECTION_STRING or EVENTHUB_CONNECTION_STRING | Usually | Needed when workload identity is not used |
+| APP_NAME | Recommended | Set to logistics-route-issue-detection |
+| CRUD_SERVICE_URL | Service-dependent | Required when this service calls CRUD APIs |
+| REDIS_URL / COSMOS_* / BLOB_* | Optional | Three-tier memory; service degrades gracefully when absent |
+| APPLICATIONINSIGHTS_CONNECTION_STRING | Optional | App telemetry |
+
+Example azd env commands:
+
+```bash
+azd env select "${AZD_ENV_NAME}"
+azd env set APP_NAME "logistics-route-issue-detection"
+# repeat azd env set for the required values above
+```
+
+### 3. Build and push image
+
+```bash
+ACR_NAME="<existing-acr-name>"
+az acr login --name "${ACR_NAME}"
+ACR_LOGIN_SERVER="$(az acr show --name "${ACR_NAME}" --query loginServer -o tsv)"
+IMAGE_REPO="${ACR_LOGIN_SERVER}/${SERVICE_NAME}"
+docker build --target prod --tag "${IMAGE_REPO}:${IMAGE_TAG}" --tag "${IMAGE_REPO}:latest" -f "${DOCKERFILE_PATH}" "${APP_PATH}"
+docker push "${IMAGE_REPO}:${IMAGE_TAG}"
+docker push "${IMAGE_REPO}:latest"
+```
+
+ACR remote build alternative:
+
+```bash
+az acr build --registry "${ACR_NAME}" --image "${SERVICE_NAME}:${IMAGE_TAG}" --file "${DOCKERFILE_PATH}" "${APP_PATH}"
+```
+
+### 4. Render and deploy
+
+Preferred (azd-first):
+
+```bash
+azd deploy --service "${SERVICE_NAME}" -e "${AZD_ENV_NAME}" --no-prompt
+```
+
+Manual render/deploy path:
+
+```bash
+SERVICE_NAME="${SERVICE_NAME}" IMAGE_PREFIX="${ACR_LOGIN_SERVER}" IMAGE_TAG="${IMAGE_TAG}" K8S_NAMESPACE="${K8S_NAMESPACE}" KEDA_ENABLED="false" PUBLICATION_MODE="none" .infra/azd/hooks/render-helm.sh logistics-route-issue-detection
+helm upgrade --install logistics-route-issue-detection .kubernetes/chart --namespace "${K8S_NAMESPACE}" --create-namespace --set serviceName=logistics-route-issue-detection --set "image.repository=${IMAGE_REPO}" --set "image.tag=${IMAGE_TAG}" --wait --timeout 5m
+```
+
+If you deploy manually, provide env values through a local values file and do not commit secrets.
+
+### 5. Validate deployment
+
+```bash
+kubectl rollout status deployment/logistics-route-issue-detection -n "${K8S_NAMESPACE}" --timeout=5m
+kubectl get pods -n "${K8S_NAMESPACE}" -l app=logistics-route-issue-detection
+kubectl logs -n "${K8S_NAMESPACE}" -l app=logistics-route-issue-detection --tail=100
+kubectl port-forward -n "${K8S_NAMESPACE}" deployment/logistics-route-issue-detection 8080:8000
+curl -s http://localhost:8080/health
+curl -s http://localhost:8080/ready
+```
+
+### 6. Teardown
+
+Standalone service cleanup:
+
+```bash
+helm uninstall logistics-route-issue-detection -n "${K8S_NAMESPACE}" || true
+kubectl delete configmap logistics-route-issue-detection-config -n "${K8S_NAMESPACE}" --ignore-not-found
+kubectl delete secret logistics-route-issue-detection-secrets -n "${K8S_NAMESPACE}" --ignore-not-found
+```
+
+Full environment cleanup (destructive, use only when intended):
+
+```bash
+azd down -e "${AZD_ENV_NAME}" --purge --force
+```

--- a/apps/product-management-acp-transformation/README.md
+++ b/apps/product-management-acp-transformation/README.md
@@ -25,3 +25,118 @@ python -m pytest ../tests
 - Uses Foundry model settings (`PROJECT_ENDPOINT` or `FOUNDRY_ENDPOINT`, fast/rich model identifiers).
 - Supports Redis/Cosmos/Blob memory configuration via shared memory settings.
 - Requires Event Hub namespace and consumer configuration for background jobs.
+
+---
+
+## Standalone Deployment - azd-first (ACR -> AKS)
+
+This service supports standalone deployment to an existing Holiday Peak Hub Azure environment.
+Use azd as the primary deployment path. Use the manual ACR -> AKS path only when you need isolated rollout or troubleshooting outside the standard workflow.
+
+### Prerequisites
+
+| Tool | Why it is needed |
+|------|------------------|
+| az CLI | Azure authentication and resource operations |
+| azd | Environment selection and service deploy |
+| docker (or az acr build) | Build and push the container image |
+| kubectl + helm | Manual AKS deployment and validation |
+
+### 1. Set service variables
+
+```bash
+SERVICE_NAME="product-management-acp-transformation"
+APP_PATH="apps/product-management-acp-transformation/src"
+DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
+AZD_ENV_NAME="dev"
+K8S_NAMESPACE="holiday-peak"
+IMAGE_TAG="$(git rev-parse --short HEAD)"
+```
+
+### 2. Configure required environment variables
+
+Set these in the selected azd environment (recommended) or in your manual Helm values file:
+
+| Variable | Required | Notes |
+|----------|----------|-------|
+| PROJECT_ENDPOINT or FOUNDRY_ENDPOINT | Yes | Azure AI Foundry project endpoint |
+| FOUNDRY_AGENT_ID_FAST | Yes | Fast-path model agent id |
+| MODEL_DEPLOYMENT_NAME_FAST | Yes | Fast-path deployment name |
+| FOUNDRY_AGENT_ID_RICH | Yes | Rich-path model agent id |
+| MODEL_DEPLOYMENT_NAME_RICH | Yes | Rich-path deployment name |
+| EVENT_HUB_NAMESPACE or EVENTHUB_NAMESPACE | Yes | Event Hub namespace FQDN |
+| EVENT_HUB_CONNECTION_STRING or EVENTHUB_CONNECTION_STRING | Usually | Needed when workload identity is not used |
+| APP_NAME | Recommended | Set to product-management-acp-transformation |
+| CRUD_SERVICE_URL | Service-dependent | Required when this service calls CRUD APIs |
+| REDIS_URL / COSMOS_* / BLOB_* | Optional | Three-tier memory; service degrades gracefully when absent |
+| APPLICATIONINSIGHTS_CONNECTION_STRING | Optional | App telemetry |
+
+Example azd env commands:
+
+```bash
+azd env select "${AZD_ENV_NAME}"
+azd env set APP_NAME "product-management-acp-transformation"
+# repeat azd env set for the required values above
+```
+
+### 3. Build and push image
+
+```bash
+ACR_NAME="<existing-acr-name>"
+az acr login --name "${ACR_NAME}"
+ACR_LOGIN_SERVER="$(az acr show --name "${ACR_NAME}" --query loginServer -o tsv)"
+IMAGE_REPO="${ACR_LOGIN_SERVER}/${SERVICE_NAME}"
+docker build --target prod --tag "${IMAGE_REPO}:${IMAGE_TAG}" --tag "${IMAGE_REPO}:latest" -f "${DOCKERFILE_PATH}" "${APP_PATH}"
+docker push "${IMAGE_REPO}:${IMAGE_TAG}"
+docker push "${IMAGE_REPO}:latest"
+```
+
+ACR remote build alternative:
+
+```bash
+az acr build --registry "${ACR_NAME}" --image "${SERVICE_NAME}:${IMAGE_TAG}" --file "${DOCKERFILE_PATH}" "${APP_PATH}"
+```
+
+### 4. Render and deploy
+
+Preferred (azd-first):
+
+```bash
+azd deploy --service "${SERVICE_NAME}" -e "${AZD_ENV_NAME}" --no-prompt
+```
+
+Manual render/deploy path:
+
+```bash
+SERVICE_NAME="${SERVICE_NAME}" IMAGE_PREFIX="${ACR_LOGIN_SERVER}" IMAGE_TAG="${IMAGE_TAG}" K8S_NAMESPACE="${K8S_NAMESPACE}" KEDA_ENABLED="false" PUBLICATION_MODE="none" .infra/azd/hooks/render-helm.sh product-management-acp-transformation
+helm upgrade --install product-management-acp-transformation .kubernetes/chart --namespace "${K8S_NAMESPACE}" --create-namespace --set serviceName=product-management-acp-transformation --set "image.repository=${IMAGE_REPO}" --set "image.tag=${IMAGE_TAG}" --wait --timeout 5m
+```
+
+If you deploy manually, provide env values through a local values file and do not commit secrets.
+
+### 5. Validate deployment
+
+```bash
+kubectl rollout status deployment/product-management-acp-transformation -n "${K8S_NAMESPACE}" --timeout=5m
+kubectl get pods -n "${K8S_NAMESPACE}" -l app=product-management-acp-transformation
+kubectl logs -n "${K8S_NAMESPACE}" -l app=product-management-acp-transformation --tail=100
+kubectl port-forward -n "${K8S_NAMESPACE}" deployment/product-management-acp-transformation 8080:8000
+curl -s http://localhost:8080/health
+curl -s http://localhost:8080/ready
+```
+
+### 6. Teardown
+
+Standalone service cleanup:
+
+```bash
+helm uninstall product-management-acp-transformation -n "${K8S_NAMESPACE}" || true
+kubectl delete configmap product-management-acp-transformation-config -n "${K8S_NAMESPACE}" --ignore-not-found
+kubectl delete secret product-management-acp-transformation-secrets -n "${K8S_NAMESPACE}" --ignore-not-found
+```
+
+Full environment cleanup (destructive, use only when intended):
+
+```bash
+azd down -e "${AZD_ENV_NAME}" --purge --force
+```

--- a/apps/product-management-assortment-optimization/README.md
+++ b/apps/product-management-assortment-optimization/README.md
@@ -25,3 +25,118 @@ python -m pytest ../tests
 - Uses Foundry model settings (`PROJECT_ENDPOINT` or `FOUNDRY_ENDPOINT`, fast/rich model identifiers).
 - Supports Redis/Cosmos/Blob memory configuration via shared memory settings.
 - Requires Event Hub namespace and consumer configuration for background jobs.
+
+---
+
+## Standalone Deployment - azd-first (ACR -> AKS)
+
+This service supports standalone deployment to an existing Holiday Peak Hub Azure environment.
+Use azd as the primary deployment path. Use the manual ACR -> AKS path only when you need isolated rollout or troubleshooting outside the standard workflow.
+
+### Prerequisites
+
+| Tool | Why it is needed |
+|------|------------------|
+| az CLI | Azure authentication and resource operations |
+| azd | Environment selection and service deploy |
+| docker (or az acr build) | Build and push the container image |
+| kubectl + helm | Manual AKS deployment and validation |
+
+### 1. Set service variables
+
+```bash
+SERVICE_NAME="product-management-assortment-optimization"
+APP_PATH="apps/product-management-assortment-optimization/src"
+DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
+AZD_ENV_NAME="dev"
+K8S_NAMESPACE="holiday-peak"
+IMAGE_TAG="$(git rev-parse --short HEAD)"
+```
+
+### 2. Configure required environment variables
+
+Set these in the selected azd environment (recommended) or in your manual Helm values file:
+
+| Variable | Required | Notes |
+|----------|----------|-------|
+| PROJECT_ENDPOINT or FOUNDRY_ENDPOINT | Yes | Azure AI Foundry project endpoint |
+| FOUNDRY_AGENT_ID_FAST | Yes | Fast-path model agent id |
+| MODEL_DEPLOYMENT_NAME_FAST | Yes | Fast-path deployment name |
+| FOUNDRY_AGENT_ID_RICH | Yes | Rich-path model agent id |
+| MODEL_DEPLOYMENT_NAME_RICH | Yes | Rich-path deployment name |
+| EVENT_HUB_NAMESPACE or EVENTHUB_NAMESPACE | Yes | Event Hub namespace FQDN |
+| EVENT_HUB_CONNECTION_STRING or EVENTHUB_CONNECTION_STRING | Usually | Needed when workload identity is not used |
+| APP_NAME | Recommended | Set to product-management-assortment-optimization |
+| CRUD_SERVICE_URL | Service-dependent | Required when this service calls CRUD APIs |
+| REDIS_URL / COSMOS_* / BLOB_* | Optional | Three-tier memory; service degrades gracefully when absent |
+| APPLICATIONINSIGHTS_CONNECTION_STRING | Optional | App telemetry |
+
+Example azd env commands:
+
+```bash
+azd env select "${AZD_ENV_NAME}"
+azd env set APP_NAME "product-management-assortment-optimization"
+# repeat azd env set for the required values above
+```
+
+### 3. Build and push image
+
+```bash
+ACR_NAME="<existing-acr-name>"
+az acr login --name "${ACR_NAME}"
+ACR_LOGIN_SERVER="$(az acr show --name "${ACR_NAME}" --query loginServer -o tsv)"
+IMAGE_REPO="${ACR_LOGIN_SERVER}/${SERVICE_NAME}"
+docker build --target prod --tag "${IMAGE_REPO}:${IMAGE_TAG}" --tag "${IMAGE_REPO}:latest" -f "${DOCKERFILE_PATH}" "${APP_PATH}"
+docker push "${IMAGE_REPO}:${IMAGE_TAG}"
+docker push "${IMAGE_REPO}:latest"
+```
+
+ACR remote build alternative:
+
+```bash
+az acr build --registry "${ACR_NAME}" --image "${SERVICE_NAME}:${IMAGE_TAG}" --file "${DOCKERFILE_PATH}" "${APP_PATH}"
+```
+
+### 4. Render and deploy
+
+Preferred (azd-first):
+
+```bash
+azd deploy --service "${SERVICE_NAME}" -e "${AZD_ENV_NAME}" --no-prompt
+```
+
+Manual render/deploy path:
+
+```bash
+SERVICE_NAME="${SERVICE_NAME}" IMAGE_PREFIX="${ACR_LOGIN_SERVER}" IMAGE_TAG="${IMAGE_TAG}" K8S_NAMESPACE="${K8S_NAMESPACE}" KEDA_ENABLED="false" PUBLICATION_MODE="none" .infra/azd/hooks/render-helm.sh product-management-assortment-optimization
+helm upgrade --install product-management-assortment-optimization .kubernetes/chart --namespace "${K8S_NAMESPACE}" --create-namespace --set serviceName=product-management-assortment-optimization --set "image.repository=${IMAGE_REPO}" --set "image.tag=${IMAGE_TAG}" --wait --timeout 5m
+```
+
+If you deploy manually, provide env values through a local values file and do not commit secrets.
+
+### 5. Validate deployment
+
+```bash
+kubectl rollout status deployment/product-management-assortment-optimization -n "${K8S_NAMESPACE}" --timeout=5m
+kubectl get pods -n "${K8S_NAMESPACE}" -l app=product-management-assortment-optimization
+kubectl logs -n "${K8S_NAMESPACE}" -l app=product-management-assortment-optimization --tail=100
+kubectl port-forward -n "${K8S_NAMESPACE}" deployment/product-management-assortment-optimization 8080:8000
+curl -s http://localhost:8080/health
+curl -s http://localhost:8080/ready
+```
+
+### 6. Teardown
+
+Standalone service cleanup:
+
+```bash
+helm uninstall product-management-assortment-optimization -n "${K8S_NAMESPACE}" || true
+kubectl delete configmap product-management-assortment-optimization-config -n "${K8S_NAMESPACE}" --ignore-not-found
+kubectl delete secret product-management-assortment-optimization-secrets -n "${K8S_NAMESPACE}" --ignore-not-found
+```
+
+Full environment cleanup (destructive, use only when intended):
+
+```bash
+azd down -e "${AZD_ENV_NAME}" --purge --force
+```

--- a/apps/product-management-consistency-validation/README.md
+++ b/apps/product-management-consistency-validation/README.md
@@ -25,3 +25,118 @@ python -m pytest ../tests
 - Uses Foundry model settings (`PROJECT_ENDPOINT` or `FOUNDRY_ENDPOINT`, fast/rich model identifiers).
 - Supports Redis/Cosmos/Blob memory configuration via shared memory settings.
 - Requires Event Hub namespace and consumer configuration for background jobs.
+
+---
+
+## Standalone Deployment - azd-first (ACR -> AKS)
+
+This service supports standalone deployment to an existing Holiday Peak Hub Azure environment.
+Use azd as the primary deployment path. Use the manual ACR -> AKS path only when you need isolated rollout or troubleshooting outside the standard workflow.
+
+### Prerequisites
+
+| Tool | Why it is needed |
+|------|------------------|
+| az CLI | Azure authentication and resource operations |
+| azd | Environment selection and service deploy |
+| docker (or az acr build) | Build and push the container image |
+| kubectl + helm | Manual AKS deployment and validation |
+
+### 1. Set service variables
+
+```bash
+SERVICE_NAME="product-management-consistency-validation"
+APP_PATH="apps/product-management-consistency-validation/src"
+DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
+AZD_ENV_NAME="dev"
+K8S_NAMESPACE="holiday-peak"
+IMAGE_TAG="$(git rev-parse --short HEAD)"
+```
+
+### 2. Configure required environment variables
+
+Set these in the selected azd environment (recommended) or in your manual Helm values file:
+
+| Variable | Required | Notes |
+|----------|----------|-------|
+| PROJECT_ENDPOINT or FOUNDRY_ENDPOINT | Yes | Azure AI Foundry project endpoint |
+| FOUNDRY_AGENT_ID_FAST | Yes | Fast-path model agent id |
+| MODEL_DEPLOYMENT_NAME_FAST | Yes | Fast-path deployment name |
+| FOUNDRY_AGENT_ID_RICH | Yes | Rich-path model agent id |
+| MODEL_DEPLOYMENT_NAME_RICH | Yes | Rich-path deployment name |
+| EVENT_HUB_NAMESPACE or EVENTHUB_NAMESPACE | Yes | Event Hub namespace FQDN |
+| EVENT_HUB_CONNECTION_STRING or EVENTHUB_CONNECTION_STRING | Usually | Needed when workload identity is not used |
+| APP_NAME | Recommended | Set to product-management-consistency-validation |
+| CRUD_SERVICE_URL | Service-dependent | Required when this service calls CRUD APIs |
+| REDIS_URL / COSMOS_* / BLOB_* | Optional | Three-tier memory; service degrades gracefully when absent |
+| APPLICATIONINSIGHTS_CONNECTION_STRING | Optional | App telemetry |
+
+Example azd env commands:
+
+```bash
+azd env select "${AZD_ENV_NAME}"
+azd env set APP_NAME "product-management-consistency-validation"
+# repeat azd env set for the required values above
+```
+
+### 3. Build and push image
+
+```bash
+ACR_NAME="<existing-acr-name>"
+az acr login --name "${ACR_NAME}"
+ACR_LOGIN_SERVER="$(az acr show --name "${ACR_NAME}" --query loginServer -o tsv)"
+IMAGE_REPO="${ACR_LOGIN_SERVER}/${SERVICE_NAME}"
+docker build --target prod --tag "${IMAGE_REPO}:${IMAGE_TAG}" --tag "${IMAGE_REPO}:latest" -f "${DOCKERFILE_PATH}" "${APP_PATH}"
+docker push "${IMAGE_REPO}:${IMAGE_TAG}"
+docker push "${IMAGE_REPO}:latest"
+```
+
+ACR remote build alternative:
+
+```bash
+az acr build --registry "${ACR_NAME}" --image "${SERVICE_NAME}:${IMAGE_TAG}" --file "${DOCKERFILE_PATH}" "${APP_PATH}"
+```
+
+### 4. Render and deploy
+
+Preferred (azd-first):
+
+```bash
+azd deploy --service "${SERVICE_NAME}" -e "${AZD_ENV_NAME}" --no-prompt
+```
+
+Manual render/deploy path:
+
+```bash
+SERVICE_NAME="${SERVICE_NAME}" IMAGE_PREFIX="${ACR_LOGIN_SERVER}" IMAGE_TAG="${IMAGE_TAG}" K8S_NAMESPACE="${K8S_NAMESPACE}" KEDA_ENABLED="false" PUBLICATION_MODE="none" .infra/azd/hooks/render-helm.sh product-management-consistency-validation
+helm upgrade --install product-management-consistency-validation .kubernetes/chart --namespace "${K8S_NAMESPACE}" --create-namespace --set serviceName=product-management-consistency-validation --set "image.repository=${IMAGE_REPO}" --set "image.tag=${IMAGE_TAG}" --wait --timeout 5m
+```
+
+If you deploy manually, provide env values through a local values file and do not commit secrets.
+
+### 5. Validate deployment
+
+```bash
+kubectl rollout status deployment/product-management-consistency-validation -n "${K8S_NAMESPACE}" --timeout=5m
+kubectl get pods -n "${K8S_NAMESPACE}" -l app=product-management-consistency-validation
+kubectl logs -n "${K8S_NAMESPACE}" -l app=product-management-consistency-validation --tail=100
+kubectl port-forward -n "${K8S_NAMESPACE}" deployment/product-management-consistency-validation 8080:8000
+curl -s http://localhost:8080/health
+curl -s http://localhost:8080/ready
+```
+
+### 6. Teardown
+
+Standalone service cleanup:
+
+```bash
+helm uninstall product-management-consistency-validation -n "${K8S_NAMESPACE}" || true
+kubectl delete configmap product-management-consistency-validation-config -n "${K8S_NAMESPACE}" --ignore-not-found
+kubectl delete secret product-management-consistency-validation-secrets -n "${K8S_NAMESPACE}" --ignore-not-found
+```
+
+Full environment cleanup (destructive, use only when intended):
+
+```bash
+azd down -e "${AZD_ENV_NAME}" --purge --force
+```

--- a/apps/product-management-normalization-classification/README.md
+++ b/apps/product-management-normalization-classification/README.md
@@ -25,3 +25,118 @@ python -m pytest ../tests
 - Uses Foundry model settings (`PROJECT_ENDPOINT` or `FOUNDRY_ENDPOINT`, fast/rich model identifiers).
 - Supports Redis/Cosmos/Blob memory configuration via shared memory settings.
 - Requires Event Hub namespace and consumer configuration for background jobs.
+
+---
+
+## Standalone Deployment - azd-first (ACR -> AKS)
+
+This service supports standalone deployment to an existing Holiday Peak Hub Azure environment.
+Use azd as the primary deployment path. Use the manual ACR -> AKS path only when you need isolated rollout or troubleshooting outside the standard workflow.
+
+### Prerequisites
+
+| Tool | Why it is needed |
+|------|------------------|
+| az CLI | Azure authentication and resource operations |
+| azd | Environment selection and service deploy |
+| docker (or az acr build) | Build and push the container image |
+| kubectl + helm | Manual AKS deployment and validation |
+
+### 1. Set service variables
+
+```bash
+SERVICE_NAME="product-management-normalization-classification"
+APP_PATH="apps/product-management-normalization-classification/src"
+DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
+AZD_ENV_NAME="dev"
+K8S_NAMESPACE="holiday-peak"
+IMAGE_TAG="$(git rev-parse --short HEAD)"
+```
+
+### 2. Configure required environment variables
+
+Set these in the selected azd environment (recommended) or in your manual Helm values file:
+
+| Variable | Required | Notes |
+|----------|----------|-------|
+| PROJECT_ENDPOINT or FOUNDRY_ENDPOINT | Yes | Azure AI Foundry project endpoint |
+| FOUNDRY_AGENT_ID_FAST | Yes | Fast-path model agent id |
+| MODEL_DEPLOYMENT_NAME_FAST | Yes | Fast-path deployment name |
+| FOUNDRY_AGENT_ID_RICH | Yes | Rich-path model agent id |
+| MODEL_DEPLOYMENT_NAME_RICH | Yes | Rich-path deployment name |
+| EVENT_HUB_NAMESPACE or EVENTHUB_NAMESPACE | Yes | Event Hub namespace FQDN |
+| EVENT_HUB_CONNECTION_STRING or EVENTHUB_CONNECTION_STRING | Usually | Needed when workload identity is not used |
+| APP_NAME | Recommended | Set to product-management-normalization-classification |
+| CRUD_SERVICE_URL | Service-dependent | Required when this service calls CRUD APIs |
+| REDIS_URL / COSMOS_* / BLOB_* | Optional | Three-tier memory; service degrades gracefully when absent |
+| APPLICATIONINSIGHTS_CONNECTION_STRING | Optional | App telemetry |
+
+Example azd env commands:
+
+```bash
+azd env select "${AZD_ENV_NAME}"
+azd env set APP_NAME "product-management-normalization-classification"
+# repeat azd env set for the required values above
+```
+
+### 3. Build and push image
+
+```bash
+ACR_NAME="<existing-acr-name>"
+az acr login --name "${ACR_NAME}"
+ACR_LOGIN_SERVER="$(az acr show --name "${ACR_NAME}" --query loginServer -o tsv)"
+IMAGE_REPO="${ACR_LOGIN_SERVER}/${SERVICE_NAME}"
+docker build --target prod --tag "${IMAGE_REPO}:${IMAGE_TAG}" --tag "${IMAGE_REPO}:latest" -f "${DOCKERFILE_PATH}" "${APP_PATH}"
+docker push "${IMAGE_REPO}:${IMAGE_TAG}"
+docker push "${IMAGE_REPO}:latest"
+```
+
+ACR remote build alternative:
+
+```bash
+az acr build --registry "${ACR_NAME}" --image "${SERVICE_NAME}:${IMAGE_TAG}" --file "${DOCKERFILE_PATH}" "${APP_PATH}"
+```
+
+### 4. Render and deploy
+
+Preferred (azd-first):
+
+```bash
+azd deploy --service "${SERVICE_NAME}" -e "${AZD_ENV_NAME}" --no-prompt
+```
+
+Manual render/deploy path:
+
+```bash
+SERVICE_NAME="${SERVICE_NAME}" IMAGE_PREFIX="${ACR_LOGIN_SERVER}" IMAGE_TAG="${IMAGE_TAG}" K8S_NAMESPACE="${K8S_NAMESPACE}" KEDA_ENABLED="false" PUBLICATION_MODE="none" .infra/azd/hooks/render-helm.sh product-management-normalization-classification
+helm upgrade --install product-management-normalization-classification .kubernetes/chart --namespace "${K8S_NAMESPACE}" --create-namespace --set serviceName=product-management-normalization-classification --set "image.repository=${IMAGE_REPO}" --set "image.tag=${IMAGE_TAG}" --wait --timeout 5m
+```
+
+If you deploy manually, provide env values through a local values file and do not commit secrets.
+
+### 5. Validate deployment
+
+```bash
+kubectl rollout status deployment/product-management-normalization-classification -n "${K8S_NAMESPACE}" --timeout=5m
+kubectl get pods -n "${K8S_NAMESPACE}" -l app=product-management-normalization-classification
+kubectl logs -n "${K8S_NAMESPACE}" -l app=product-management-normalization-classification --tail=100
+kubectl port-forward -n "${K8S_NAMESPACE}" deployment/product-management-normalization-classification 8080:8000
+curl -s http://localhost:8080/health
+curl -s http://localhost:8080/ready
+```
+
+### 6. Teardown
+
+Standalone service cleanup:
+
+```bash
+helm uninstall product-management-normalization-classification -n "${K8S_NAMESPACE}" || true
+kubectl delete configmap product-management-normalization-classification-config -n "${K8S_NAMESPACE}" --ignore-not-found
+kubectl delete secret product-management-normalization-classification-secrets -n "${K8S_NAMESPACE}" --ignore-not-found
+```
+
+Full environment cleanup (destructive, use only when intended):
+
+```bash
+azd down -e "${AZD_ENV_NAME}" --purge --force
+```

--- a/apps/search-enrichment-agent/README.md
+++ b/apps/search-enrichment-agent/README.md
@@ -25,3 +25,118 @@ python -m pytest ../tests
 - Uses Foundry model settings (`PROJECT_ENDPOINT` or `FOUNDRY_ENDPOINT`, fast/rich model identifiers).
 - Supports Redis/Cosmos/Blob memory configuration via shared memory settings.
 - Requires Event Hub namespace and consumer configuration for background jobs.
+
+---
+
+## Standalone Deployment - azd-first (ACR -> AKS)
+
+This service supports standalone deployment to an existing Holiday Peak Hub Azure environment.
+Use azd as the primary deployment path. Use the manual ACR -> AKS path only when you need isolated rollout or troubleshooting outside the standard workflow.
+
+### Prerequisites
+
+| Tool | Why it is needed |
+|------|------------------|
+| az CLI | Azure authentication and resource operations |
+| azd | Environment selection and service deploy |
+| docker (or az acr build) | Build and push the container image |
+| kubectl + helm | Manual AKS deployment and validation |
+
+### 1. Set service variables
+
+```bash
+SERVICE_NAME="search-enrichment-agent"
+APP_PATH="apps/search-enrichment-agent/src"
+DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
+AZD_ENV_NAME="dev"
+K8S_NAMESPACE="holiday-peak"
+IMAGE_TAG="$(git rev-parse --short HEAD)"
+```
+
+### 2. Configure required environment variables
+
+Set these in the selected azd environment (recommended) or in your manual Helm values file:
+
+| Variable | Required | Notes |
+|----------|----------|-------|
+| PROJECT_ENDPOINT or FOUNDRY_ENDPOINT | Yes | Azure AI Foundry project endpoint |
+| FOUNDRY_AGENT_ID_FAST | Yes | Fast-path model agent id |
+| MODEL_DEPLOYMENT_NAME_FAST | Yes | Fast-path deployment name |
+| FOUNDRY_AGENT_ID_RICH | Yes | Rich-path model agent id |
+| MODEL_DEPLOYMENT_NAME_RICH | Yes | Rich-path deployment name |
+| EVENT_HUB_NAMESPACE or EVENTHUB_NAMESPACE | Yes | Event Hub namespace FQDN |
+| EVENT_HUB_CONNECTION_STRING or EVENTHUB_CONNECTION_STRING | Usually | Needed when workload identity is not used |
+| APP_NAME | Recommended | Set to search-enrichment-agent |
+| CRUD_SERVICE_URL | Service-dependent | Required when this service calls CRUD APIs |
+| REDIS_URL / COSMOS_* / BLOB_* | Optional | Three-tier memory; service degrades gracefully when absent |
+| APPLICATIONINSIGHTS_CONNECTION_STRING | Optional | App telemetry |
+
+Example azd env commands:
+
+```bash
+azd env select "${AZD_ENV_NAME}"
+azd env set APP_NAME "search-enrichment-agent"
+# repeat azd env set for the required values above
+```
+
+### 3. Build and push image
+
+```bash
+ACR_NAME="<existing-acr-name>"
+az acr login --name "${ACR_NAME}"
+ACR_LOGIN_SERVER="$(az acr show --name "${ACR_NAME}" --query loginServer -o tsv)"
+IMAGE_REPO="${ACR_LOGIN_SERVER}/${SERVICE_NAME}"
+docker build --target prod --tag "${IMAGE_REPO}:${IMAGE_TAG}" --tag "${IMAGE_REPO}:latest" -f "${DOCKERFILE_PATH}" "${APP_PATH}"
+docker push "${IMAGE_REPO}:${IMAGE_TAG}"
+docker push "${IMAGE_REPO}:latest"
+```
+
+ACR remote build alternative:
+
+```bash
+az acr build --registry "${ACR_NAME}" --image "${SERVICE_NAME}:${IMAGE_TAG}" --file "${DOCKERFILE_PATH}" "${APP_PATH}"
+```
+
+### 4. Render and deploy
+
+Preferred (azd-first):
+
+```bash
+azd deploy --service "${SERVICE_NAME}" -e "${AZD_ENV_NAME}" --no-prompt
+```
+
+Manual render/deploy path:
+
+```bash
+SERVICE_NAME="${SERVICE_NAME}" IMAGE_PREFIX="${ACR_LOGIN_SERVER}" IMAGE_TAG="${IMAGE_TAG}" K8S_NAMESPACE="${K8S_NAMESPACE}" KEDA_ENABLED="false" PUBLICATION_MODE="none" .infra/azd/hooks/render-helm.sh search-enrichment-agent
+helm upgrade --install search-enrichment-agent .kubernetes/chart --namespace "${K8S_NAMESPACE}" --create-namespace --set serviceName=search-enrichment-agent --set "image.repository=${IMAGE_REPO}" --set "image.tag=${IMAGE_TAG}" --wait --timeout 5m
+```
+
+If you deploy manually, provide env values through a local values file and do not commit secrets.
+
+### 5. Validate deployment
+
+```bash
+kubectl rollout status deployment/search-enrichment-agent -n "${K8S_NAMESPACE}" --timeout=5m
+kubectl get pods -n "${K8S_NAMESPACE}" -l app=search-enrichment-agent
+kubectl logs -n "${K8S_NAMESPACE}" -l app=search-enrichment-agent --tail=100
+kubectl port-forward -n "${K8S_NAMESPACE}" deployment/search-enrichment-agent 8080:8000
+curl -s http://localhost:8080/health
+curl -s http://localhost:8080/ready
+```
+
+### 6. Teardown
+
+Standalone service cleanup:
+
+```bash
+helm uninstall search-enrichment-agent -n "${K8S_NAMESPACE}" || true
+kubectl delete configmap search-enrichment-agent-config -n "${K8S_NAMESPACE}" --ignore-not-found
+kubectl delete secret search-enrichment-agent-secrets -n "${K8S_NAMESPACE}" --ignore-not-found
+```
+
+Full environment cleanup (destructive, use only when intended):
+
+```bash
+azd down -e "${AZD_ENV_NAME}" --purge --force
+```

--- a/apps/truth-enrichment/README.md
+++ b/apps/truth-enrichment/README.md
@@ -31,376 +31,115 @@ python -m pytest ../tests
 
 ---
 
-## Deployment Guide — ACR → AKS
+## Standalone Deployment - azd-first (ACR -> AKS)
 
-This guide covers a **manual, step-by-step deployment** of this agent from source to a running pod in AKS.  
-No KeyVault agent is required; environment variables are injected directly into the cluster.
+This service supports standalone deployment to an existing Holiday Peak Hub Azure environment.
+Use azd as the primary deployment path. Use the manual ACR -> AKS path only when you need isolated rollout or troubleshooting outside the standard workflow.
 
 ### Prerequisites
 
-| Tool | Purpose |
-|------|---------|
-| `az` CLI ≥ 2.60 | Azure CLI for ACR and AKS operations |
-| `docker` or `az acr build` | Build and push the container image |
-| `helm` ≥ 3.14 | Render and install the Helm chart |
-| `kubectl` | Apply rendered manifests to AKS |
+| Tool | Why it is needed |
+|------|------------------|
+| az CLI | Azure authentication and resource operations |
+| azd | Environment selection and service deploy |
+| docker (or az acr build) | Build and push the container image |
+| kubectl + helm | Manual AKS deployment and validation |
+
+### 1. Set service variables
 
 ```bash
-# Verify versions
-az version
-docker version
-helm version --short
-kubectl version --client --short
-```
-
----
-
-### Step 1 — Set shell variables
-
-Replace the placeholder values to match your environment before running any subsequent step.
-
-```bash
-# ── Project identifiers ──────────────────────────────────────────────────────
-SUBSCRIPTION_ID="<your-subscription-id>"
-RESOURCE_GROUP="rg-holidaypeakhub405-dev"
-ENVIRONMENT="dev"                                   # dev | staging | prod
-PROJECT_NAME="holidaypeakhub405"
-
-# ── ACR ──────────────────────────────────────────────────────────────────────
-ACR_NAME="${PROJECT_NAME}${ENVIRONMENT}acr"         # e.g. holidaypeakhub405devacr
-ACR_LOGIN_SERVER="${ACR_NAME}.azurecr.io"
-
-# ── Service ──────────────────────────────────────────────────────────────────
 SERVICE_NAME="truth-enrichment"
-IMAGE_TAG="$(git rev-parse --short HEAD)"           # or any explicit tag, e.g. "1.0.0"
-IMAGE_REPO="${ACR_LOGIN_SERVER}/${SERVICE_NAME}"
-
-# ── AKS ──────────────────────────────────────────────────────────────────────
-AKS_CLUSTER="aks-holidaypeakhub405-${ENVIRONMENT}"
+APP_PATH="apps/truth-enrichment/src"
+DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
+AZD_ENV_NAME="dev"
 K8S_NAMESPACE="holiday-peak"
+IMAGE_TAG="$(git rev-parse --short HEAD)"
 ```
 
----
+### 2. Configure required environment variables
 
-### Step 2 — Authenticate
+Set these in the selected azd environment (recommended) or in your manual Helm values file:
+
+| Variable | Required | Notes |
+|----------|----------|-------|
+| PROJECT_ENDPOINT or FOUNDRY_ENDPOINT | Yes | Azure AI Foundry project endpoint |
+| FOUNDRY_AGENT_ID_FAST | Yes | Fast-path model agent id |
+| MODEL_DEPLOYMENT_NAME_FAST | Yes | Fast-path deployment name |
+| FOUNDRY_AGENT_ID_RICH | Yes | Rich-path model agent id |
+| MODEL_DEPLOYMENT_NAME_RICH | Yes | Rich-path deployment name |
+| EVENT_HUB_NAMESPACE or EVENTHUB_NAMESPACE | Yes | Event Hub namespace FQDN |
+| EVENT_HUB_CONNECTION_STRING or EVENTHUB_CONNECTION_STRING | Usually | Needed when workload identity is not used |
+| APP_NAME | Recommended | Set to truth-enrichment |
+| CRUD_SERVICE_URL | Service-dependent | Required when this service calls CRUD APIs |
+| REDIS_URL / COSMOS_* / BLOB_* | Optional | Three-tier memory; service degrades gracefully when absent |
+| APPLICATIONINSIGHTS_CONNECTION_STRING | Optional | App telemetry |
+
+Example azd env commands:
 
 ```bash
-# Log in to Azure
-az login
-az account set --subscription "$SUBSCRIPTION_ID"
-
-# Attach ACR credentials to the local Docker daemon (one-time per session)
-az acr login --name "$ACR_NAME"
-
-# Merge AKS credentials into the local kubeconfig
-az aks get-credentials \
-  --resource-group "$RESOURCE_GROUP" \
-  --name "$AKS_CLUSTER" \
-  --overwrite-existing
-
-# Verify cluster access
-kubectl get nodes
+azd env select "${AZD_ENV_NAME}"
+azd env set APP_NAME "truth-enrichment"
+# repeat azd env set for the required values above
 ```
 
----
-
-### Step 3 — Build and push the image to ACR
-
-Build from the service `src` directory, which acts as the Docker build context.
+### 3. Build and push image
 
 ```bash
-# From the repository root
-docker build \
-  --target prod \
-  --tag "${IMAGE_REPO}:${IMAGE_TAG}" \
-  --tag "${IMAGE_REPO}:latest" \
-  -f apps/truth-enrichment/src/Dockerfile \
-  apps/truth-enrichment/src
-
-# Push both tags
+ACR_NAME="<existing-acr-name>"
+az acr login --name "${ACR_NAME}"
+ACR_LOGIN_SERVER="$(az acr show --name "${ACR_NAME}" --query loginServer -o tsv)"
+IMAGE_REPO="${ACR_LOGIN_SERVER}/${SERVICE_NAME}"
+docker build --target prod --tag "${IMAGE_REPO}:${IMAGE_TAG}" --tag "${IMAGE_REPO}:latest" -f "${DOCKERFILE_PATH}" "${APP_PATH}"
 docker push "${IMAGE_REPO}:${IMAGE_TAG}"
 docker push "${IMAGE_REPO}:latest"
 ```
 
-> **Alternative — build directly inside ACR** (removes the need for a local Docker daemon):
-> ```bash
-> az acr build \
->   --registry "$ACR_NAME" \
->   --image "${SERVICE_NAME}:${IMAGE_TAG}" \
->   --file apps/truth-enrichment/src/Dockerfile \
->   apps/truth-enrichment/src
-> ```
-
-Verify the image is available in the registry:
+ACR remote build alternative:
 
 ```bash
-az acr repository show-tags \
-  --name "$ACR_NAME" \
-  --repository "$SERVICE_NAME" \
-  --orderby time_desc \
-  --output table
+az acr build --registry "${ACR_NAME}" --image "${SERVICE_NAME}:${IMAGE_TAG}" --file "${DOCKERFILE_PATH}" "${APP_PATH}"
 ```
 
----
+### 4. Render and deploy
 
-### Step 4 — Create the Kubernetes namespace
+Preferred (azd-first):
 
 ```bash
-kubectl get namespace "$K8S_NAMESPACE" &>/dev/null \
-  || kubectl create namespace "$K8S_NAMESPACE"
+azd deploy --service "${SERVICE_NAME}" -e "${AZD_ENV_NAME}" --no-prompt
 ```
 
----
-
-### Step 5 — Inject environment variables into the cluster
-
-Environment variables are split into two manifests: a **ConfigMap** for non-sensitive settings and a **Secret** for credentials.  
-Neither manifest should be committed to source control.
-
-#### 5a — ConfigMap (non-sensitive)
+Manual render/deploy path:
 
 ```bash
-kubectl create configmap truth-enrichment-config \
-  --namespace "$K8S_NAMESPACE" \
-  --from-literal=APP_NAME="truth-enrichment" \
-  --from-literal=PROJECT_ENDPOINT="https://<foundry-project>.api.azureml.ms" \
-  --from-literal=FOUNDRY_ENDPOINT="https://<foundry-project>.api.azureml.ms" \
-  --from-literal=FOUNDRY_AGENT_ID_FAST="<fast-agent-id>" \
-  --from-literal=MODEL_DEPLOYMENT_NAME_FAST="gpt-4o-mini" \
-  --from-literal=FOUNDRY_AGENT_ID_RICH="<rich-agent-id>" \
-  --from-literal=MODEL_DEPLOYMENT_NAME_RICH="gpt-4o" \
-  --from-literal=FOUNDRY_STREAM="false" \
-  --from-literal=CRUD_SERVICE_URL="http://crud-service.holiday-peak.svc.cluster.local" \
-  --from-literal=EVENT_HUB_NAMESPACE="<eventhub-namespace>.servicebus.windows.net" \
-  --from-literal=DAM_ENDPOINT="https://<dam-service-url>" \
-  --from-literal=DAM_MAX_IMAGES="4" \
-  --from-literal=COSMOS_ACCOUNT_URI="https://<cosmos-account>.documents.azure.com:443/" \
-  --from-literal=COSMOS_DATABASE="holiday-peak" \
-  --from-literal=COSMOS_CONTAINER="memory" \
-  --from-literal=BLOB_ACCOUNT_URL="https://<storage-account>.blob.core.windows.net" \
-  --from-literal=BLOB_CONTAINER="agent-memory" \
-  --dry-run=client -o yaml | kubectl apply -f -
+SERVICE_NAME="${SERVICE_NAME}" IMAGE_PREFIX="${ACR_LOGIN_SERVER}" IMAGE_TAG="${IMAGE_TAG}" K8S_NAMESPACE="${K8S_NAMESPACE}" KEDA_ENABLED="false" PUBLICATION_MODE="none" .infra/azd/hooks/render-helm.sh truth-enrichment
+helm upgrade --install truth-enrichment .kubernetes/chart --namespace "${K8S_NAMESPACE}" --create-namespace --set serviceName=truth-enrichment --set "image.repository=${IMAGE_REPO}" --set "image.tag=${IMAGE_TAG}" --wait --timeout 5m
 ```
 
-> Re-running `--dry-run=client -o yaml | kubectl apply -f -` is idempotent and safe to repeat on updates.
+If you deploy manually, provide env values through a local values file and do not commit secrets.
 
-#### 5b — Secret (sensitive credentials)
+### 5. Validate deployment
 
 ```bash
-kubectl create secret generic truth-enrichment-secrets \
-  --namespace "$K8S_NAMESPACE" \
-  --from-literal=EVENT_HUB_CONNECTION_STRING="Endpoint=sb://<ns>.servicebus.windows.net/;SharedAccessKeyName=...;SharedAccessKey=..." \
-  --from-literal=REDIS_URL="rediss://:<password>@<redis-host>:6380/0" \
-  --from-literal=DAM_API_KEY="<dam-service-api-key>" \
-  --from-literal=APPLICATIONINSIGHTS_CONNECTION_STRING="InstrumentationKey=...;IngestionEndpoint=..." \
-  --dry-run=client -o yaml | kubectl apply -f -
+kubectl rollout status deployment/truth-enrichment -n "${K8S_NAMESPACE}" --timeout=5m
+kubectl get pods -n "${K8S_NAMESPACE}" -l app=truth-enrichment
+kubectl logs -n "${K8S_NAMESPACE}" -l app=truth-enrichment --tail=100
+kubectl port-forward -n "${K8S_NAMESPACE}" deployment/truth-enrichment 8080:8000
+curl -s http://localhost:8080/health
+curl -s http://localhost:8080/ready
 ```
 
-> **Prefer managed identity over static keys when available.** Set `AZURE_CLIENT_ID` to the workload identity client ID and omit static connection strings for services that support Azure AD authentication (Event Hubs, Cosmos DB, Blob Storage).
+### 6. Teardown
 
-#### 5c — Verify
+Standalone service cleanup:
 
 ```bash
-kubectl describe configmap truth-enrichment-config -n "$K8S_NAMESPACE"
-kubectl describe secret truth-enrichment-secrets -n "$K8S_NAMESPACE"
+helm uninstall truth-enrichment -n "${K8S_NAMESPACE}" || true
+kubectl delete configmap truth-enrichment-config -n "${K8S_NAMESPACE}" --ignore-not-found
+kubectl delete secret truth-enrichment-secrets -n "${K8S_NAMESPACE}" --ignore-not-found
 ```
 
----
-
-### Step 6 — Render the Helm chart
-
-The render hook produces a `kubectl`-ready manifest under `.kubernetes/rendered/`.
+Full environment cleanup (destructive, use only when intended):
 
 ```bash
-# From the repository root
-SERVICE_NAME="truth-enrichment" \
-IMAGE_PREFIX="${ACR_LOGIN_SERVER}" \
-IMAGE_TAG="${IMAGE_TAG}" \
-K8S_NAMESPACE="${K8S_NAMESPACE}" \
-KEDA_ENABLED="false" \
-PUBLICATION_MODE="none" \
-  .infra/azd/hooks/render-helm.sh truth-enrichment
-```
-
-Inspect the rendered output before applying:
-
-```bash
-cat .kubernetes/rendered/truth-enrichment/*.yaml
-```
-
----
-
-### Step 7 — Inject env vars into the rendered manifest
-
-The Helm chart exposes environment variables via `--set env.<KEY>=<VALUE>`. To pass all values without exposing credentials in shell history, create a local `values-env.yaml` file (**do not commit this file**).
-
-```yaml
-# values-env.yaml  — LOCAL FILE, add to .gitignore
-env:
-  # ConfigMap values
-  APP_NAME: "truth-enrichment"
-  PROJECT_ENDPOINT: "https://<foundry-project>.api.azureml.ms"
-  FOUNDRY_AGENT_ID_FAST: "<fast-agent-id>"
-  MODEL_DEPLOYMENT_NAME_FAST: "gpt-4o-mini"
-  FOUNDRY_AGENT_ID_RICH: "<rich-agent-id>"
-  MODEL_DEPLOYMENT_NAME_RICH: "gpt-4o"
-  FOUNDRY_STREAM: "false"
-  CRUD_SERVICE_URL: "http://crud-service.holiday-peak.svc.cluster.local"
-  EVENT_HUB_NAMESPACE: "<eventhub-namespace>.servicebus.windows.net"
-  DAM_ENDPOINT: "https://<dam-service-url>"
-  DAM_MAX_IMAGES: "4"
-  COSMOS_ACCOUNT_URI: "https://<cosmos-account>.documents.azure.com:443/"
-  COSMOS_DATABASE: "holiday-peak"
-  COSMOS_CONTAINER: "memory"
-  BLOB_ACCOUNT_URL: "https://<storage-account>.blob.core.windows.net"
-  BLOB_CONTAINER: "agent-memory"
-  # Sensitive values — keep this file out of version control
-  EVENT_HUB_CONNECTION_STRING: "Endpoint=sb://..."
-  REDIS_URL: "rediss://:<password>@<host>:6380/0"
-  DAM_API_KEY: "<dam-service-api-key>"
-  APPLICATIONINSIGHTS_CONNECTION_STRING: "InstrumentationKey=..."
-```
-
-Then install or upgrade:
-
-```bash
-helm upgrade --install truth-enrichment \
-  .kubernetes/chart \
-  --namespace "$K8S_NAMESPACE" \
-  --create-namespace \
-  --set serviceName=truth-enrichment \
-  --set "image.repository=${IMAGE_REPO}" \
-  --set "image.tag=${IMAGE_TAG}" \
-  --set nodeSelector.agentpool=agents \
-  --set tolerations[0].key=workload \
-  --set tolerations[0].operator=Equal \
-  --set tolerations[0].value=agents \
-  --set tolerations[0].effect=NoSchedule \
-  --values values-env.yaml \
-  --wait \
-  --timeout 5m
-```
-
----
-
-### Step 8 — Validate the deployment
-
-```bash
-# Watch rollout progress
-kubectl rollout status deployment/truth-enrichment \
-  --namespace "$K8S_NAMESPACE" \
-  --timeout=5m
-
-# Inspect the running pods
-kubectl get pods -n "$K8S_NAMESPACE" -l app=truth-enrichment
-
-# Stream logs from the first pod
-kubectl logs -n "$K8S_NAMESPACE" \
-  -l app=truth-enrichment \
-  --follow --tail=100
-
-# Smoke-test via port-forward
-kubectl port-forward \
-  -n "$K8S_NAMESPACE" \
-  deployment/truth-enrichment 8080:8000 &
-
-curl -s http://localhost:8080/health | python3 -m json.tool
-curl -s http://localhost:8080/ready  | python3 -m json.tool
-
-# Test the enrichment endpoint
-curl -s -X POST http://localhost:8080/enrich/product/SKU-001 \
-  -H "Content-Type: application/json" | python3 -m json.tool
-```
-
----
-
-### Environment Variable Reference
-
-#### Azure AI Foundry (required)
-
-| Variable | Description | Example |
-|----------|-------------|---------|
-| `PROJECT_ENDPOINT` / `FOUNDRY_ENDPOINT` | Azure AI Foundry project endpoint | `https://<project>.api.azureml.ms` |
-| `FOUNDRY_AGENT_ID_FAST` | SLM agent ID for low-complexity requests | `asst_abc123` |
-| `MODEL_DEPLOYMENT_NAME_FAST` | SLM deployment name | `gpt-4o-mini` |
-| `FOUNDRY_AGENT_ID_RICH` | LLM agent ID for complex enrichment requests | `asst_xyz456` |
-| `MODEL_DEPLOYMENT_NAME_RICH` | LLM deployment name | `gpt-4o` |
-| `FOUNDRY_STREAM` | Enable streaming responses | `false` |
-
-#### CRUD Service (required)
-
-| Variable | Description | Example |
-|----------|-------------|---------|
-| `CRUD_SERVICE_URL` | Internal URL of the CRUD service for product lookups | `http://crud-service.holiday-peak.svc.cluster.local` |
-
-#### Azure Event Hub (required)
-
-| Variable | Description | Example |
-|----------|-------------|---------|
-| `EVENT_HUB_CONNECTION_STRING` / `EVENTHUB_CONNECTION_STRING` | Connection string with *Listen* rights on `enrichment-jobs` | `Endpoint=sb://...` |
-| `EVENT_HUB_NAMESPACE` / `EVENTHUB_NAMESPACE` | Namespace FQDN (used when workload identity replaces connection strings) | `<ns>.servicebus.windows.net` |
-| `AZURE_CLIENT_ID` | Managed identity client ID for Event Hub auth via workload identity | `<uuid>` |
-
-#### DAM Image Analysis (optional — vision enrichment path)
-
-| Variable | Description | Default | Example |
-|----------|-------------|---------|---------|
-| `DAM_ENDPOINT` / `DAM_BASE_URL` | Digital Asset Management service base URL | — | `https://<dam-service>` |
-| `DAM_API_KEY` | API key for the DAM service | — | `<secret>` |
-| `DAM_MAX_IMAGES` | Maximum number of images analyzed per enrichment request | `4` | `4` |
-
-#### Three-tier Memory (optional — degrades gracefully when absent)
-
-| Variable | Description | Example |
-|----------|-------------|---------|
-| `REDIS_URL` | Hot memory — Redis connection string | `rediss://:<password>@<host>:6380/0` |
-| `COSMOS_ACCOUNT_URI` | Warm memory — Cosmos DB account endpoint | `https://<account>.documents.azure.com:443/` |
-| `COSMOS_DATABASE` | Cosmos DB database name | `holiday-peak` |
-| `COSMOS_CONTAINER` | Cosmos DB container name | `memory` |
-| `BLOB_ACCOUNT_URL` | Cold memory — Blob Storage account URL | `https://<account>.blob.core.windows.net` |
-| `BLOB_CONTAINER` | Blob container name | `agent-memory` |
-
-#### Observability (optional)
-
-| Variable | Description | Example |
-|----------|-------------|---------|
-| `APPLICATIONINSIGHTS_CONNECTION_STRING` / `APPINSIGHTS_CONNECTION_STRING` | Application Insights telemetry connection string | `InstrumentationKey=...;IngestionEndpoint=...` |
-| `FOUNDRY_TRACING_ENABLED` | Enable Foundry trace capture | `true` |
-| `FOUNDRY_TRACING_MAX_EVENTS` | Max events buffered per trace | `500` |
-
----
-
-### Updating the deployment
-
-To deploy a new image version without replacing env vars:
-
-```bash
-IMAGE_TAG="<new-tag>"
-
-kubectl set image deployment/truth-enrichment \
-  truth-enrichment="${IMAGE_REPO}:${IMAGE_TAG}" \
-  --namespace "$K8S_NAMESPACE"
-
-kubectl rollout status deployment/truth-enrichment \
-  --namespace "$K8S_NAMESPACE" --timeout=5m
-```
-
-To update a single environment variable without a full redeploy:
-
-```bash
-# Edit the ConfigMap directly
-kubectl edit configmap truth-enrichment-config -n "$K8S_NAMESPACE"
-
-# Then trigger a rolling restart to pick up the changes
-kubectl rollout restart deployment/truth-enrichment -n "$K8S_NAMESPACE"
-```
-
----
-
-### Teardown
-
-```bash
-helm uninstall truth-enrichment --namespace "$K8S_NAMESPACE"
-kubectl delete configmap truth-enrichment-config -n "$K8S_NAMESPACE"
-kubectl delete secret truth-enrichment-secrets -n "$K8S_NAMESPACE"
+azd down -e "${AZD_ENV_NAME}" --purge --force
 ```

--- a/apps/truth-export/README.md
+++ b/apps/truth-export/README.md
@@ -27,3 +27,118 @@ python -m pytest ../tests
 - Uses Foundry model settings (`PROJECT_ENDPOINT` or `FOUNDRY_ENDPOINT`, fast/rich model identifiers).
 - Supports Redis/Cosmos/Blob memory configuration via shared memory settings.
 - Requires Event Hub namespace and consumer configuration for background jobs.
+
+---
+
+## Standalone Deployment - azd-first (ACR -> AKS)
+
+This service supports standalone deployment to an existing Holiday Peak Hub Azure environment.
+Use azd as the primary deployment path. Use the manual ACR -> AKS path only when you need isolated rollout or troubleshooting outside the standard workflow.
+
+### Prerequisites
+
+| Tool | Why it is needed |
+|------|------------------|
+| az CLI | Azure authentication and resource operations |
+| azd | Environment selection and service deploy |
+| docker (or az acr build) | Build and push the container image |
+| kubectl + helm | Manual AKS deployment and validation |
+
+### 1. Set service variables
+
+```bash
+SERVICE_NAME="truth-export"
+APP_PATH="apps/truth-export/src"
+DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
+AZD_ENV_NAME="dev"
+K8S_NAMESPACE="holiday-peak"
+IMAGE_TAG="$(git rev-parse --short HEAD)"
+```
+
+### 2. Configure required environment variables
+
+Set these in the selected azd environment (recommended) or in your manual Helm values file:
+
+| Variable | Required | Notes |
+|----------|----------|-------|
+| PROJECT_ENDPOINT or FOUNDRY_ENDPOINT | Yes | Azure AI Foundry project endpoint |
+| FOUNDRY_AGENT_ID_FAST | Yes | Fast-path model agent id |
+| MODEL_DEPLOYMENT_NAME_FAST | Yes | Fast-path deployment name |
+| FOUNDRY_AGENT_ID_RICH | Yes | Rich-path model agent id |
+| MODEL_DEPLOYMENT_NAME_RICH | Yes | Rich-path deployment name |
+| EVENT_HUB_NAMESPACE or EVENTHUB_NAMESPACE | Yes | Event Hub namespace FQDN |
+| EVENT_HUB_CONNECTION_STRING or EVENTHUB_CONNECTION_STRING | Usually | Needed when workload identity is not used |
+| APP_NAME | Recommended | Set to truth-export |
+| CRUD_SERVICE_URL | Service-dependent | Required when this service calls CRUD APIs |
+| REDIS_URL / COSMOS_* / BLOB_* | Optional | Three-tier memory; service degrades gracefully when absent |
+| APPLICATIONINSIGHTS_CONNECTION_STRING | Optional | App telemetry |
+
+Example azd env commands:
+
+```bash
+azd env select "${AZD_ENV_NAME}"
+azd env set APP_NAME "truth-export"
+# repeat azd env set for the required values above
+```
+
+### 3. Build and push image
+
+```bash
+ACR_NAME="<existing-acr-name>"
+az acr login --name "${ACR_NAME}"
+ACR_LOGIN_SERVER="$(az acr show --name "${ACR_NAME}" --query loginServer -o tsv)"
+IMAGE_REPO="${ACR_LOGIN_SERVER}/${SERVICE_NAME}"
+docker build --target prod --tag "${IMAGE_REPO}:${IMAGE_TAG}" --tag "${IMAGE_REPO}:latest" -f "${DOCKERFILE_PATH}" "${APP_PATH}"
+docker push "${IMAGE_REPO}:${IMAGE_TAG}"
+docker push "${IMAGE_REPO}:latest"
+```
+
+ACR remote build alternative:
+
+```bash
+az acr build --registry "${ACR_NAME}" --image "${SERVICE_NAME}:${IMAGE_TAG}" --file "${DOCKERFILE_PATH}" "${APP_PATH}"
+```
+
+### 4. Render and deploy
+
+Preferred (azd-first):
+
+```bash
+azd deploy --service "${SERVICE_NAME}" -e "${AZD_ENV_NAME}" --no-prompt
+```
+
+Manual render/deploy path:
+
+```bash
+SERVICE_NAME="${SERVICE_NAME}" IMAGE_PREFIX="${ACR_LOGIN_SERVER}" IMAGE_TAG="${IMAGE_TAG}" K8S_NAMESPACE="${K8S_NAMESPACE}" KEDA_ENABLED="false" PUBLICATION_MODE="none" .infra/azd/hooks/render-helm.sh truth-export
+helm upgrade --install truth-export .kubernetes/chart --namespace "${K8S_NAMESPACE}" --create-namespace --set serviceName=truth-export --set "image.repository=${IMAGE_REPO}" --set "image.tag=${IMAGE_TAG}" --wait --timeout 5m
+```
+
+If you deploy manually, provide env values through a local values file and do not commit secrets.
+
+### 5. Validate deployment
+
+```bash
+kubectl rollout status deployment/truth-export -n "${K8S_NAMESPACE}" --timeout=5m
+kubectl get pods -n "${K8S_NAMESPACE}" -l app=truth-export
+kubectl logs -n "${K8S_NAMESPACE}" -l app=truth-export --tail=100
+kubectl port-forward -n "${K8S_NAMESPACE}" deployment/truth-export 8080:8000
+curl -s http://localhost:8080/health
+curl -s http://localhost:8080/ready
+```
+
+### 6. Teardown
+
+Standalone service cleanup:
+
+```bash
+helm uninstall truth-export -n "${K8S_NAMESPACE}" || true
+kubectl delete configmap truth-export-config -n "${K8S_NAMESPACE}" --ignore-not-found
+kubectl delete secret truth-export-secrets -n "${K8S_NAMESPACE}" --ignore-not-found
+```
+
+Full environment cleanup (destructive, use only when intended):
+
+```bash
+azd down -e "${AZD_ENV_NAME}" --purge --force
+```

--- a/apps/truth-hitl/README.md
+++ b/apps/truth-hitl/README.md
@@ -27,3 +27,118 @@ python -m pytest ../tests
 - Uses Foundry model settings (`PROJECT_ENDPOINT` or `FOUNDRY_ENDPOINT`, fast/rich model identifiers).
 - Supports Redis/Cosmos/Blob memory configuration via shared memory settings.
 - Requires Event Hub namespace and consumer configuration for background jobs.
+
+---
+
+## Standalone Deployment - azd-first (ACR -> AKS)
+
+This service supports standalone deployment to an existing Holiday Peak Hub Azure environment.
+Use azd as the primary deployment path. Use the manual ACR -> AKS path only when you need isolated rollout or troubleshooting outside the standard workflow.
+
+### Prerequisites
+
+| Tool | Why it is needed |
+|------|------------------|
+| az CLI | Azure authentication and resource operations |
+| azd | Environment selection and service deploy |
+| docker (or az acr build) | Build and push the container image |
+| kubectl + helm | Manual AKS deployment and validation |
+
+### 1. Set service variables
+
+```bash
+SERVICE_NAME="truth-hitl"
+APP_PATH="apps/truth-hitl/src"
+DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
+AZD_ENV_NAME="dev"
+K8S_NAMESPACE="holiday-peak"
+IMAGE_TAG="$(git rev-parse --short HEAD)"
+```
+
+### 2. Configure required environment variables
+
+Set these in the selected azd environment (recommended) or in your manual Helm values file:
+
+| Variable | Required | Notes |
+|----------|----------|-------|
+| PROJECT_ENDPOINT or FOUNDRY_ENDPOINT | Yes | Azure AI Foundry project endpoint |
+| FOUNDRY_AGENT_ID_FAST | Yes | Fast-path model agent id |
+| MODEL_DEPLOYMENT_NAME_FAST | Yes | Fast-path deployment name |
+| FOUNDRY_AGENT_ID_RICH | Yes | Rich-path model agent id |
+| MODEL_DEPLOYMENT_NAME_RICH | Yes | Rich-path deployment name |
+| EVENT_HUB_NAMESPACE or EVENTHUB_NAMESPACE | Yes | Event Hub namespace FQDN |
+| EVENT_HUB_CONNECTION_STRING or EVENTHUB_CONNECTION_STRING | Usually | Needed when workload identity is not used |
+| APP_NAME | Recommended | Set to truth-hitl |
+| CRUD_SERVICE_URL | Service-dependent | Required when this service calls CRUD APIs |
+| REDIS_URL / COSMOS_* / BLOB_* | Optional | Three-tier memory; service degrades gracefully when absent |
+| APPLICATIONINSIGHTS_CONNECTION_STRING | Optional | App telemetry |
+
+Example azd env commands:
+
+```bash
+azd env select "${AZD_ENV_NAME}"
+azd env set APP_NAME "truth-hitl"
+# repeat azd env set for the required values above
+```
+
+### 3. Build and push image
+
+```bash
+ACR_NAME="<existing-acr-name>"
+az acr login --name "${ACR_NAME}"
+ACR_LOGIN_SERVER="$(az acr show --name "${ACR_NAME}" --query loginServer -o tsv)"
+IMAGE_REPO="${ACR_LOGIN_SERVER}/${SERVICE_NAME}"
+docker build --target prod --tag "${IMAGE_REPO}:${IMAGE_TAG}" --tag "${IMAGE_REPO}:latest" -f "${DOCKERFILE_PATH}" "${APP_PATH}"
+docker push "${IMAGE_REPO}:${IMAGE_TAG}"
+docker push "${IMAGE_REPO}:latest"
+```
+
+ACR remote build alternative:
+
+```bash
+az acr build --registry "${ACR_NAME}" --image "${SERVICE_NAME}:${IMAGE_TAG}" --file "${DOCKERFILE_PATH}" "${APP_PATH}"
+```
+
+### 4. Render and deploy
+
+Preferred (azd-first):
+
+```bash
+azd deploy --service "${SERVICE_NAME}" -e "${AZD_ENV_NAME}" --no-prompt
+```
+
+Manual render/deploy path:
+
+```bash
+SERVICE_NAME="${SERVICE_NAME}" IMAGE_PREFIX="${ACR_LOGIN_SERVER}" IMAGE_TAG="${IMAGE_TAG}" K8S_NAMESPACE="${K8S_NAMESPACE}" KEDA_ENABLED="false" PUBLICATION_MODE="none" .infra/azd/hooks/render-helm.sh truth-hitl
+helm upgrade --install truth-hitl .kubernetes/chart --namespace "${K8S_NAMESPACE}" --create-namespace --set serviceName=truth-hitl --set "image.repository=${IMAGE_REPO}" --set "image.tag=${IMAGE_TAG}" --wait --timeout 5m
+```
+
+If you deploy manually, provide env values through a local values file and do not commit secrets.
+
+### 5. Validate deployment
+
+```bash
+kubectl rollout status deployment/truth-hitl -n "${K8S_NAMESPACE}" --timeout=5m
+kubectl get pods -n "${K8S_NAMESPACE}" -l app=truth-hitl
+kubectl logs -n "${K8S_NAMESPACE}" -l app=truth-hitl --tail=100
+kubectl port-forward -n "${K8S_NAMESPACE}" deployment/truth-hitl 8080:8000
+curl -s http://localhost:8080/health
+curl -s http://localhost:8080/ready
+```
+
+### 6. Teardown
+
+Standalone service cleanup:
+
+```bash
+helm uninstall truth-hitl -n "${K8S_NAMESPACE}" || true
+kubectl delete configmap truth-hitl-config -n "${K8S_NAMESPACE}" --ignore-not-found
+kubectl delete secret truth-hitl-secrets -n "${K8S_NAMESPACE}" --ignore-not-found
+```
+
+Full environment cleanup (destructive, use only when intended):
+
+```bash
+azd down -e "${AZD_ENV_NAME}" --purge --force
+```

--- a/apps/truth-ingestion/README.md
+++ b/apps/truth-ingestion/README.md
@@ -27,3 +27,118 @@ python -m pytest ../tests
 - Uses Foundry model settings (`PROJECT_ENDPOINT` or `FOUNDRY_ENDPOINT`, fast/rich model identifiers).
 - Supports Redis/Cosmos/Blob memory configuration via shared memory settings.
 - Requires Event Hub namespace and consumer configuration for background jobs.
+
+---
+
+## Standalone Deployment - azd-first (ACR -> AKS)
+
+This service supports standalone deployment to an existing Holiday Peak Hub Azure environment.
+Use azd as the primary deployment path. Use the manual ACR -> AKS path only when you need isolated rollout or troubleshooting outside the standard workflow.
+
+### Prerequisites
+
+| Tool | Why it is needed |
+|------|------------------|
+| az CLI | Azure authentication and resource operations |
+| azd | Environment selection and service deploy |
+| docker (or az acr build) | Build and push the container image |
+| kubectl + helm | Manual AKS deployment and validation |
+
+### 1. Set service variables
+
+```bash
+SERVICE_NAME="truth-ingestion"
+APP_PATH="apps/truth-ingestion/src"
+DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
+AZD_ENV_NAME="dev"
+K8S_NAMESPACE="holiday-peak"
+IMAGE_TAG="$(git rev-parse --short HEAD)"
+```
+
+### 2. Configure required environment variables
+
+Set these in the selected azd environment (recommended) or in your manual Helm values file:
+
+| Variable | Required | Notes |
+|----------|----------|-------|
+| PROJECT_ENDPOINT or FOUNDRY_ENDPOINT | Yes | Azure AI Foundry project endpoint |
+| FOUNDRY_AGENT_ID_FAST | Yes | Fast-path model agent id |
+| MODEL_DEPLOYMENT_NAME_FAST | Yes | Fast-path deployment name |
+| FOUNDRY_AGENT_ID_RICH | Yes | Rich-path model agent id |
+| MODEL_DEPLOYMENT_NAME_RICH | Yes | Rich-path deployment name |
+| EVENT_HUB_NAMESPACE or EVENTHUB_NAMESPACE | Yes | Event Hub namespace FQDN |
+| EVENT_HUB_CONNECTION_STRING or EVENTHUB_CONNECTION_STRING | Usually | Needed when workload identity is not used |
+| APP_NAME | Recommended | Set to truth-ingestion |
+| CRUD_SERVICE_URL | Service-dependent | Required when this service calls CRUD APIs |
+| REDIS_URL / COSMOS_* / BLOB_* | Optional | Three-tier memory; service degrades gracefully when absent |
+| APPLICATIONINSIGHTS_CONNECTION_STRING | Optional | App telemetry |
+
+Example azd env commands:
+
+```bash
+azd env select "${AZD_ENV_NAME}"
+azd env set APP_NAME "truth-ingestion"
+# repeat azd env set for the required values above
+```
+
+### 3. Build and push image
+
+```bash
+ACR_NAME="<existing-acr-name>"
+az acr login --name "${ACR_NAME}"
+ACR_LOGIN_SERVER="$(az acr show --name "${ACR_NAME}" --query loginServer -o tsv)"
+IMAGE_REPO="${ACR_LOGIN_SERVER}/${SERVICE_NAME}"
+docker build --target prod --tag "${IMAGE_REPO}:${IMAGE_TAG}" --tag "${IMAGE_REPO}:latest" -f "${DOCKERFILE_PATH}" "${APP_PATH}"
+docker push "${IMAGE_REPO}:${IMAGE_TAG}"
+docker push "${IMAGE_REPO}:latest"
+```
+
+ACR remote build alternative:
+
+```bash
+az acr build --registry "${ACR_NAME}" --image "${SERVICE_NAME}:${IMAGE_TAG}" --file "${DOCKERFILE_PATH}" "${APP_PATH}"
+```
+
+### 4. Render and deploy
+
+Preferred (azd-first):
+
+```bash
+azd deploy --service "${SERVICE_NAME}" -e "${AZD_ENV_NAME}" --no-prompt
+```
+
+Manual render/deploy path:
+
+```bash
+SERVICE_NAME="${SERVICE_NAME}" IMAGE_PREFIX="${ACR_LOGIN_SERVER}" IMAGE_TAG="${IMAGE_TAG}" K8S_NAMESPACE="${K8S_NAMESPACE}" KEDA_ENABLED="false" PUBLICATION_MODE="none" .infra/azd/hooks/render-helm.sh truth-ingestion
+helm upgrade --install truth-ingestion .kubernetes/chart --namespace "${K8S_NAMESPACE}" --create-namespace --set serviceName=truth-ingestion --set "image.repository=${IMAGE_REPO}" --set "image.tag=${IMAGE_TAG}" --wait --timeout 5m
+```
+
+If you deploy manually, provide env values through a local values file and do not commit secrets.
+
+### 5. Validate deployment
+
+```bash
+kubectl rollout status deployment/truth-ingestion -n "${K8S_NAMESPACE}" --timeout=5m
+kubectl get pods -n "${K8S_NAMESPACE}" -l app=truth-ingestion
+kubectl logs -n "${K8S_NAMESPACE}" -l app=truth-ingestion --tail=100
+kubectl port-forward -n "${K8S_NAMESPACE}" deployment/truth-ingestion 8080:8000
+curl -s http://localhost:8080/health
+curl -s http://localhost:8080/ready
+```
+
+### 6. Teardown
+
+Standalone service cleanup:
+
+```bash
+helm uninstall truth-ingestion -n "${K8S_NAMESPACE}" || true
+kubectl delete configmap truth-ingestion-config -n "${K8S_NAMESPACE}" --ignore-not-found
+kubectl delete secret truth-ingestion-secrets -n "${K8S_NAMESPACE}" --ignore-not-found
+```
+
+Full environment cleanup (destructive, use only when intended):
+
+```bash
+azd down -e "${AZD_ENV_NAME}" --purge --force
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,29 +1,33 @@
 # Holiday Peak Hub - Architecture Documentation
 
-**Last Updated**: March 27, 2026  
+**Last Updated**: April 2, 2026  
 **Version**: main (post PR #559)  
 **Status**: Active Development
 
-## Latest Update Snapshot (March 27, 2026)
+## Latest Update Snapshot (April 2, 2026)
 
 - Enrichment/search orchestration hardening merged via PR #559 (Issue #558).
 - Truth flow now enforces human-gated enrichment validation (`pending_review`) with dual HITL publish (`export-jobs` and `search-enrichment-jobs`).
 - Search flow now supports two-stage UX (baseline first, background rerank) and request context propagation.
 - Catalog search now stores stage/session search context with best-effort persistence across hot/warm/cold memory tiers.
 - Validation status: local repository test run reports 1647 passed (2 warnings).
+- Agentic app README deployment docs are standardized with standalone azd-first guidance and app-specific ACR/AKS paths.
 
 ## Overview
 
 Holiday Peak Hub is a **cloud-native, agent-driven retail accelerator** with complete frontend implementation and comprehensive backend architecture plan. This documentation covers all architectural decisions, implementation plans, and operational procedures.
 
-## Developer Scripts
+## Developer Tooling
 
-Per-app run and test scripts are available under [scripts](scripts). These scripts create per-app virtual environments under each app src folder and run tests with coverage outputs per app directory.
+Repository-maintained automation scripts are available under [../scripts/ops](../scripts/ops) and [../scripts/ci](../scripts/ci).
+
+Per-app local run/test commands are documented in each service README under [../apps](../apps) (for example [../apps/ecommerce-catalog-search/README.md](../apps/ecommerce-catalog-search/README.md)).
 
 Python package management in this repository is uv-first. In CI, dependency installs use `uv pip --system`; use pip only as a compatibility bootstrap path to install uv.
 
-- Run an app: [scripts/run-app.sh](scripts/run-app.sh) with a per-app wrapper like [scripts/run-ecommerce-checkout-support.sh](scripts/run-ecommerce-checkout-support.sh)
-- Run all tests with coverage per app: [scripts/run-all-tests.sh](scripts/run-all-tests.sh)
+- Run tests: `python -m pytest`
+- Run lint: `python -m pylint lib/src apps/**/src`
+- Run format: `python -m black lib apps && python -m isort lib apps`
 
 ## Infrastructure CLI
 
@@ -187,11 +191,13 @@ azd env set POSTGRES_USER <aks-managed-identity-name>
 azd env set POSTGRES_PASSWORD ""
 ```
 
-6. **Deploy UI through azd**
+6. **Deploy UI through the azd dev entry workflow (SWA action path)**
 
 ```bash
-azd deploy --service ui --no-prompt -e dev
+gh workflow run deploy-azd-dev.yml -f location=eastus2 -f projectName=holidaypeakhub405 -f imageTag=latest -f deployStatic=true -f uiOnly=true -f forceApimSync=false -f autoAllowAcrRunnerIp=true
 ```
+
+This preserves the current governance path for UI rollout and avoids direct `azd deploy --service ui` usage.
 
 7. **Validate AKS health and CRUD runtime**
 


### PR DESCRIPTION
## Summary\n- add consistent standalone azd-first deployment sections to all agentic app READMEs\n- retain app-specific service names/paths and deployment validation commands\n- fix stale docs references in docs/README.md to match current scripts and workflow policy\n\n## Scope\n- 26 agent service READMEs under apps/* (excluding ui and crud-service)\n- docs/README.md\n\nCloses #606\nCloses #607