### PR TITLE
chore: persist prompt schema migration and catalog fallback updates

### DIFF
--- a/.github/prompts/architecture-evaluate.prompt.md
+++ b/.github/prompts/architecture-evaluate.prompt.md
@@ -1,8 +1,8 @@
 ---
-title: "Architecture: Evaluate Design"
+name: "Architecture: Evaluate Design"
 description: "Evaluate a proposed architecture or system design for pattern correctness, integration safety, and scalability."
 agent: "SystemArchitect"
-input: "Describe the system or component being designed. Include context on scale, integration points, and constraints."
+argument-hint: "Describe the system or component being designed. Include context on scale, integration points, and constraints."
 ---
 
 Evaluate the proposed design:
@@ -16,3 +16,4 @@ Evaluate the proposed design:
 7. **Trade-offs** — Document alternatives considered, why this approach was chosen, and what is sacrificed.
 
 Deliver an assessment with a diagram (Mermaid), risk table, and recommendations.
+

--- a/.github/prompts/architecture-integration.prompt.md
+++ b/.github/prompts/architecture-integration.prompt.md
@@ -1,8 +1,8 @@
 ---
-title: "Architecture: Design Integration"
+name: "Architecture: Design Integration"
 description: "Design a cross-service integration with event contracts, API versioning, and failure handling."
 agent: "SystemArchitect"
-input: "Describe the services to integrate, data flows, and consistency requirements (eventual vs strong)."
+argument-hint: "Describe the services to integrate, data flows, and consistency requirements (eventual vs strong)."
 ---
 
 Design the integration between the specified services:
@@ -15,3 +15,4 @@ Design the integration between the specified services:
 6. **Security** — Authentication between services (mTLS, token exchange). Authorization at gateway. Input validation at each boundary.
 
 Deliver a Mermaid sequence diagram, contract specifications, and implementation guidance for each service.
+

--- a/.github/prompts/azure-architecture-review.prompt.md
+++ b/.github/prompts/azure-architecture-review.prompt.md
@@ -1,8 +1,8 @@
 ---
-title: "Azure: Architecture Review"
+name: "Azure: Architecture Review"
 description: "Review Azure resource topology for high availability, security, cost efficiency, and Well-Architected Framework alignment."
 agent: "TechLeadOrchestrator"
-input: "Specify the Azure resource group, subscription, or architecture diagram to review. Include SLA targets and compliance requirements."
+argument-hint: "Specify the Azure resource group, subscription, or architecture diagram to review. Include SLA targets and compliance requirements."
 ---
 
 Coordinate a multi-specialist Azure architecture review:
@@ -43,3 +43,4 @@ Coordinate a multi-specialist Azure architecture review:
    - Top 10 remediation items ranked by impact
 
 Deliver the scorecard, architecture diagram (Mermaid), and prioritized remediation backlog.
+

--- a/.github/prompts/azure-cost-optimize.prompt.md
+++ b/.github/prompts/azure-cost-optimize.prompt.md
@@ -1,8 +1,8 @@
 ---
-title: "Azure: Cost Optimization"
+name: "Azure: Cost Optimization"
 description: "Identify over-provisioned Azure resources and recommend SKU changes, reserved instances, and architectural simplifications."
 agent: "TechLeadOrchestrator"
-input: "Specify the subscription, resource group, or service to optimize. Include current monthly spend if known and target budget."
+argument-hint: "Specify the subscription, resource group, or service to optimize. Include current monthly spend if known and target budget."
 ---
 
 Coordinate Azure cost optimization across all resource types:
@@ -37,3 +37,4 @@ Coordinate Azure cost optimization across all resource types:
    - Estimated monthly savings per change
    - Implementation steps and rollback plan for each
    - Total projected monthly/annual savings
+

--- a/.github/prompts/azure-migrate.prompt.md
+++ b/.github/prompts/azure-migrate.prompt.md
@@ -1,8 +1,8 @@
 ---
-title: "Azure: Migration Plan"
+name: "Azure: Migration Plan"
 description: "Plan migration between Azure services, from on-premises, or from other cloud providers with risk assessment and staged rollout."
 agent: "TechLeadOrchestrator"
-input: "Describe the source (current service/provider) and target (desired Azure service). Include data volumes, latency requirements, and downtime tolerance."
+argument-hint: "Describe the source (current service/provider) and target (desired Azure service). Include data volumes, latency requirements, and downtime tolerance."
 ---
 
 Coordinate multi-agent migration planning:
@@ -46,3 +46,4 @@ Coordinate multi-agent migration planning:
    - **Stage 3: Cutover** — Switch reads to target, monitor error rates
    - **Stage 4: Decommission** — Remove source resources after validation period
    - Rollback trigger criteria for each stage
