### PR TITLE
Harden Foundry lifecycle and deployment validation

### DIFF
--- a/.github/workflows/deploy-azd.yml
+++ b/.github/workflows/deploy-azd.yml
@@ -1598,6 +1598,8 @@ jobs:
           AI_SEARCH_AUTH_MODE: ${{ needs.provision.outputs.AI_SEARCH_AUTH_MODE }}
           PROJECT_ENDPOINT: ${{ needs.provision.outputs.PROJECT_ENDPOINT }}
           PROJECT_NAME: ${{ needs.provision.outputs.PROJECT_NAME }}
+          FOUNDRY_AGENT_NAME_FAST: ${{ matrix.service }}-fast
+          FOUNDRY_AGENT_NAME_RICH: ${{ matrix.service }}-rich
           FOUNDRY_AUTO_ENSURE_ON_STARTUP: "true"
           FOUNDRY_STRICT_ENFORCEMENT: "true"
           MODEL_DEPLOYMENT_NAME_FAST: gpt-5-nano

--- a/.infra/azd/hooks/ensure-foundry-agents.ps1
+++ b/.infra/azd/hooks/ensure-foundry-agents.ps1
@@ -101,7 +101,31 @@ function Invoke-EnsureEndpoint {
         try {
             Write-Host "  [$ServiceName] Calling $Url (attempt $attempt/$Retries)..."
             $response = Invoke-RestMethod -Uri $Url -Method POST -ContentType 'application/json' -TimeoutSec 120
-            Write-Host "  [$ServiceName] OK: fast=$($response.fast_agent_id), rich=$($response.rich_agent_id)"
+
+            $results = $response.results
+            $requiredRoles = @('fast', 'rich')
+            $validStatuses = @('exists', 'found_by_name', 'created')
+            $missing = @()
+
+            foreach ($role in $requiredRoles) {
+                $details = $results.$role
+                if (-not $details) {
+                    $missing += "$role:missing"
+                    continue
+                }
+
+                $status = [string]$details.status
+                $agentId = [string]$details.agent_id
+                if (($validStatuses -notcontains $status) -or [string]::IsNullOrWhiteSpace($agentId)) {
+                    $missing += "$role:$status"
+                }
+            }
+
+            if ($missing.Count -gt 0) {
+                throw "Ensure response incomplete ($($missing -join ', '))"
+            }
+
+            Write-Host "  [$ServiceName] OK: fast+rich roles resolved."
             return $true
         }
         catch {

--- a/.infra/azd/hooks/ensure-foundry-agents.sh
+++ b/.infra/azd/hooks/ensure-foundry-agents.sh
@@ -120,10 +120,46 @@ call_ensure() {
       --max-time 120 2>/dev/null || echo "000")"
 
     if [ "$HTTP_CODE" = "200" ]; then
-      echo "  [$SVC] OK (HTTP $HTTP_CODE)"
-      cat /tmp/ensure_response.json 2>/dev/null || true
-      echo ""
-      return 0
+      if python3 - "$SVC" <<'PY'
+import json
+import sys
+
+service = sys.argv[1]
+
+try:
+    with open('/tmp/ensure_response.json', encoding='utf-8') as handle:
+        payload = json.load(handle)
+except Exception as exc:  # pragma: no cover - shell integration guard
+    print(f"  [{service}] Invalid ensure response payload: {exc}")
+    sys.exit(1)
+
+results = payload.get('results') or {}
+required_roles = ('fast', 'rich')
+valid_statuses = {'exists', 'found_by_name', 'created'}
+missing = []
+
+for role in required_roles:
+    details = results.get(role)
+    if not isinstance(details, dict):
+        missing.append(f"{role}:missing")
+        continue
+    status = str(details.get('status') or '')
+    agent_id = str(details.get('agent_id') or '')
+    if status not in valid_statuses or not agent_id:
+        missing.append(f"{role}:{status or 'unknown'}")
+
+if missing:
+    print(f"  [{service}] Ensure response incomplete: {', '.join(missing)}")
+    sys.exit(1)
+
+print(f"  [{service}] Ensure response validated: fast+rich roles resolved.")
+PY
+      then
+        echo "  [$SVC] OK (HTTP $HTTP_CODE)"
+        cat /tmp/ensure_response.json 2>/dev/null || true
+        echo ""
+        return 0
+      fi
     fi
 
     echo "  [$SVC] Attempt $attempt failed (HTTP $HTTP_CODE)"

--- a/.infra/azd/hooks/render-helm.ps1
+++ b/.infra/azd/hooks/render-helm.ps1
@@ -210,6 +210,41 @@ if ($pdbEnabled -eq "true") {
   }
 }
 
+$isAgentService = $ServiceName -ne "crud-service"
+$resolvedFoundryAgentNameFast = $env:FOUNDRY_AGENT_NAME_FAST
+$resolvedFoundryAgentNameRich = $env:FOUNDRY_AGENT_NAME_RICH
+$resolvedModelDeploymentFast = $env:MODEL_DEPLOYMENT_NAME_FAST
+$resolvedModelDeploymentRich = $env:MODEL_DEPLOYMENT_NAME_RICH
+
+if ($isAgentService) {
+  if ([string]::IsNullOrWhiteSpace($resolvedFoundryAgentNameFast)) {
+    $resolvedFoundryAgentNameFast = "$ServiceName-fast"
+  }
+  if ([string]::IsNullOrWhiteSpace($resolvedFoundryAgentNameRich)) {
+    $resolvedFoundryAgentNameRich = "$ServiceName-rich"
+  }
+  if ([string]::IsNullOrWhiteSpace($resolvedModelDeploymentFast)) {
+    $resolvedModelDeploymentFast = "gpt-5-nano"
+  }
+  if ([string]::IsNullOrWhiteSpace($resolvedModelDeploymentRich)) {
+    $resolvedModelDeploymentRich = "gpt-5"
+  }
+
+  if (-not [string]::IsNullOrWhiteSpace($env:FOUNDRY_AGENT_ID_FAST) -and $env:FOUNDRY_AGENT_ID_FAST.EndsWith("-pending")) {
+    throw "Invalid FOUNDRY_AGENT_ID_FAST for ${ServiceName}: placeholder ids are not deployable."
+  }
+  if (-not [string]::IsNullOrWhiteSpace($env:FOUNDRY_AGENT_ID_RICH) -and $env:FOUNDRY_AGENT_ID_RICH.EndsWith("-pending")) {
+    throw "Invalid FOUNDRY_AGENT_ID_RICH for ${ServiceName}: placeholder ids are not deployable."
+  }
+
+  if ([string]::IsNullOrWhiteSpace($env:FOUNDRY_AGENT_ID_FAST) -and [string]::IsNullOrWhiteSpace($resolvedFoundryAgentNameFast)) {
+    throw "Missing Foundry fast-role definition for $ServiceName (set FOUNDRY_AGENT_ID_FAST or FOUNDRY_AGENT_NAME_FAST)."
+  }
+  if ([string]::IsNullOrWhiteSpace($env:FOUNDRY_AGENT_ID_RICH) -and [string]::IsNullOrWhiteSpace($resolvedFoundryAgentNameRich)) {
+    throw "Missing Foundry rich-role definition for $ServiceName (set FOUNDRY_AGENT_ID_RICH or FOUNDRY_AGENT_NAME_RICH)."
+  }
+}
+
 $envMappings = @{
   # Database
   POSTGRES_HOST = $env:POSTGRES_HOST
@@ -231,8 +266,10 @@ $envMappings = @{
   PROJECT_NAME = $env:PROJECT_NAME
   FOUNDRY_AGENT_ID_FAST = $env:FOUNDRY_AGENT_ID_FAST
   FOUNDRY_AGENT_ID_RICH = $env:FOUNDRY_AGENT_ID_RICH
-  MODEL_DEPLOYMENT_NAME_FAST = $env:MODEL_DEPLOYMENT_NAME_FAST
-  MODEL_DEPLOYMENT_NAME_RICH = $env:MODEL_DEPLOYMENT_NAME_RICH
+  FOUNDRY_AGENT_NAME_FAST = $resolvedFoundryAgentNameFast
+  FOUNDRY_AGENT_NAME_RICH = $resolvedFoundryAgentNameRich
+  MODEL_DEPLOYMENT_NAME_FAST = $resolvedModelDeploymentFast
+  MODEL_DEPLOYMENT_NAME_RICH = $resolvedModelDeploymentRich
   FOUNDRY_STREAM = $env:FOUNDRY_STREAM
   FOUNDRY_STRICT_ENFORCEMENT = $env:FOUNDRY_STRICT_ENFORCEMENT
   FOUNDRY_AUTO_ENSURE_ON_STARTUP = $env:FOUNDRY_AUTO_ENSURE_ON_STARTUP
@@ -345,12 +382,13 @@ if ($ServiceName -eq "search-enrichment-agent") {
   $envMappings["SEARCH_ENRICHMENT_EVENT_HUB_CONSUMER_GROUP"] = $searchEnrichmentConsumerGroup
 }
 
-$isAgentService = $ServiceName -ne "crud-service"
 if ($isAgentService) {
   Assert-RequiredEnvKeys -TargetService $ServiceName -Mappings $envMappings -RequiredKeys @(
     "EVENT_HUB_NAMESPACE",
     "PROJECT_ENDPOINT",
     "PROJECT_NAME",
+    "MODEL_DEPLOYMENT_NAME_FAST",
+    "MODEL_DEPLOYMENT_NAME_RICH",
     "COSMOS_ACCOUNT_URI",
     "COSMOS_DATABASE",
     "REDIS_HOST",
@@ -377,6 +415,38 @@ foreach ($key in $envMappings.Keys) {
 }
 
 & helm @helmArgs | Out-File -FilePath $rendered -Encoding utf8
+
+if ($isAgentService) {
+  $requiredFoundryRenderedKeys = @(
+    "PROJECT_ENDPOINT",
+    "PROJECT_NAME",
+    "MODEL_DEPLOYMENT_NAME_FAST",
+    "MODEL_DEPLOYMENT_NAME_RICH",
+    "FOUNDRY_AGENT_NAME_FAST",
+    "FOUNDRY_AGENT_NAME_RICH"
+  )
+
+  foreach ($foundryKey in $requiredFoundryRenderedKeys) {
+    $present = Select-String -Path $rendered -SimpleMatch "name: $foundryKey" -Quiet
+    if (-not $present) {
+      throw "Rendered manifest missing Foundry env key '$foundryKey' for $ServiceName"
+    }
+  }
+
+  if (-not [string]::IsNullOrWhiteSpace($env:FOUNDRY_AGENT_ID_FAST)) {
+    $presentFastId = Select-String -Path $rendered -SimpleMatch "name: FOUNDRY_AGENT_ID_FAST" -Quiet
+    if (-not $presentFastId) {
+      throw "Rendered manifest missing Foundry env key 'FOUNDRY_AGENT_ID_FAST' for $ServiceName"
+    }
+  }
+
+  if (-not [string]::IsNullOrWhiteSpace($env:FOUNDRY_AGENT_ID_RICH)) {
+    $presentRichId = Select-String -Path $rendered -SimpleMatch "name: FOUNDRY_AGENT_ID_RICH" -Quiet
+    if (-not $presentRichId) {
+      throw "Rendered manifest missing Foundry env key 'FOUNDRY_AGENT_ID_RICH' for $ServiceName"
+    }
+  }
+}
 
 if ($isTruthService) {
   $requiredRenderedKeys = @(

--- a/.infra/azd/hooks/render-helm.sh
+++ b/.infra/azd/hooks/render-helm.sh
@@ -225,6 +225,35 @@ require_env_keys() {
   fi
 }
 
+if is_agent_service; then
+  FOUNDRY_AGENT_NAME_FAST="${FOUNDRY_AGENT_NAME_FAST:-$SERVICE_NAME-fast}"
+  FOUNDRY_AGENT_NAME_RICH="${FOUNDRY_AGENT_NAME_RICH:-$SERVICE_NAME-rich}"
+  MODEL_DEPLOYMENT_NAME_FAST="${MODEL_DEPLOYMENT_NAME_FAST:-gpt-5-nano}"
+  MODEL_DEPLOYMENT_NAME_RICH="${MODEL_DEPLOYMENT_NAME_RICH:-gpt-5}"
+
+  case "${FOUNDRY_AGENT_ID_FAST:-}" in
+    *-pending)
+      echo "Invalid FOUNDRY_AGENT_ID_FAST for $SERVICE_NAME: placeholder ids are not deployable." >&2
+      exit 1
+      ;;
+  esac
+  case "${FOUNDRY_AGENT_ID_RICH:-}" in
+    *-pending)
+      echo "Invalid FOUNDRY_AGENT_ID_RICH for $SERVICE_NAME: placeholder ids are not deployable." >&2
+      exit 1
+      ;;
+  esac
+
+  if [ -z "${FOUNDRY_AGENT_ID_FAST:-}" ] && [ -z "${FOUNDRY_AGENT_NAME_FAST:-}" ]; then
+    echo "Missing Foundry fast-role definition for $SERVICE_NAME (set FOUNDRY_AGENT_ID_FAST or FOUNDRY_AGENT_NAME_FAST)." >&2
+    exit 1
+  fi
+  if [ -z "${FOUNDRY_AGENT_ID_RICH:-}" ] && [ -z "${FOUNDRY_AGENT_NAME_RICH:-}" ]; then
+    echo "Missing Foundry rich-role definition for $SERVICE_NAME (set FOUNDRY_AGENT_ID_RICH or FOUNDRY_AGENT_NAME_RICH)." >&2
+    exit 1
+  fi
+fi
+
 # Database
 add_env_arg "POSTGRES_HOST" "${POSTGRES_HOST:-}"
 add_env_arg "POSTGRES_USER" "${POSTGRES_USER:-}"
@@ -245,6 +274,8 @@ add_env_arg "PROJECT_ENDPOINT" "${PROJECT_ENDPOINT:-}"
 add_env_arg "PROJECT_NAME" "${PROJECT_NAME:-}"
 add_env_arg "FOUNDRY_AGENT_ID_FAST" "${FOUNDRY_AGENT_ID_FAST:-}"
 add_env_arg "FOUNDRY_AGENT_ID_RICH" "${FOUNDRY_AGENT_ID_RICH:-}"
+add_env_arg "FOUNDRY_AGENT_NAME_FAST" "${FOUNDRY_AGENT_NAME_FAST:-}"
+add_env_arg "FOUNDRY_AGENT_NAME_RICH" "${FOUNDRY_AGENT_NAME_RICH:-}"
 add_env_arg "MODEL_DEPLOYMENT_NAME_FAST" "${MODEL_DEPLOYMENT_NAME_FAST:-}"
 add_env_arg "MODEL_DEPLOYMENT_NAME_RICH" "${MODEL_DEPLOYMENT_NAME_RICH:-}"
 add_env_arg "FOUNDRY_STREAM" "${FOUNDRY_STREAM:-}"
@@ -314,6 +345,8 @@ if is_agent_service; then
     EVENT_HUB_NAMESPACE \
     PROJECT_ENDPOINT \
     PROJECT_NAME \
+    MODEL_DEPLOYMENT_NAME_FAST \
+    MODEL_DEPLOYMENT_NAME_RICH \
     COSMOS_ACCOUNT_URI \
     COSMOS_DATABASE \
     REDIS_HOST \
@@ -332,6 +365,24 @@ fi
 
 # shellcheck disable=SC2086
 helm template "$SERVICE_NAME" "$CHART_PATH" $HELM_ARGS > "$OUT_DIR/all.yaml"
+
+if is_agent_service; then
+  for key in PROJECT_ENDPOINT PROJECT_NAME MODEL_DEPLOYMENT_NAME_FAST MODEL_DEPLOYMENT_NAME_RICH FOUNDRY_AGENT_NAME_FAST FOUNDRY_AGENT_NAME_RICH; do
+    if ! grep -q "name: $key" "$OUT_DIR/all.yaml"; then
+      echo "Rendered manifest missing Foundry env key '$key' for $SERVICE_NAME" >&2
+      exit 1
+    fi
+  done
+
+  if [ -n "${FOUNDRY_AGENT_ID_FAST:-}" ] && ! grep -q "name: FOUNDRY_AGENT_ID_FAST" "$OUT_DIR/all.yaml"; then
+    echo "Rendered manifest missing Foundry env key 'FOUNDRY_AGENT_ID_FAST' for $SERVICE_NAME" >&2
+    exit 1
+  fi
+  if [ -n "${FOUNDRY_AGENT_ID_RICH:-}" ] && ! grep -q "name: FOUNDRY_AGENT_ID_RICH" "$OUT_DIR/all.yaml"; then
+    echo "Rendered manifest missing Foundry env key 'FOUNDRY_AGENT_ID_RICH' for $SERVICE_NAME" >&2
+    exit 1
+  fi
+fi
 
 if is_truth_service; then
   for key in EVENT_HUB_NAMESPACE PROJECT_ENDPOINT COSMOS_ACCOUNT_URI COSMOS_DATABASE TRUTH_EVENT_HUB_NAME TRUTH_EVENT_HUB_CONSUMER_GROUP; do

--- a/docs/architecture/components/libs/agents.md
+++ b/docs/architecture/components/libs/agents.md
@@ -265,6 +265,20 @@ Supported roles:
 
 The service updates in-memory model targets with resolved/created Foundry agent IDs.
 
+`POST /invoke` now performs a lazy Foundry ensure pass when runtime role definitions
+exist but SLM/LLM targets are unresolved (for example, missing role IDs at startup).
+If ensure cannot resolve all configured callable role targets (`fast`/`rich`), the service returns `503`
+with a Foundry runtime resolution error instead of attempting a model call with
+placeholder role IDs.
+
+Deploy-time Helm rendering now validates the Foundry contract for each agent service:
+
+- `PROJECT_ENDPOINT` / `PROJECT_NAME` must be present.
+- Both model roles must be defined (`MODEL_DEPLOYMENT_NAME_FAST` and `MODEL_DEPLOYMENT_NAME_RICH`).
+- Both Foundry role identities must be defined (explicit `FOUNDRY_AGENT_ID_*` or deterministic
+    `FOUNDRY_AGENT_NAME_*` defaults).
+- Placeholder ids ending with `-pending` are rejected at render time.
+
 Default deployment models in this repo are:
 
 - SLM (`fast`): `gpt-5-nano`

--- a/lib/src/holiday_peak_lib/app_factory.py
+++ b/lib/src/holiday_peak_lib/app_factory.py
@@ -42,6 +42,24 @@ def _build_foundry_config(agent_env: str, deployment_env: str) -> FoundryAgentCo
     return build_foundry_config(agent_env, deployment_env)
 
 
+def _runtime_foundry_config(config: FoundryAgentConfig | None) -> FoundryAgentConfig | None:
+    """Return a Foundry config only when a resolvable runtime agent id is available.
+
+    The lifecycle builder may emit placeholder ids like ``fast-pending`` when
+    endpoint settings exist but role-specific agent ids are not configured.
+    Wiring those placeholders as live model targets causes runtime 404s during
+    invocation. We keep such configs for ensure/provision endpoints, but avoid
+    binding them as callable SLM/LLM targets.
+    """
+    if config is None:
+        return None
+
+    agent_id = str(config.agent_id or "").strip()
+    if not agent_id or agent_id.endswith("-pending"):
+        return None
+    return config
+
+
 def create_standard_app(
     service_name: str,
     agent_class: type[BaseRetailAgent],
@@ -121,8 +139,33 @@ def build_service_app(
     if slm_config is None and llm_config is None:
         slm_config = _build_foundry_config("FOUNDRY_AGENT_ID_FAST", "MODEL_DEPLOYMENT_NAME_FAST")
         llm_config = _build_foundry_config("FOUNDRY_AGENT_ID_RICH", "MODEL_DEPLOYMENT_NAME_RICH")
-    if slm_config or llm_config:
-        builder = builder.with_foundry_models(slm_config=slm_config, llm_config=llm_config)
+
+    runtime_slm_config = _runtime_foundry_config(slm_config)
+    runtime_llm_config = _runtime_foundry_config(llm_config)
+    if runtime_slm_config or runtime_llm_config:
+        builder = builder.with_foundry_models(
+            slm_config=runtime_slm_config,
+            llm_config=runtime_llm_config,
+        )
+
+    unresolved_roles = []
+    if slm_config and runtime_slm_config is None:
+        unresolved_roles.append("fast")
+    if llm_config and runtime_llm_config is None:
+        unresolved_roles.append("rich")
+    if unresolved_roles:
+        logger.warning(
+            "foundry_runtime_targets_disabled",
+            extra={
+                "service": service_name,
+                "roles": unresolved_roles,
+                "hint": (
+                    "Set FOUNDRY_AGENT_ID_FAST/FOUNDRY_AGENT_ID_RICH (or role names) "
+                    "or enable FOUNDRY_AUTO_ENSURE_ON_STARTUP to provision agents before invoke."
+                ),
+            },
+        )
+
     agent = builder.build()
     tracer = get_foundry_tracer(service_name)
     if hasattr(agent, "connector_registry"):
@@ -163,7 +206,7 @@ def build_service_app(
 
             foundry_ready = all(
                 result.get("status") in {"exists", "found_by_name", "created"}
-                and bool(result.get("agent_id") or result.get("agent_name"))
+                and bool(result.get("agent_id"))
                 for result in results.values()
             )
 
@@ -279,11 +322,32 @@ def build_service_app(
 
             results[selected_role] = ensure_result
 
-        if strict_foundry_mode:
-            foundry_ready = any(
-                bool(result.get("agent_id"))
-                and result.get("status") in {"exists", "found_by_name", "created"}
-                for result in results.values()
+        configured_requested_roles = [
+            selected_role
+            for selected_role in selected_roles
+            if role_to_config.get(selected_role) is not None
+        ]
+
+        resolved_roles = sum(
+            1
+            for selected_role, result in results.items()
+            if selected_role in configured_requested_roles
+            if bool(result.get("agent_id"))
+            and result.get("status") in {"exists", "found_by_name", "created"}
+        )
+        foundry_ready = bool(configured_requested_roles) and (
+            resolved_roles == len(configured_requested_roles)
+        )
+
+        if strict_foundry_mode and not foundry_ready:
+            logger.warning(
+                "foundry_strict_ensure_incomplete",
+                extra={
+                    "service": service_name,
+                    "resolved_roles": resolved_roles,
+                    "configured_requested_roles": configured_requested_roles,
+                    "requested_roles": list(results.keys()),
+                },
             )
 
         return {
@@ -300,6 +364,9 @@ def build_service_app(
         nonlocal foundry_ready
         foundry_ready = value
 
+    def _requires_foundry_runtime_resolution() -> bool:
+        return bool((slm_config or llm_config) and not (agent.slm or agent.llm))
+
     register_standard_endpoints(
         app,
         service_name=service_name,
@@ -310,6 +377,7 @@ def build_service_app(
         strict_foundry_mode=strict_foundry_mode,
         is_foundry_ready=_is_foundry_ready,
         set_foundry_ready=_set_foundry_ready,
+        requires_foundry_runtime_resolution=_requires_foundry_runtime_resolution,
         ensure_agents_handler=ensure_agents,
     )
 

--- a/lib/src/holiday_peak_lib/app_factory_components/endpoints.py
+++ b/lib/src/holiday_peak_lib/app_factory_components/endpoints.py
@@ -21,9 +21,18 @@ def register_standard_endpoints(
     strict_foundry_mode: bool,
     is_foundry_ready: Callable[[], bool],
     set_foundry_ready: Callable[[bool], None],
+    requires_foundry_runtime_resolution: Callable[[], bool],
     ensure_agents_handler: Callable[[dict | None], Awaitable[dict[str, Any]]],
 ) -> None:
     """Register common health, invoke, telemetry and Foundry endpoints."""
+
+    def _log_info(message: str, extra: dict[str, Any] | None = None) -> None:
+        log_method = getattr(logger, "info", None)
+        if callable(log_method):
+            try:
+                log_method(message, extra=extra or {})
+            except TypeError:
+                log_method(message)
 
     @app.get("/health")
     async def health() -> dict[str, Any]:
@@ -63,12 +72,62 @@ def register_standard_endpoints(
 
     @app.post("/invoke")
     async def invoke(payload: dict) -> dict[str, Any]:
+        needs_runtime_resolution = requires_foundry_runtime_resolution()
+        if needs_runtime_resolution or (strict_foundry_mode and not is_foundry_ready()):
+            _log_info(
+                "foundry_invoke_auto_ensure_start",
+                extra={
+                    "service": service_name,
+                    "strict_mode": strict_foundry_mode,
+                    "needs_runtime_resolution": needs_runtime_resolution,
+                    "foundry_ready_before": is_foundry_ready(),
+                },
+            )
+            try:
+                ensure_result = await ensure_agents_handler(None)
+            except HTTPException:
+                raise
+            except Exception as exc:  # pragma: no cover - defensive endpoint guard
+                raise HTTPException(
+                    status_code=503,
+                    detail=(
+                        "Unable to resolve Foundry runtime definitions before invoke. "
+                        "Call POST /foundry/agents/ensure and retry."
+                    ),
+                ) from exc
+
+            set_foundry_ready(bool(ensure_result.get("foundry_ready", is_foundry_ready())))
+            _log_info(
+                "foundry_invoke_auto_ensure_done",
+                extra={
+                    "service": service_name,
+                    "strict_mode": strict_foundry_mode,
+                    "foundry_ready_after": is_foundry_ready(),
+                    "resolved_roles": [
+                        role
+                        for role, details in (ensure_result.get("results") or {}).items()
+                        if isinstance(details, dict)
+                        and bool(details.get("agent_id"))
+                        and details.get("status") in {"exists", "found_by_name", "created"}
+                    ],
+                },
+            )
+
         if strict_foundry_mode and not is_foundry_ready():
             raise HTTPException(
                 status_code=503,
                 detail=(
                     "Strict Foundry enforcement is enabled and no Foundry target is ready. "
                     "Call POST /foundry/agents/ensure first."
+                ),
+            )
+
+        if requires_foundry_runtime_resolution():
+            raise HTTPException(
+                status_code=503,
+                detail=(
+                    "Foundry runtime definitions are unresolved. "
+                    "Call POST /foundry/agents/ensure and retry."
                 ),
             )
 

--- a/lib/src/holiday_peak_lib/app_factory_components/foundry_lifecycle.py
+++ b/lib/src/holiday_peak_lib/app_factory_components/foundry_lifecycle.py
@@ -13,6 +13,11 @@ DEFAULT_FOUNDRY_MODELS = {
 }
 
 
+def _has_resolved_agent_id(agent_id: str | None) -> bool:
+    value = str(agent_id or "").strip()
+    return bool(value) and not value.endswith("-pending")
+
+
 def build_foundry_config(agent_env: str, deployment_env: str) -> FoundryAgentConfig | None:
     """Build Foundry configuration from environment variables."""
     endpoint = os.getenv("PROJECT_ENDPOINT") or os.getenv("FOUNDRY_ENDPOINT")
@@ -104,7 +109,7 @@ class FoundryLifecycleManager:
         if ensured_name:
             config.agent_name = str(ensured_name)
 
-        if config.agent_id:
+        if _has_resolved_agent_id(config.agent_id):
             model_target = self.build_foundry_model_target_fn(config)
             if selected_role == "fast":
                 self.agent.slm = model_target

--- a/lib/tests/test_app_factory.py
+++ b/lib/tests/test_app_factory.py
@@ -71,6 +71,114 @@ class TestBuildServiceApp:
         assert isinstance(app, FastAPI)
         assert app.title == "test-service"
 
+    def test_build_app_skips_pending_foundry_runtime_targets(
+        self, mock_hot_memory, mock_warm_memory, mock_cold_memory, monkeypatch
+    ):
+        """Test invoke requests fail fast when Foundry runtime definitions stay unresolved."""
+
+        class ModelAwareAgent(BaseRetailAgent):
+            async def handle(self, request: dict) -> dict:
+                return {"model_wired": bool(self.slm or self.llm)}
+
+        monkeypatch.setenv("PROJECT_ENDPOINT", "https://test.endpoint.com")
+        monkeypatch.delenv("FOUNDRY_AGENT_ID_FAST", raising=False)
+        monkeypatch.delenv("FOUNDRY_AGENT_ID_RICH", raising=False)
+        monkeypatch.delenv("FOUNDRY_AGENT_NAME_FAST", raising=False)
+        monkeypatch.delenv("FOUNDRY_AGENT_NAME_RICH", raising=False)
+        monkeypatch.setenv("FOUNDRY_AUTO_ENSURE_ON_STARTUP", "false")
+
+        app = build_service_app(
+            service_name="test-service",
+            agent_class=ModelAwareAgent,
+            hot_memory=mock_hot_memory,
+            warm_memory=mock_warm_memory,
+            cold_memory=mock_cold_memory,
+        )
+
+        client = TestClient(app)
+        with patch("holiday_peak_lib.app_factory.ensure_foundry_agent") as mock_ensure:
+            mock_ensure.return_value = {
+                "status": "missing",
+                "agent_id": None,
+                "agent_name": "test-service-fast",
+                "created": False,
+            }
+            response = client.post("/invoke", json={"query": "test"})
+
+        assert response.status_code == 503
+        assert "Foundry runtime definitions are unresolved" in response.json()["detail"]
+
+    def test_invoke_auto_ensures_pending_foundry_runtime_targets(
+        self, mock_hot_memory, mock_warm_memory, mock_cold_memory, monkeypatch
+    ):
+        """Test invoke auto-ensures missing Foundry runtime ids before processing."""
+
+        class RuntimeEnsureAgent(BaseRetailAgent):
+            async def handle(self, request: dict) -> dict:
+                return await self.invoke_model(
+                    request=request,
+                    messages=[{"role": "user", "content": str(request.get("query", ""))}],
+                )
+
+        async def _mock_invoker(**_kwargs):
+            return {"response": "resolved"}
+
+        from holiday_peak_lib.agents.base_agent import ModelTarget
+
+        monkeypatch.setenv("PROJECT_ENDPOINT", "https://test.endpoint.com")
+        monkeypatch.delenv("FOUNDRY_AGENT_ID_FAST", raising=False)
+        monkeypatch.delenv("FOUNDRY_AGENT_ID_RICH", raising=False)
+        monkeypatch.delenv("FOUNDRY_AGENT_NAME_FAST", raising=False)
+        monkeypatch.delenv("FOUNDRY_AGENT_NAME_RICH", raising=False)
+        monkeypatch.setenv("FOUNDRY_AUTO_ENSURE_ON_STARTUP", "false")
+
+        with patch("holiday_peak_lib.app_factory.ensure_foundry_agent") as mock_ensure:
+            mock_ensure.side_effect = [
+                {
+                    "status": "exists",
+                    "agent_id": "agent-fast-123",
+                    "agent_name": "test-service-fast",
+                    "created": False,
+                },
+                {
+                    "status": "exists",
+                    "agent_id": "agent-rich-456",
+                    "agent_name": "test-service-rich",
+                    "created": False,
+                },
+            ]
+
+            with patch("holiday_peak_lib.app_factory.build_foundry_model_target") as mock_target:
+                mock_target.side_effect = [
+                    ModelTarget(
+                        name="slm",
+                        model="gpt-5-nano",
+                        invoker=_mock_invoker,
+                        provider="foundry",
+                    ),
+                    ModelTarget(
+                        name="llm",
+                        model="gpt-5",
+                        invoker=_mock_invoker,
+                        provider="foundry",
+                    ),
+                ]
+
+                app = build_service_app(
+                    service_name="test-service",
+                    agent_class=RuntimeEnsureAgent,
+                    hot_memory=mock_hot_memory,
+                    warm_memory=mock_warm_memory,
+                    cold_memory=mock_cold_memory,
+                )
+
+                client = TestClient(app)
+                response = client.post("/invoke", json={"query": "test"})
+
+        assert response.status_code == 200
+        assert response.json()["response"] == "resolved"
+        assert mock_ensure.call_count == 2
+
     def test_build_app_with_custom_config(
         self, mock_hot_memory, mock_warm_memory, mock_cold_memory
     ):
@@ -500,10 +608,10 @@ class TestBuildServiceApp:
         assert response.status_code == 200
         assert response.json()["status"] == "ready"
 
-    def test_strict_foundry_mode_requires_ensure_before_invoke(
+    def test_strict_foundry_mode_auto_ensures_before_invoke(
         self, mock_hot_memory, mock_warm_memory, mock_cold_memory, monkeypatch
     ):
-        """Test strict mode blocks invoke until ensure endpoint is called."""
+        """Test strict mode auto-runs ensure during invoke before routing."""
         monkeypatch.setenv("PROJECT_ENDPOINT", "https://test.endpoint.com")
         monkeypatch.setenv("FOUNDRY_AGENT_ID_FAST", "agent-123")
         monkeypatch.setenv("FOUNDRY_STRICT_ENFORCEMENT", "true")
@@ -517,9 +625,6 @@ class TestBuildServiceApp:
         )
 
         client = TestClient(app)
-        pre_response = client.post("/invoke", json={"query": "test"})
-        assert pre_response.status_code == 503
-
         with patch("holiday_peak_lib.app_factory.ensure_foundry_agent") as mock_ensure:
             mock_ensure.return_value = {
                 "status": "exists",
@@ -527,16 +632,11 @@ class TestBuildServiceApp:
                 "agent_name": "test-service-fast",
                 "created": False,
             }
-            ensure_response = client.post(
-                "/foundry/agents/ensure",
-                json={"role": "fast", "create_if_missing": True},
-            )
+            response = client.post("/invoke", json={"query": "test"})
 
-        assert ensure_response.status_code == 200
-        assert ensure_response.json()["foundry_ready"] is True
-
-        post_response = client.post("/invoke", json={"query": "test"})
-        assert post_response.status_code == 200
+        assert response.status_code == 200
+        assert response.json()["status"] == "ok"
+        assert mock_ensure.call_count >= 1
 
     def test_build_foundry_config_from_env(self, monkeypatch):
         """Test building Foundry config from environment."""

--- a/lib/tests/test_app_factory_endpoints.py
+++ b/lib/tests/test_app_factory_endpoints.py
@@ -33,12 +33,17 @@ class _Tracer:
 
 
 class _Logger:
-    pass
+    def info(self, *_args, **_kwargs) -> None:
+        return None
+
+    def exception(self, *_args, **_kwargs) -> None:
+        return None
 
 
 def test_register_standard_endpoints_ready_and_ensure_flow():
     app = FastAPI()
     foundry_ready = False
+    runtime_definitions_missing = True
 
     def _is_ready() -> bool:
         return foundry_ready
@@ -47,7 +52,12 @@ def test_register_standard_endpoints_ready_and_ensure_flow():
         nonlocal foundry_ready
         foundry_ready = value
 
+    def _requires_runtime_resolution() -> bool:
+        return runtime_definitions_missing
+
     async def _ensure_handler(_payload: dict | None) -> dict:
+        nonlocal runtime_definitions_missing
+        runtime_definitions_missing = False
         return {
             "service": "svc",
             "strict_foundry_mode": True,
@@ -65,6 +75,7 @@ def test_register_standard_endpoints_ready_and_ensure_flow():
         strict_foundry_mode=True,
         is_foundry_ready=_is_ready,
         set_foundry_ready=_set_ready,
+        requires_foundry_runtime_resolution=_requires_runtime_resolution,
         ensure_agents_handler=_ensure_handler,
     )
 
@@ -73,3 +84,53 @@ def test_register_standard_endpoints_ready_and_ensure_flow():
     ensure_response = client.post("/foundry/agents/ensure", json={"role": "fast"})
     assert ensure_response.status_code == 200
     assert client.get("/ready").status_code == 200
+
+
+def test_invoke_auto_ensures_foundry_before_routing():
+    app = FastAPI()
+    foundry_ready = True
+    runtime_definitions_missing = True
+    ensure_calls = 0
+
+    def _is_ready() -> bool:
+        return foundry_ready
+
+    def _set_ready(value: bool) -> None:
+        nonlocal foundry_ready
+        foundry_ready = value
+
+    def _requires_runtime_resolution() -> bool:
+        return runtime_definitions_missing
+
+    async def _ensure_handler(_payload: dict | None) -> dict:
+        nonlocal runtime_definitions_missing
+        nonlocal ensure_calls
+        ensure_calls += 1
+        runtime_definitions_missing = False
+        return {
+            "service": "svc",
+            "strict_foundry_mode": False,
+            "foundry_ready": True,
+            "results": {"fast": {"status": "exists", "agent_id": "a1"}},
+        }
+
+    register_standard_endpoints(
+        app,
+        service_name="svc",
+        registry=_Registry(),
+        router=_Router(),
+        tracer=_Tracer(),
+        logger=_Logger(),
+        strict_foundry_mode=False,
+        is_foundry_ready=_is_ready,
+        set_foundry_ready=_set_ready,
+        requires_foundry_runtime_resolution=_requires_runtime_resolution,
+        ensure_agents_handler=_ensure_handler,
+    )
+
+    client = TestClient(app)
+    response = client.post("/invoke", json={"query": "hello"})
+
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+    assert ensure_calls == 1

--- a/lib/tests/test_app_factory_foundry_lifecycle.py
+++ b/lib/tests/test_app_factory_foundry_lifecycle.py
@@ -73,3 +73,40 @@ async def test_ensure_role_wires_model_target():
 
     assert result["agent_id"] == "agent-fast"
     assert agent.slm == "target-fast"
+
+
+@pytest.mark.asyncio
+async def test_ensure_role_skips_wiring_when_id_remains_pending():
+    agent = _Agent(config=AgentDependencies())
+    cfg = FoundryAgentConfig(
+        endpoint="https://example.test",
+        agent_id="fast-pending",
+        deployment_name="gpt-fast",
+    )
+    ensure_fn = AsyncMock(
+        return_value={
+            "status": "missing",
+            "agent_id": None,
+            "agent_name": "svc-fast",
+            "created": False,
+        }
+    )
+
+    manager = FoundryLifecycleManager(
+        service_name="svc",
+        agent=agent,
+        slm_config=cfg,
+        llm_config=None,
+        ensure_foundry_agent_fn=ensure_fn,
+        build_foundry_model_target_fn=lambda _: "target-fast",
+    )
+
+    result = await manager.ensure_role(
+        selected_role="fast",
+        config=cfg,
+        instructions="instruction",
+        create_if_missing=True,
+    )
+
+    assert result["status"] == "missing"
+    assert agent.slm is None


### PR DESCRIPTION
## Summary
- harden Foundry lifecycle handling with lazy ensure-on-invoke and explicit placeholder-ID protections
- align helm/deploy hook validation across shell and PowerShell, including service/deploy contract checks
- fix PowerShell interpolation edge case in helm render hook (${ServiceName}:)
- expand unit tests and docs for lifecycle + endpoint safeguards
- execute full backend image refresh in dev for CRUD + all agent services

## Validation
- python -m pytest lib/tests/test_app_factory.py lib/tests/test_app_factory_endpoints.py lib/tests/test_app_factory_foundry_lifecycle.py
  - result: 30 passed
- zd deploy --service ... -e dev (full service set)
  - result: completed successfully, including 	ruth-export and 	ruth-hitl

Closes #643