### PR TITLE
fix(governance): make audit resilient to CI token branch-protection limits

### DIFF
--- a/scripts/ops/audit_main_governance.py
+++ b/scripts/ops/audit_main_governance.py
@@ -103,7 +103,8 @@ def _github_get_optional(repo: str, endpoint: str) -> Any | None:
     try:
         return _github_get(repo, endpoint)
     except RuntimeError as exc:
-        if "GitHub API 404" in str(exc):
+        # GitHub Actions integration tokens often cannot read branch protection.
+        if "GitHub API 404" in str(exc) or "GitHub API 403" in str(exc):
             return None
         raise
 


### PR DESCRIPTION
## Summary
- treat branch protection endpoint as optional when GitHub API returns 403 for integration-scoped tokens
- preserve strict governance validation by relying on accessible rulesets/branch rules data
- keep 404 handling for optional endpoints unchanged

## Validation
- python scripts/ops/audit_main_governance.py --repo Azure-Samples/holiday-peak-hub --required-check lint --required-check test --min-approvals 1 --require-conversation-resolution

Closes #610