+

--- a/.github/prompts/azure-troubleshoot.prompt.md
+++ b/.github/prompts/azure-troubleshoot.prompt.md
@@ -1,8 +1,8 @@
 ---
-title: "Azure: Troubleshoot Service"
+name: "Azure: Troubleshoot Service"
 description: "Debug a failing Azure service by coordinating the relevant Azure specialist with platform diagnostics."
 agent: "TechLeadOrchestrator"
-input: "Describe the issue: which Azure service, error messages, affected endpoints, and when it started. Include resource group and service name."
+argument-hint: "Describe the issue: which Azure service, error messages, affected endpoints, and when it started. Include resource group and service name."
 ---
 
 Coordinate Azure service troubleshooting:
@@ -42,3 +42,4 @@ Coordinate Azure service troubleshooting:
    - No new alerts triggered
 
 Deliver a troubleshooting report with root cause, fix applied, and prevention recommendations.
+

--- a/.github/prompts/codebase-onboarding.prompt.md
+++ b/.github/prompts/codebase-onboarding.prompt.md
@@ -1,8 +1,8 @@
 ---
-title: "Codebase Onboarding"
+name: "Codebase Onboarding"
 description: "Fast repository orientation: understand architecture, entry points, conventions, and how to run/test/deploy."
 agent: "TechLeadOrchestrator"
-input: "Optionally specify focus areas (backend, frontend, infra, a specific service). Otherwise, the full repo is scanned."
+argument-hint: "Optionally specify focus areas (backend, frontend, infra, a specific service). Otherwise, the full repo is scanned."
 ---
 
 Coordinate a multi-agent codebase onboarding scan:
@@ -42,3 +42,4 @@ Coordinate a multi-agent codebase onboarding scan:
    - Key files and directories to know
    - Common gotchas and pitfalls
    - Suggested first tasks for new contributors
+

--- a/.github/prompts/connector-audit.prompt.md
+++ b/.github/prompts/connector-audit.prompt.md
@@ -1,8 +1,8 @@
 ---
-title: "Connector: Audit Integrations"
+name: "Connector: Audit Integrations"
 description: "Audit existing enterprise integrations for reliability, error handling, compliance, and operational health."
 agent: "TechLeadOrchestrator"
-input: "Specify the integration(s) to audit. Include the external platform, data flow direction, and any known issues."
+argument-hint: "Specify the integration(s) to audit. Include the external platform, data flow direction, and any known issues."
 ---
 
 Coordinate an enterprise integration audit:
@@ -40,3 +40,4 @@ Coordinate an enterprise integration audit:
    - Critical findings requiring immediate remediation
    - Improvement recommendations ranked by risk reduction
    - Suggested SLA definitions for each integration
+

--- a/.github/prompts/connector-design.prompt.md
+++ b/.github/prompts/connector-design.prompt.md
@@ -1,8 +1,8 @@
 ---
-title: "Connector: Design Integration"
+name: "Connector: Design Integration"
 description: "Design a new enterprise integration adapter (REST/GraphQL/OData) with architecture review and implementation plan."
 agent: "TechLeadOrchestrator"
-input: "Describe the target platform (PIM, DAM, CRM, Commerce, etc.), the API type (REST/GraphQL/OData), and the data flows required."
+argument-hint: "Describe the target platform (PIM, DAM, CRM, Commerce, etc.), the API type (REST/GraphQL/OData), and the data flows required."
 ---
 
 Coordinate enterprise connector design:
@@ -37,3 +37,4 @@ Coordinate enterprise connector design:
    - Load tests to validate rate limit handling
 
 Deliver a connector design document with architecture diagram, data mapping table, implementation spec, and test plan.
+

