### PR TITLE
hotfix: restore fallback invoke and telemetry visibility (#683)

### DIFF
--- a/apps/ecommerce-catalog-search/tests/test_app.py
+++ b/apps/ecommerce-catalog-search/tests/test_app.py
@@ -39,16 +39,16 @@ def test_agent_activity_endpoints():
         traces_response = client.get("/agent/traces")
         assert traces_response.status_code == 200
         assert "traces" in traces_response.json()
+        assert len(traces_response.json()["traces"]) >= 1
 
         metrics_response = client.get("/agent/metrics")
         assert metrics_response.status_code == 200
         assert metrics_response.json()["service"] == "ecommerce-catalog-search"
-        assert metrics_response.json()["enabled"] is False
+        assert metrics_response.json()["enabled"] is True
 
         evaluation_response = client.get("/agent/evaluation/latest")
         assert evaluation_response.status_code == 200
         assert "latest" in evaluation_response.json()
-        assert evaluation_response.json()["latest"] is None
 
 
 def test_ready_returns_503_when_strict_mode_ai_search_not_ready(monkeypatch):

--- a/apps/search-enrichment-agent/tests/test_app.py
+++ b/apps/search-enrichment-agent/tests/test_app.py
@@ -37,9 +37,9 @@ def test_agent_activity_endpoints() -> None:
     metrics_response = client.get("/agent/metrics")
     assert metrics_response.status_code == 200
     assert metrics_response.json()["service"] == "search-enrichment-agent"
-    assert metrics_response.json()["enabled"] is False
+    assert metrics_response.json()["enabled"] is True
 
     evaluation_response = client.get("/agent/evaluation/latest")
     assert evaluation_response.status_code == 200
     assert "latest" in evaluation_response.json()
-    assert evaluation_response.json()["latest"] is None
+    assert evaluation_response.json()["latest"] is not None

--- a/apps/truth-enrichment/tests/test_app.py
+++ b/apps/truth-enrichment/tests/test_app.py
@@ -62,9 +62,9 @@ def test_agent_activity_endpoints(client):
     metrics_response = client.get("/agent/metrics")
     assert metrics_response.status_code == 200
     assert metrics_response.json()["service"] == "truth-enrichment"
-    assert metrics_response.json()["enabled"] is False
+    assert metrics_response.json()["enabled"] is True
 
     evaluation_response = client.get("/agent/evaluation/latest")
     assert evaluation_response.status_code == 200
     assert "latest" in evaluation_response.json()
-    assert evaluation_response.json()["latest"] is None
+    assert evaluation_response.json()["latest"] is not None

--- a/docs/architecture/components/libs/agents.md
+++ b/docs/architecture/components/libs/agents.md
@@ -333,17 +333,17 @@ Readiness payload now includes a `foundry` capability object with:
 
 Foundry tracer collection can be controlled per service via
 `disable_tracing_without_foundry` on `create_standard_app` / `build_service_app`.
-When set to `true`, tracer collection is disabled whenever no Foundry model
-target is bound. In this repository, all agentic services enable this flag to
-enforce Foundry-bound telemetry semantics.
+This flag is maintained as a per-service compatibility hint. Core telemetry
+remains enabled so fallback/local execution paths keep emitting traces,
+metrics, and latest-evaluation data for admin observability surfaces.
 
 ### Strict Foundry Enforcement Mode
 
 Set `FOUNDRY_STRICT_ENFORCEMENT=true` to require a successful ensure step before
 serving `/invoke` requests:
 
-- Before ensure: `/invoke` returns `503`
-- After successful `POST /foundry/agents/ensure`: `/invoke` is enabled
+- With bound Foundry targets: strict mode enforces Foundry readiness for `/invoke`
+- Without bound Foundry targets: `/invoke` can continue through local/fallback logic
 
 This mode is designed for environments where all agent prompts/instructions must be
 managed exclusively in Foundry.

--- a/lib/src/holiday_peak_lib/app_factory.py
+++ b/lib/src/holiday_peak_lib/app_factory.py
@@ -76,9 +76,9 @@ def create_standard_app(
     Foundry is preferred by default, but readiness enforcement is optional and
     controlled via ``require_foundry_readiness``.
 
-    Tracing policy is per service. Set ``disable_tracing_without_foundry=True``
-    to disable Foundry tracer collection whenever no callable Foundry target is
-    bound for that service.
+    ``disable_tracing_without_foundry`` is a backward-compatible per-service
+    hint. Core telemetry collection remains enabled so admin observability
+    surfaces stay available even when Foundry targets are not bound.
     """
     self_healing_kernel = SelfHealingKernel.from_env(service_name)
     memory_settings = MemorySettings()
@@ -149,9 +149,8 @@ def build_service_app(
     Args:
         require_foundry_readiness: When ``True``, ``/ready`` and invoke guards
             enforce Foundry runtime availability for this service.
-        disable_tracing_without_foundry: When ``True``, the Foundry tracer is
-            disabled unless the service has at least one callable Foundry model
-            target bound.
+        disable_tracing_without_foundry: Backward-compatible per-service hint.
+            Core telemetry remains enabled for local/fallback execution paths.
     """
     logger = configure_logging(app_name=service_name)
     app = FastAPI(title=service_name)
@@ -218,20 +217,12 @@ def build_service_app(
         return bool(getattr(agent, "slm", None) or getattr(agent, "llm", None))
 
     def _sync_foundry_tracing_state() -> None:
-        if disable_tracing_without_foundry:
-            get_foundry_tracer(service_name, enabled=_has_bound_foundry_target())
-            return
+        _ = disable_tracing_without_foundry
         get_foundry_tracer(service_name)
 
-    if disable_tracing_without_foundry:
-        tracer = get_foundry_tracer(
-            service_name,
-            enabled=_has_bound_foundry_target(),
-        )
-    else:
-        tracer = get_foundry_tracer(service_name)
+    tracer = get_foundry_tracer(service_name)
 
-    strict_foundry_mode = strict_foundry_mode_enabled()
+    strict_foundry_mode = strict_foundry_mode_enabled() and _has_bound_foundry_target()
     foundry_ready = _has_bound_foundry_target()
     auto_ensure_on_startup = auto_ensure_on_startup_enabled(strict_foundry_mode=strict_foundry_mode)
 

--- a/lib/tests/test_app_factory.py
+++ b/lib/tests/test_app_factory.py
@@ -74,7 +74,7 @@ class TestBuildServiceApp:
     def test_build_app_skips_pending_foundry_runtime_targets(
         self, mock_hot_memory, mock_warm_memory, mock_cold_memory, monkeypatch
     ):
-        """Test invoke requests fail fast when Foundry runtime definitions stay unresolved."""
+        """Test unresolved Foundry runtime defs do not block fallback invoke paths."""
 
         class ModelAwareAgent(BaseRetailAgent):
             async def handle(self, request: dict) -> dict:
@@ -107,8 +107,8 @@ class TestBuildServiceApp:
             }
             response = client.post("/invoke", json={"query": "test"})
 
-        assert response.status_code == 503
-        assert "Foundry readiness enforcement is enabled" in response.json()["detail"]
+        assert response.status_code == 200
+        assert response.json()["model_wired"] is False
 
     def test_invoke_auto_ensures_pending_foundry_runtime_targets(
         self, mock_hot_memory, mock_warm_memory, mock_cold_memory, monkeypatch
@@ -628,7 +628,7 @@ class TestBuildServiceApp:
     def test_ready_endpoint_returns_ok_after_ensure_in_strict_mode(
         self, mock_hot_memory, mock_warm_memory, mock_cold_memory, monkeypatch
     ):
-        """Test /ready flips to 200 after agents are ensured in strict mode."""
+        """Test /ready flips to 200 after agents are ensured when readiness is required."""
         monkeypatch.setenv("PROJECT_ENDPOINT", "https://test.endpoint.com")
         monkeypatch.delenv("FOUNDRY_AGENT_ID_FAST", raising=False)
         monkeypatch.delenv("FOUNDRY_AGENT_ID_RICH", raising=False)
@@ -641,6 +641,7 @@ class TestBuildServiceApp:
             hot_memory=mock_hot_memory,
             warm_memory=mock_warm_memory,
             cold_memory=mock_cold_memory,
+            require_foundry_readiness=True,
         )
         client = TestClient(app)
 


### PR DESCRIPTION
## Summary\n- restore fallback invoke behavior so services without bound Foundry targets do not return 503\n- keep telemetry/tracing visible in fallback mode so run history and tracing surfaces remain available\n- update tests and docs to reflect restored readiness and telemetry semantics\n\n## Validation\n- python -m pytest\n- python -m isort --check-only lib/src lib/tests apps/ecommerce-catalog-search/tests/test_app.py apps/search-enrichment-agent/tests/test_app.py apps/truth-enrichment/tests/test_app.py\n- python -m black --check lib/src/holiday_peak_lib/app_factory.py lib/tests/test_app_factory.py apps/ecommerce-catalog-search/tests/test_app.py apps/search-enrichment-agent/tests/test_app.py apps/truth-enrichment/tests/test_app.py docs/architecture/components/libs/agents.md\n\nCloses #683