### PR TITLE
ci/python: fail lint on pylint E/F diagnostics

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           python -m isort --check-only lib apps
           python -m black --check lib apps
-          python -m pylint lib/src apps/*/src
+          python -m pylint --fail-on=E,F lib/src apps/*/src
       - name: Type check (mypy)
         run: |
           python -m mypy --config-file pyproject.toml --ignore-missing-imports --follow-imports=skip lib/src/holiday_peak_lib/agents/service_agent.py lib/src/holiday_peak_lib/agents/memory/builder.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,8 @@ Get-ChildItem apps | ForEach-Object {
 `uv` is the canonical package manager for this repo. `pip` is compatibility-only for bootstrapping `uv`.
 
 ## Development workflow
-- Format/lint: `python -m isort --check lib apps` then `python -m black --check lib apps` and `python -m pylint lib/src apps/*/src`
+- Format/lint: `python -m isort --check lib apps` then `python -m black --check lib apps` and `python -m pylint --fail-on=E,F lib/src apps/*/src`
+- Lint policy: any pylint `E` or `F` diagnostic is blocking in both CI and the local push gate.
 - Tests: `pytest lib/tests apps/**/tests --maxfail=1 --cov=. --cov-report=term-missing --cov-fail-under=75`
 - Coverage floor is 75% to match CI.
 - Optional (recommended) push gate setup: `git config core.hooksPath .githooks`

--- a/apps/crud-service/src/crud_service/integrations/agent_client.py
+++ b/apps/crud-service/src/crud_service/integrations/agent_client.py
@@ -34,7 +34,8 @@ class AgentClient:
         if not apim_base:
             return None
 
-        return f"{apim_base.rstrip('/')}/agents/{service_name}"
+        apim_base_url = str(apim_base)
+        return f"{apim_base_url.rstrip('/')}/agents/{service_name}"
 
     @circuit(
         failure_threshold=settings.agent_circuit_failure_threshold,

--- a/apps/crud-service/src/crud_service/routes/orders.py
+++ b/apps/crud-service/src/crud_service/routes/orders.py
@@ -118,9 +118,10 @@ async def get_order(order_id: str, current_user: User = Depends(get_current_user
             extra={"error_type": type(exc).__name__},
             exc_info=True,
         )
+    order_response_fields = set(OrderResponse.model_fields.keys())
 
     return OrderTrackingResponse(
-        **{k: v for k, v in order.items() if k in OrderResponse.model_fields},
+        **{k: v for k, v in order.items() if k in order_response_fields},
         tracking=tracking,
         eta=eta,
         carrier=carrier,

--- a/apps/ecommerce-product-detail-enrichment/src/ecommerce_product_detail_enrichment/agents.py
+++ b/apps/ecommerce-product-detail-enrichment/src/ecommerce_product_detail_enrichment/agents.py
@@ -16,6 +16,7 @@ from holiday_peak_lib.agents.memory import (
     read_hot_with_compatibility,
     resolve_namespace_context,
 )
+from holiday_peak_lib.agents.prompt_loader import load_prompt_instructions
 
 from .adapters import (
     EnrichmentAdapters,

--- a/scripts/ops/pre_push_gate.py
+++ b/scripts/ops/pre_push_gate.py
@@ -34,7 +34,7 @@ def run_lint_gate() -> None:
         if (path / "pyproject.toml").exists()
     )
     run_step(
-        ["python", "-m", "pylint", *pylint_targets],
+        ["python", "-m", "pylint", "--fail-on=E,F", *pylint_targets],
         title="Lint gate: pylint",
     )
 


### PR DESCRIPTION
## Summary\n- enforce --fail-on=E,F in CI lint workflow and pre-push gate\n- fix current E-level pylint findings in CRUD and product-detail enrichment modules\n- document contributor lint policy for blocking E/F diagnostics\n\n## Validation\n- python -m pylint --fail-on=E,F lib/src apps/*/src\n- python -m pytest apps/crud-service/tests/unit/test_agent_client.py apps/crud-service/tests/unit/test_agent_client_new_methods.py apps/ecommerce-product-detail-enrichment/tests/test_agents.py apps/ecommerce-product-detail-enrichment/tests/test_mcp_tools.py\n- pre-push gate: lint + full app test suites (passed)\n\nCloses #612