--- a/.github/prompts/issue-engineering-with-process.prompt.md
+++ b/.github/prompts/issue-engineering-with-process.prompt.md
@@ -1,0 +1,71 @@
+---
+name: "Issue Engineering With Process"
+description: "Run issue engineering with mandatory code-first investigation, BPMN issue creation, branch-per-issue execution, PR validation, merge monitoring, and branch cleanup."
+agent: "TechLeadOrchestrator"
+argument-hint: "Provide the list of requested changes, issue references (if any), constraints, and expected outcomes."
+---
+
+Execute issue engineering with strict process control:
+
+1. **Code-First Reconnaissance (mandatory before any action)**
+   - Read the relevant code paths first.
+   - Use workspace search and file reads to confirm current behavior.
+   - Call relevant specialists via `#runSubagent` before implementation when cross-domain analysis is needed:
+     - `SystemArchitect` for architecture/integration concerns
+     - `PythonDeveloper`, `TypeScriptDeveloper`, `RustDeveloper`, `UIDesigner`, `PlatformEngineer` as applicable
+   - Do not implement or open PRs before reconnaissance is complete.
+
+2. **Per-Change Engineering Analysis (for every requested change item)**
+   - Build an itemized list where each item includes:
+     - Current behavior (with file/function evidence)
+     - Required change
+     - Affected components and risks
+     - Effort estimate (S/M/L/XL + rough hours)
+   - Keep each item atomic and independently traceable.
+
+3. **Issue Creation With BPMN Format (mandatory before coding each item)**
+   - For each item in the list, open one GitHub issue before implementation starts.
+   - Each issue must include:
+     - Problem statement
+     - Acceptance criteria checklist
+     - Risks and dependencies
+     - BPMN-formatted process section using Mermaid (required), for example:
+
+     ```mermaid
+     flowchart LR
+       A[Analyze Current Code] --> B[Design Change]
+       B --> C[Implement on Issue Branch]
+       C --> D[Open PR]
+       D --> E[Validation and Fixes]
+       E --> F[Merge to Main]
+       F --> G[Monitor Workflows]
+       G --> H[Close Issue and Cleanup]
+     ```
+
+4. **Branch-Per-Issue Execution**
+   - Work each issue in a separate branch.
+   - Create branches from `main` using repository branch naming policy.
+   - Keep commits scoped to the corresponding issue only.
+
+5. **PR-First Validation and Merge Discipline**
+   - Open a PR for each issue branch targeting `main`.
+   - Perform validation in the PR (tests, lint, review feedback).
+   - Apply all fixes required for clean validation in the same open PR branch.
+   - After checks and reviews pass, merge to `main`.
+   - Monitor post-merge workflows/deployment and resolve regressions through PR updates until green.
+
+6. **Issue and Remote Branch Closure**
+   - After merge completion, close the related GitHub issue with merge evidence.
+   - Delete the remote working branch.
+
+7. **Local Branch and Repository Cleanup**
+   - Switch to `main` and pull latest changes.
+   - Delete the local working branch.
+   - Confirm repository cleanup (`git status` clean, no stale branches for completed issues).
+
+Deliver a final execution report containing:
+- Issue list with BPMN links/sections
+- Branch and PR mapping per issue
+- Validation evidence and merge status
+- Monitoring outcome
+- Closure + cleanup confirmation

--- a/.github/prompts/migration-plan.prompt.md
+++ b/.github/prompts/migration-plan.prompt.md
@@ -1,8 +1,8 @@
 ---
-title: "Migration Plan"
+name: "Migration Plan"
 description: "Plan a framework upgrade, major dependency bump, language version migration, or service migration with risk assessment and staged rollout."
 agent: "TechLeadOrchestrator"
-input: "Describe the migration: source version/framework → target version/framework. Include the reason for migrating and any deadline."
+argument-hint: "Describe the migration: source version/framework → target version/framework. Include the reason for migrating and any deadline."
 ---
 
 Coordinate a multi-agent migration plan:
@@ -43,3 +43,4 @@ Coordinate a multi-agent migration plan:
    - **Stage 5: Cleanup** — Remove compatibility shims, deprecated code paths, and old config
    - Rollback trigger criteria and procedure for each stage
    - Estimated timeline per stage
+

--- a/.github/prompts/platform-cicd-audit.prompt.md
+++ b/.github/prompts/platform-cicd-audit.prompt.md
@@ -1,8 +1,8 @@
 ---
-title: "Platform: CI/CD Audit"
+name: "Platform: CI/CD Audit"
 description: "Audit CI/CD pipelines for reliability, security, test masking, and deployment safety."
 agent: "PlatformEngineer"
-input: "Specify the pipeline file(s) or CI system (GitHub Actions, Azure Pipelines) to audit."
+argument-hint: "Specify the pipeline file(s) or CI system (GitHub Actions, Azure Pipelines) to audit."
 ---
 
 Audit the specified CI/CD pipelines:
@@ -15,3 +15,4 @@ Audit the specified CI/CD pipelines:
 6. **Coverage** — Test coverage gates present. Coverage delta comparison on PRs. Minimum threshold configured.
 
 Deliver findings as a compliance table with pass/fail, evidence, and remediation steps.
+

--- a/.github/prompts/platform-dependency-audit.prompt.md
+++ b/.github/prompts/platform-dependency-audit.prompt.md
@@ -1,8 +1,8 @@
 ---
-title: "Platform: Dependency Audit"
+name: "Platform: Dependency Audit"
 description: "Audit project dependencies for vulnerabilities, currency, and license compliance."
 agent: "PlatformEngineer"
-input: "Specify the project or lockfile to audit (package.json, Cargo.toml, pyproject.toml, etc.)."
+argument-hint: "Specify the project or lockfile to audit (package.json, Cargo.toml, pyproject.toml, etc.)."
 ---
 
 Audit dependencies for the specified project:
@@ -15,3 +15,4 @@ Audit dependencies for the specified project:
 6. **Upgrade Path** — For critical vulnerabilities, provide the minimum version bump required and assess breaking change risk.
 
 Deliver a report with severity-ranked findings and an upgrade plan.
+

--- a/.github/prompts/platform-quality-evaluation.prompt.md
+++ b/.github/prompts/platform-quality-evaluation.prompt.md
@@ -1,8 +1,8 @@
 ---
-title: "Platform: Quality Evaluation"
+name: "Platform: Quality Evaluation"
 description: "Comprehensive platform quality audit delegating to specialist agents for best practices, architecture, and compliance checks."
 agent: "TechLeadOrchestrator"
-input: "Specify the project or repository to evaluate. Optionally narrow scope to specific areas (CI/CD, dependencies, architecture, code quality)."
+argument-hint: "Specify the project or repository to evaluate. Optionally narrow scope to specific areas (CI/CD, dependencies, architecture, code quality)."
 ---
 
 Conduct a full platform quality evaluation by delegating to specialist agents:
@@ -35,3 +35,4 @@ Conduct a full platform quality evaluation by delegating to specialist agents:
    - Comparison with previous evaluation if available
 
 Deliver a quality report with per-category scores, top 10 remediation items, and trend indicators.
+

--- a/.github/prompts/pr-review.prompt.md
+++ b/.github/prompts/pr-review.prompt.md
@@ -1,8 +1,8 @@
 ---
-title: "PR: Review Pull Request"
+name: "PR: Review Pull Request"
 description: "Review a pull request for architecture compliance, test coverage, security, and merge readiness."
 agent: "PRReviewer"
-input: "Provide the PR number or let the agent detect the active PR. Optionally specify focus areas."
+argument-hint: "Provide the PR number or let the agent detect the active PR. Optionally specify focus areas."
 ---
 
 Review the pull request for merge readiness:
@@ -16,3 +16,4 @@ Review the pull request for merge readiness:
 7. **Code Quality** — No code smells introduced. Consistent style. Clear naming.
 
 Deliver a review summary with approve/request-changes verdict, blocking issues, and optional improvements.
+

--- a/.github/prompts/python-implement.prompt.md
+++ b/.github/prompts/python-implement.prompt.md
@@ -1,8 +1,8 @@
 ---
-title: "Python: Implement Feature"
+name: "Python: Implement Feature"
 description: "Implement a Python feature with type hints, async patterns, and pytest coverage following PEP standards."
 agent: "PythonDeveloper"
-input: "Describe the feature, module, or function to implement. Include any API contracts or data models."
+argument-hint: "Describe the feature, module, or function to implement. Include any API contracts or data models."
 ---
 
 Implement the requested Python feature following these standards:
@@ -15,3 +15,4 @@ Implement the requested Python feature following these standards:
 6. **Paradigm** — Prefer data-oriented (plain dataclasses + standalone functions) over OOP unless encapsulated state is genuinely needed.
 
 Deliver the implementation, tests, and any necessary configuration changes.
+

--- a/.github/prompts/python-refactor.prompt.md
+++ b/.github/prompts/python-refactor.prompt.md
@@ -1,8 +1,8 @@
 ---
-title: "Python: Refactor Module"
+name: "Python: Refactor Module"
 description: "Refactor Python code to reduce complexity, eliminate code smells, and improve maintainability."
 agent: "PythonDeveloper"
-input: "Specify the module or file to refactor. Optionally describe the target improvement (performance, readability, testability)."
+argument-hint: "Specify the module or file to refactor. Optionally describe the target improvement (performance, readability, testability)."
 ---
 
 Refactor the specified Python module:
@@ -14,3 +14,4 @@ Refactor the specified Python module:
 5. **Verify** — Run existing tests after each step. Report any behavioral changes.
 
 Deliver the refactored code with a summary of changes made and rationale for each.
+

--- a/.github/prompts/python-review.prompt.md
+++ b/.github/prompts/python-review.prompt.md
@@ -1,8 +1,8 @@
 ---
-title: "Python: Review Code"
+name: "Python: Review Code"
 description: "Review Python code for type safety, async correctness, security, and adherence to PEP standards."
 agent: "PythonDeveloper"
-input: "Provide the file(s) or module to review. Optionally specify focus areas (security, performance, correctness)."
+argument-hint: "Provide the file(s) or module to review. Optionally specify focus areas (security, performance, correctness)."
 ---
 
 Review the specified Python code checking for:
@@ -15,3 +15,4 @@ Review the specified Python code checking for:
 6. **Test Quality** — Coverage of edge cases. Proper mocking boundaries. No testing implementation details.
 
 Provide findings as a prioritized list with file locations, severity (critical/warning/info), and fix recommendations.
+

--- a/.github/prompts/rust-implement.prompt.md
+++ b/.github/prompts/rust-implement.prompt.md
@@ -1,8 +1,8 @@
 ---
-title: "Rust: Implement Feature"
+name: "Rust: Implement Feature"
 description: "Implement a Rust feature with safe ownership patterns, proper error handling, and cargo test coverage."
 agent: "RustDeveloper"
-input: "Describe the feature, crate, or module to implement. Include any trait contracts or wire formats."
+argument-hint: "Describe the feature, crate, or module to implement. Include any trait contracts or wire formats."
 ---
 
 Implement the requested Rust feature following these standards:
@@ -15,3 +15,4 @@ Implement the requested Rust feature following these standards:
 6. **API Design** — Follow Rust API Guidelines. #[must_use] on fallible returns. Newtype pattern for domain types.
 
 Deliver implementation, tests, and Cargo.toml dependency changes.
+

--- a/.github/prompts/rust-review.prompt.md
+++ b/.github/prompts/rust-review.prompt.md
@@ -1,8 +1,8 @@
 ---
-title: "Rust: Review Code"
+name: "Rust: Review Code"
 description: "Review Rust code for safety, ownership correctness, performance, and idiomatic patterns."
 agent: "RustDeveloper"
-input: "Provide the crate or file(s) to review. Optionally specify focus (safety, performance, API design)."
+argument-hint: "Provide the crate or file(s) to review. Optionally specify focus (safety, performance, API design)."
 ---
 
 Review the specified Rust code checking for:
@@ -15,3 +15,4 @@ Review the specified Rust code checking for:
 6. **Idioms** — Match exhaustiveness. Builder pattern usage. Trait object vs generic trade-offs.
 
 Deliver findings as a prioritized list with severity, location, and fix recommendations.
+

--- a/.github/prompts/security-audit.prompt.md
+++ b/.github/prompts/security-audit.prompt.md
@@ -1,8 +1,8 @@
 ---
-title: "Security Audit"
+name: "Security Audit"
 description: "Full-stack security audit across code, infrastructure, dependencies, secrets, and cloud configuration."
 agent: "TechLeadOrchestrator"
-input: "Specify the scope: entire repo, specific service, or specific concern (OWASP category, dependency CVE, secret leak). Include compliance targets if applicable (SOC2, HIPAA, PCI-DSS)."
+argument-hint: "Specify the scope: entire repo, specific service, or specific concern (OWASP category, dependency CVE, secret leak). Include compliance targets if applicable (SOC2, HIPAA, PCI-DSS)."
 ---
 
 Coordinate a comprehensive security audit by delegating to all relevant specialists:
@@ -42,3 +42,4 @@ Coordinate a comprehensive security audit by delegating to all relevant speciali
    - Critical/high findings requiring immediate action
    - Compliance gap analysis (against specified standards)
    - Remediation backlog with effort estimates
+

--- a/.github/prompts/ship-deploy-hotfix.prompt.md
+++ b/.github/prompts/ship-deploy-hotfix.prompt.md
@@ -1,8 +1,8 @@
 ---
-title: "Ship: Deploy and Hotfix"
+name: "Ship: Deploy and Hotfix"
 description: "End-to-end deployment workflow: issue → branch → PR → merge → deploy → monitor → hotfix. Delegates to all relevant specialists."
 agent: "TechLeadOrchestrator"
-input: "Describe the change to ship. Include the triggering issue/PR number if it exists, or describe the change so an issue can be created."
+argument-hint: "Describe the change to ship. Include the triggering issue/PR number if it exists, or describe the change so an issue can be created."
 ---
 
 Execute the full deployment lifecycle for the described change. This prompt is agent-independent — it handles changes originating from any domain (UI, backend, infrastructure, dependencies).
@@ -86,3 +86,4 @@ After deployment, actively monitor for regressions:
 - [ ] Deployment successful with health checks passing
 - [ ] No P1/P2 regressions within monitoring window
 - [ ] Any hotfixes completed and documented
+

--- a/.github/prompts/tech-debt-assessment.prompt.md
+++ b/.github/prompts/tech-debt-assessment.prompt.md
@@ -1,8 +1,8 @@
 ---
-title: "Tech Debt Assessment"
+name: "Tech Debt Assessment"
 description: "Inventory technical debt across the codebase, score by business impact, and create a prioritized remediation backlog."
 agent: "TechLeadOrchestrator"
-input: "Specify scope: entire repo or specific areas. Optionally include known pain points or recent incidents caused by tech debt."
+argument-hint: "Specify scope: entire repo or specific areas. Optionally include known pain points or recent incidents caused by tech debt."
 ---
 
 Coordinate a systematic tech debt inventory:
@@ -44,3 +44,4 @@ Coordinate a systematic tech debt inventory:
    - Quick wins (< 1 day effort, high impact) highlighted separately
    - Estimated total remediation effort (in engineering days)
    - Recommended cadence for debt reduction (e.g., 20% of each sprint)
+

--- a/.github/prompts/tech-lead-document-architecture.prompt.md
+++ b/.github/prompts/tech-lead-document-architecture.prompt.md
@@ -1,8 +1,8 @@
 ---
-title: "Tech Lead: Document Architecture"
+name: "Tech Lead: Document Architecture"
 description: "Produce comprehensive platform documentation including architecture diagrams, ADRs, and design principia by coordinating business, architecture, and UI agents."
 agent: "TechLeadOrchestrator"
-input: "Specify the system or project to document. Include target audience (developers, stakeholders, ops) and any existing docs to update."
+argument-hint: "Specify the system or project to document. Include target audience (developers, stakeholders, ops) and any existing docs to update."
 ---
 
 Coordinate multi-agent documentation of the platform:
@@ -37,3 +37,4 @@ Coordinate multi-agent documentation of the platform:
    - Environment setup and prerequisites
 
 Deliver a documentation package with ADRs, diagrams (Mermaid + draw.io), API reference, and runbook organized by audience.
+

--- a/.github/prompts/tech-lead-innovation-research.prompt.md
+++ b/.github/prompts/tech-lead-innovation-research.prompt.md
@@ -1,8 +1,8 @@
 ---
-title: "Tech Lead: Innovation Research"
+name: "Tech Lead: Innovation Research"
 description: "Research innovative solutions by coordinating business strategy agents for opportunity framing and technical agents for feasibility analysis."
 agent: "TechLeadOrchestrator"
-input: "Describe the problem space or opportunity to explore. Include business constraints, current limitations, and desired outcomes."
+argument-hint: "Describe the problem space or opportunity to explore. Include business constraints, current limitations, and desired outcomes."
 ---
 
 Coordinate a multi-agent innovation research cycle:
@@ -33,3 +33,4 @@ Coordinate a multi-agent innovation research cycle:
 5. **Proof of Concept** — If approved, delegate PoC implementation to the appropriate specialist agents with a time-boxed scope.
 
 Deliver an innovation brief with opportunity analysis, candidate comparison matrix, recommended approach, and PoC plan.
+

--- a/.github/prompts/tech-lead-investigate.prompt.md
+++ b/.github/prompts/tech-lead-investigate.prompt.md
@@ -1,8 +1,8 @@
 ---
-title: "Tech Lead: Investigate Issue"
+name: "Tech Lead: Investigate Issue"
 description: "Investigate a bug or production issue by coordinating diagnostic agents across the stack."
 agent: "TechLeadOrchestrator"
-input: "Describe the issue: symptoms, reproduction steps, affected users/systems, and any error messages or logs."
+argument-hint: "Describe the issue: symptoms, reproduction steps, affected users/systems, and any error messages or logs."
 ---
 
 Investigate the reported issue:
@@ -20,3 +20,4 @@ Investigate the reported issue:
 6. **Prevention** — Delegate to `PlatformEngineer` to recommend test/monitoring additions to prevent recurrence.
 
 Deliver an investigation report with root cause, fix plan, and prevention recommendations.
+

--- a/.github/prompts/tech-lead-issue-correction.prompt.md
+++ b/.github/prompts/tech-lead-issue-correction.prompt.md
@@ -1,8 +1,8 @@
 ---
-title: "Tech Lead: Issue Correction"
+name: "Tech Lead: Issue Correction"
 description: "Map identified problems into GitHub issues and delegate each to the appropriate specialist agent for resolution."
 agent: "TechLeadOrchestrator"
-input: "Describe the problems found: error logs, failing tests, user reports, or code smells. Include affected files or modules if known."
+argument-hint: "Describe the problems found: error logs, failing tests, user reports, or code smells. Include affected files or modules if known."
 ---
 
 Analyze the reported problems and create a structured remediation plan:
@@ -25,3 +25,4 @@ Analyze the reported problems and create a structured remediation plan:
 6. **Execution** — Invoke each specialist via `#runSubagent` with the issue brief. Track completion against the issue checklist.
 
 Deliver a table mapping each issue number to its agent, priority, dependencies, and status.
+

--- a/.github/prompts/tech-lead-issue-execute.prompt.md
+++ b/.github/prompts/tech-lead-issue-execute.prompt.md
@@ -1,8 +1,8 @@
 ---
-title: "Tech Lead: Execute Issue"
+name: "Tech Lead: Execute Issue"
 description: "Pick up a GitHub issue and drive it to completion — analyze requirements, decompose into tasks, delegate to specialists, verify, and close."
 agent: "TechLeadOrchestrator"
-input: "Paste the GitHub issue URL, number, or full description. Include any additional context such as related PRs, blockers, or stakeholder constraints."
+argument-hint: "Paste the GitHub issue URL, number, or full description. Include any additional context such as related PRs, blockers, or stakeholder constraints."
 ---
 
 Drive a GitHub issue from open to closed:
@@ -46,3 +46,4 @@ Drive a GitHub issue from open to closed:
    - Decisions taken and rationale
    - Any follow-up items or deferred scope
    - Deliver a completion report linking the issue to the changes, with verification evidence.
+

--- a/.github/prompts/tech-lead-plan.prompt.md
+++ b/.github/prompts/tech-lead-plan.prompt.md
@@ -1,8 +1,8 @@
 ---
-title: "Tech Lead: Plan Feature"
+name: "Tech Lead: Plan Feature"
 description: "Decompose a feature request into sequenced, agent-assignable tasks with acceptance criteria and risk assessment."
 agent: "TechLeadOrchestrator"
-input: "Describe the feature or initiative. Include business context, scope boundaries, and any known constraints."
+argument-hint: "Describe the feature or initiative. Include business context, scope boundaries, and any known constraints."
 ---
 
 Plan the requested feature:
@@ -23,3 +23,4 @@ Plan the requested feature:
 7. **Acceptance Criteria** — Define "done" for each sub-task and for the feature as a whole.
 
 Deliver a plan as a structured table with task ID, title, agent name, dependencies, acceptance criteria, and risk level. Then execute the plan by invoking each agent via `#runSubagent` in dependency order.
+

--- a/.github/prompts/typescript-implement.prompt.md
+++ b/.github/prompts/typescript-implement.prompt.md
@@ -1,8 +1,8 @@
 ---
-title: "TypeScript: Implement Feature"
+name: "TypeScript: Implement Feature"
 description: "Implement a TypeScript/React feature with strict types, React Server Components, and accessibility compliance."
 agent: "TypeScriptDeveloper"
-input: "Describe the feature or component to implement. Include API contracts, UI wireframe description, or data requirements."
+argument-hint: "Describe the feature or component to implement. Include API contracts, UI wireframe description, or data requirements."
 ---
 
 Implement the requested TypeScript feature following these standards:
@@ -15,3 +15,4 @@ Implement the requested TypeScript feature following these standards:
 6. **Testing** — Vitest/Jest with React Testing Library. Test behavior, not implementation. MSW for API mocking.
 
 Deliver the implementation, tests, and any route/config changes.
+

--- a/.github/prompts/typescript-review.prompt.md
+++ b/.github/prompts/typescript-review.prompt.md
@@ -1,8 +1,8 @@
 ---
-title: "TypeScript: Review Code"
+name: "TypeScript: Review Code"
 description: "Review TypeScript/React code for type safety, accessibility, performance, and React best practices."
 agent: "TypeScriptDeveloper"
-input: "Provide the file(s) or component tree to review. Optionally specify focus (types, a11y, performance)."
+argument-hint: "Provide the file(s) or component tree to review. Optionally specify focus (types, a11y, performance)."
 ---
 
 Review the specified TypeScript code checking for:
@@ -15,3 +15,4 @@ Review the specified TypeScript code checking for:
 6. **Code Quality** — ESLint warnings. Duplicated components. Missing error boundaries.
 
 Deliver findings as a prioritized list with severity, location, and fix recommendations.
+

--- a/.github/prompts/ui-accessibility-audit.prompt.md
+++ b/.github/prompts/ui-accessibility-audit.prompt.md
@@ -1,8 +1,8 @@
 ---
-title: "UI: Accessibility Audit"
+name: "UI: Accessibility Audit"
 description: "Audit a UI component or page for WCAG 2.2 AA compliance, keyboard navigation, and screen reader compatibility."
 agent: "UIDesigner"
-input: "Specify the component, page, or URL to audit. Include the target platform (web, CLI, desktop)."
+argument-hint: "Specify the component, page, or URL to audit. Include the target platform (web, CLI, desktop)."
 ---
 
 Perform a comprehensive accessibility audit:
@@ -15,3 +15,4 @@ Perform a comprehensive accessibility audit:
 6. **Forms** — Labels programmatically associated. Error messages linked to fields. Required fields marked for assistive tech.
 
 Deliver a compliance report with pass/fail per criterion, remediation steps, and priority ranking.
+

--- a/.github/prompts/ui-design-component.prompt.md
+++ b/.github/prompts/ui-design-component.prompt.md
@@ -1,8 +1,8 @@
 ---
-title: "UI: Design Component"
+name: "UI: Design Component"
 description: "Design and implement a responsive, accessible UI component with proper semantic HTML and design tokens."
 agent: "UIDesigner"
-input: "Describe the component (purpose, content, interactions). Specify platform: web (Tailwind), CLI (Ink), or desktop (Tauri)."
+argument-hint: "Describe the component (purpose, content, interactions). Specify platform: web (Tailwind), CLI (Ink), or desktop (Tauri)."
 ---
 
 Design and implement the requested UI component:
@@ -15,3 +15,4 @@ Design and implement the requested UI component:
 6. **Cross-Platform** — If web: Tailwind + logical properties. If CLI: Ink components. If desktop: Tauri + web stack.
 
 Deliver the component code, usage example, and accessibility notes.
+

--- a/apps/ecommerce-catalog-search/README.md
+++ b/apps/ecommerce-catalog-search/README.md
@@ -7,6 +7,7 @@ Provides product discovery and ACP-aligned catalog search responses.
 - Resolve search queries into relevant product sets.
 - Return inventory-aware and commerce-ready product context.
 - Support intelligent search enrichment for downstream flows.
+- Applies deterministic lexical intent routing for travel+apparel language (for example, vacation + clothes) while preserving dedicated winter-travel apparel classification.
 
 ## Key endpoints or interfaces
 - `POST /invoke` for synchronous service requests.

--- a/apps/ecommerce-catalog-search/src/ecommerce_catalog_search/agents.py
+++ b/apps/ecommerce-catalog-search/src/ecommerce_catalog_search/agents.py
@@ -115,6 +115,7 @@ APPAREL_LEXICAL_SIGNALS = frozenset(
     {
         "apparel",
         "clothing",
+        "clothes",
         "coat",
         "jacket",
         "parka",
@@ -622,6 +623,23 @@ def _deterministic_intent_policy(query: str) -> IntentClassification:
                 "keywords": sorted(apparel_hits),
             },
             reasoning="Deterministic lexical policy matched winter + apparel signals.",
+        )
+
+    if travel_hits and apparel_hits:
+        return IntentClassification(
+            intent="travel_clothing",
+            confidence=0.72,
+            category="apparel",
+            use_case="travel clothing",
+            entities={
+                "travel_context": True,
+                "category": "apparel",
+                "use_case": "travel clothing",
+                "keywords": sorted(travel_hits | apparel_hits),
+                "travel_signals": sorted(travel_hits),
+                "apparel_signals": sorted(apparel_hits),
+            },
+            reasoning="Deterministic lexical policy matched travel + apparel signals.",
         )
 
     return IntentClassification(

--- a/apps/ecommerce-catalog-search/tests/test_agents.py
+++ b/apps/ecommerce-catalog-search/tests/test_agents.py
@@ -697,6 +697,31 @@ class TestCatalogSearchAgent:
         assert "insulated jacket" in intent.entities["keywords"]
 
     @pytest.mark.asyncio
+    async def test_classify_intent_uses_deterministic_travel_apparel_fallback(
+        self, agent_dependencies
+    ):
+        """Intent classifier should deterministically capture travel + apparel language."""
+        with patch("ecommerce_catalog_search.agents.build_catalog_adapters") as mock_build:
+            mock_build.return_value = CatalogAdapters(
+                products=AsyncMock(),
+                inventory=AsyncMock(),
+                mapping=AcpCatalogMapper(),
+            )
+            agent = CatalogSearchAgent(config=agent_dependencies)
+
+        intent = await agent.classify_intent(
+            "I'm going to Russia on vacation, which clothes should I buy?"
+        )
+
+        assert intent.intent == "travel_clothing"
+        assert intent.confidence >= 0.6
+        assert intent.category == "apparel"
+        assert intent.use_case == "travel clothing"
+        assert "vacation" in intent.entities["travel_signals"]
+        assert "clothes" in intent.entities["apparel_signals"]
+        assert intent.intent != "keyword_lookup"
+
+    @pytest.mark.asyncio
     async def test_handle_keyword_mode_adaptive_reranks_winter_travel_to_apparel(
         self, agent_dependencies
     ):


### PR DESCRIPTION
## Summary
- migrate prompt frontmatter keys from title/input to name/argument-hint across .github/prompts
- add issue-engineering-with-process prompt
- include catalog deterministic travel+apparel intent fallback updates and tests

## Validation
- lint gates executed by local hook
- lib tests and app tests executed by local hook prior to push
