### PR TITLE
feat: explicit degraded fallback contract for catalog search

### DIFF
--- a/apps/ecommerce-catalog-search/README.md
+++ b/apps/ecommerce-catalog-search/README.md
@@ -8,6 +8,7 @@ Provides product discovery and ACP-aligned catalog search responses.
 - Default to intelligent search mode when no mode is specified, while keeping explicit keyword mode available for demos and compatibility.
 - Return inventory-aware and commerce-ready product context.
 - Support intelligent search enrichment for downstream flows.
+- Emit explicit degraded fallback metadata (`result_type`, `degraded_reason`, `fallback_keywords`) when model synthesis times out or fails.
 - Applies deterministic lexical intent routing for travel+apparel language (for example, vacation + clothes) while preserving dedicated winter-travel apparel classification.
 
 ## Key endpoints or interfaces

--- a/apps/ecommerce-catalog-search/src/ecommerce_catalog_search/agents.py
+++ b/apps/ecommerce-catalog-search/src/ecommerce_catalog_search/agents.py
@@ -80,6 +80,10 @@ WINTER_TRAVEL_INTENT_CONFIDENCE_THRESHOLD = 0.8
 KEYWORD_ADAPTIVE_MIN_QUERY_TOKENS = 6
 KEYWORD_ADAPTIVE_BASELINE_WINDOW = 3
 KEYWORD_ADAPTIVE_APPAREL_COVERAGE_THRESHOLD = 0.34
+DEGRADED_MODEL_FALLBACK_MESSAGE = (
+    "Showing the best available catalog guidance while intelligent generation "
+    "is temporarily unavailable."
+)
 
 _LEXICAL_TOKEN_PATTERN = re.compile(r"[a-z0-9]+")
 
@@ -397,9 +401,13 @@ class CatalogSearchAgent(BaseRetailAgent):
             "summary": summary,
             "recommendation": recommendation,
             "answer_source": "agent_fallback",
+            "result_type": "deterministic",
+            "degraded": False,
+            "model_attempted": False,
         }
 
         if self.slm or self.llm:
+            deterministic_response["model_attempted"] = True
             messages = [
                 {
                     "role": "system",
@@ -427,6 +435,10 @@ class CatalogSearchAgent(BaseRetailAgent):
                 model_response["search_stage"] = search_stage
                 model_response["session_id"] = namespace_context.session_id
                 model_response["answer_source"] = "agent_model"
+                model_response["result_type"] = "model_answer"
+                model_response["degraded"] = False
+                model_response["model_attempted"] = True
+                model_response["model_status"] = "success"
                 return model_response
             except asyncio.TimeoutError:
                 logger.warning(
@@ -437,6 +449,16 @@ class CatalogSearchAgent(BaseRetailAgent):
                         "search_stage": search_stage,
                     },
                 )
+                deterministic_response.update(
+                    {
+                        "result_type": "degraded_fallback",
+                        "degraded": True,
+                        "degraded_reason": "model_timeout",
+                        "degraded_message": DEGRADED_MODEL_FALLBACK_MESSAGE,
+                        "fallback_keywords": _build_fallback_keywords(str(query), intent),
+                        "model_status": "timeout",
+                    }
+                )
             except Exception:  # pylint: disable=broad-exception-caught
                 logger.warning(
                     "catalog_search_model_response_fallback",
@@ -446,6 +468,16 @@ class CatalogSearchAgent(BaseRetailAgent):
                         "search_stage": search_stage,
                     },
                     exc_info=True,
+                )
+                deterministic_response.update(
+                    {
+                        "result_type": "degraded_fallback",
+                        "degraded": True,
+                        "degraded_reason": "model_error",
+                        "degraded_message": DEGRADED_MODEL_FALLBACK_MESSAGE,
+                        "fallback_keywords": _build_fallback_keywords(str(query), intent),
+                        "model_status": "error",
+                    }
                 )
 
         return deterministic_response
@@ -566,6 +598,36 @@ def _coerce_keyword_list(raw_keywords: Any) -> list[str]:
         return []
 
     return [item.strip() for item in raw_keywords if isinstance(item, str) and item.strip()]
+
+
+def _build_fallback_keywords(
+    query: str,
+    intent: IntentClassification | None,
+) -> list[str]:
+    raw_keywords: list[str] = []
+
+    if intent is not None and isinstance(intent.entities, dict):
+        raw_keywords.extend(_coerce_keyword_list(intent.entities.get("keywords")))
+
+    raw_keywords.extend(_LEXICAL_TOKEN_PATTERN.findall(query.lower()))
+
+    deduplicated: list[str] = []
+    seen_keywords: set[str] = set()
+    for keyword in raw_keywords:
+        value = keyword.strip()
+        if not value:
+            continue
+
+        normalized = value.lower()
+        if normalized in seen_keywords:
+            continue
+
+        seen_keywords.add(normalized)
+        deduplicated.append(value)
+        if len(deduplicated) >= 8:
+            break
+
+    return deduplicated
 
 
 def _deterministic_intent_policy(query: str) -> IntentClassification:

--- a/apps/ecommerce-catalog-search/tests/test_agents.py
+++ b/apps/ecommerce-catalog-search/tests/test_agents.py
@@ -210,9 +210,143 @@ class TestCatalogSearchAgent:
             assert result["query"] == "rain jacket"
             assert isinstance(result["results"], list)
             assert result["answer_source"] == "agent_fallback"
+            assert result["result_type"] == "degraded_fallback"
+            assert result["degraded"] is True
+            assert result["degraded_reason"] == "model_timeout"
+            assert result["model_attempted"] is True
+            assert result["model_status"] == "timeout"
+            assert isinstance(result.get("degraded_message"), str)
+            assert "temporarily unavailable" in result["degraded_message"].lower()
+            assert isinstance(result.get("fallback_keywords"), list)
+            assert "rain" in result["fallback_keywords"]
             assert isinstance(result.get("summary"), str)
             assert isinstance(result.get("recommendation"), str)
             agent.invoke_model.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_handle_model_error_returns_degraded_fallback_answer(
+        self, agent_dependencies, mock_catalog_product
+    ):
+        """Unexpected model failures should return explicit degraded metadata."""
+        mock_inventory_item = InventoryItem(sku="SKU-001", available=10, reserved=0)
+
+        with patch("ecommerce_catalog_search.agents.build_catalog_adapters") as mock_build:
+            mock_products = AsyncMock()
+            mock_products.get_product = AsyncMock(return_value=mock_catalog_product)
+            mock_products.get_related = AsyncMock(return_value=[])
+
+            mock_inventory = AsyncMock()
+            mock_inventory.get_item = AsyncMock(return_value=mock_inventory_item)
+
+            mock_build.return_value = CatalogAdapters(
+                products=mock_products,
+                inventory=mock_inventory,
+                mapping=AcpCatalogMapper(),
+            )
+
+            agent = CatalogSearchAgent(config=agent_dependencies)
+            agent.slm = object()
+            agent.invoke_model = AsyncMock(side_effect=RuntimeError("model failure"))
+
+            result = await agent.handle(
+                {
+                    "query": "winter travel jacket",
+                    "limit": 5,
+                    "mode": "intelligent",
+                }
+            )
+
+            assert result["answer_source"] == "agent_fallback"
+            assert result["result_type"] == "degraded_fallback"
+            assert result["degraded"] is True
+            assert result["degraded_reason"] == "model_error"
+            assert result["model_attempted"] is True
+            assert result["model_status"] == "error"
+            assert isinstance(result.get("fallback_keywords"), list)
+            assert "winter" in result["fallback_keywords"]
+            assert "travel" in result["fallback_keywords"]
+
+    @pytest.mark.asyncio
+    async def test_handle_without_model_returns_non_degraded_deterministic_response(
+        self, agent_dependencies, mock_catalog_product
+    ):
+        """Deterministic path should not be flagged as degraded when no model is configured."""
+        mock_inventory_item = InventoryItem(sku="SKU-001", available=10, reserved=0)
+
+        with patch("ecommerce_catalog_search.agents.build_catalog_adapters") as mock_build:
+            mock_products = AsyncMock()
+            mock_products.get_product = AsyncMock(return_value=mock_catalog_product)
+            mock_products.get_related = AsyncMock(return_value=[])
+
+            mock_inventory = AsyncMock()
+            mock_inventory.get_item = AsyncMock(return_value=mock_inventory_item)
+
+            mock_build.return_value = CatalogAdapters(
+                products=mock_products,
+                inventory=mock_inventory,
+                mapping=AcpCatalogMapper(),
+            )
+
+            agent = CatalogSearchAgent(config=agent_dependencies)
+            result = await agent.handle(
+                {
+                    "query": "running shoes",
+                    "limit": 3,
+                    "mode": "intelligent",
+                }
+            )
+
+            assert result["answer_source"] == "agent_fallback"
+            assert result["result_type"] == "deterministic"
+            assert result["degraded"] is False
+            assert result["model_attempted"] is False
+            assert "degraded_reason" not in result
+            assert "fallback_keywords" not in result
+
+    @pytest.mark.asyncio
+    async def test_handle_model_success_returns_model_answer_metadata(
+        self, agent_dependencies, mock_catalog_product
+    ):
+        """Successful model synthesis should remain classified as model answer."""
+        mock_inventory_item = InventoryItem(sku="SKU-001", available=10, reserved=0)
+
+        with patch("ecommerce_catalog_search.agents.build_catalog_adapters") as mock_build:
+            mock_products = AsyncMock()
+            mock_products.get_product = AsyncMock(return_value=mock_catalog_product)
+            mock_products.get_related = AsyncMock(return_value=[])
+
+            mock_inventory = AsyncMock()
+            mock_inventory.get_item = AsyncMock(return_value=mock_inventory_item)
+
+            mock_build.return_value = CatalogAdapters(
+                products=mock_products,
+                inventory=mock_inventory,
+                mapping=AcpCatalogMapper(),
+            )
+
+            agent = CatalogSearchAgent(config=agent_dependencies)
+            agent.slm = object()
+            agent.invoke_model = AsyncMock(
+                return_value={
+                    "service": "test-catalog-search",
+                    "results": [],
+                    "mode": "intelligent",
+                }
+            )
+
+            result = await agent.handle(
+                {
+                    "query": "rain jacket",
+                    "limit": 5,
+                    "mode": "intelligent",
+                }
+            )
+
+            assert result["answer_source"] == "agent_model"
+            assert result["result_type"] == "model_answer"
+            assert result["degraded"] is False
+            assert result["model_attempted"] is True
+            assert result["model_status"] == "success"
 
     @pytest.mark.asyncio
     async def test_handle_persists_search_history_to_memory_tiers(

--- a/apps/ui/app/search/page.tsx
+++ b/apps/ui/app/search/page.tsx
@@ -110,6 +110,8 @@ export default function SearchPage() {
   const proxyFailure = getProxyFailureError(error);
   const searchSource = data?.source;
   const fallbackReason = data?.fallback_reason;
+  const isAgentDegradedFallback = data?.source === 'agent' && data?.degraded === true;
+  const degradedFallbackKeywords = data?.fallback_keywords || [];
   const isIntelligentFallback =
     data?.requested_mode === 'intelligent' && data?.source === 'crud';
   const showUnavailableAgentFallbackAlert =
@@ -215,6 +217,25 @@ export default function SearchPage() {
             dismissible={false}
           >
             Results are from CRUD catalog search because the agent path was unavailable.
+          </Alert>
+        ) : null}
+        {query && isAgentDegradedFallback ? (
+          <Alert
+            variant="warning"
+            title="Intelligent synthesis is temporarily degraded"
+            dismissible={false}
+          >
+            <div className="space-y-2">
+              <p>
+                {data?.degraded_message
+                  || 'Showing the best available catalog guidance while intelligent generation is temporarily unavailable.'}
+              </p>
+              {degradedFallbackKeywords.length > 0 ? (
+                <p className="text-sm text-[var(--hp-text-muted)]">
+                  Fallback keywords: {degradedFallbackKeywords.join(', ')}
+                </p>
+              ) : null}
+            </div>
           </Alert>
         ) : null}
         <IntentPanel mode={resolvedMode} intent={data?.intent} subqueries={data?.subqueries} />

--- a/apps/ui/lib/services/semanticSearchService.ts
+++ b/apps/ui/lib/services/semanticSearchService.ts
@@ -17,6 +17,9 @@ import type { Product as UiProduct } from '../../components/types';
 const AGENT_API_BASE_URL = resolveAgentApiClientBaseUrl().baseUrl || '';
 const MOCK_HOST_SUFFIX = 'example.com';
 
+export type SearchResultType = 'deterministic' | 'model_answer' | 'degraded_fallback';
+export type SearchDegradedReason = 'model_timeout' | 'model_error';
+
 function usesMockHost(rawUrl: string): boolean {
   const candidate = rawUrl.trim();
   if (!candidate) {
@@ -30,6 +33,37 @@ function usesMockHost(rawUrl: string): boolean {
   } catch {
     return false;
   }
+}
+
+function parseSearchResultType(value: unknown): SearchResultType | undefined {
+  if (
+    value === 'deterministic'
+    || value === 'model_answer'
+    || value === 'degraded_fallback'
+  ) {
+    return value;
+  }
+
+  return undefined;
+}
+
+function parseSearchDegradedReason(value: unknown): SearchDegradedReason | undefined {
+  if (value === 'model_timeout' || value === 'model_error') {
+    return value;
+  }
+
+  return undefined;
+}
+
+function parseStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .filter((item): item is string => typeof item === 'string')
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
 }
 
 export interface SemanticSearchRequest {
@@ -65,6 +99,12 @@ export interface SemanticSearchResponse {
   trace_id?: string;
   intent?: SemanticSearchIntent | null;
   subqueries?: string[];
+  answer_source?: string;
+  result_type?: SearchResultType;
+  degraded?: boolean;
+  degraded_reason?: SearchDegradedReason;
+  degraded_message?: string;
+  fallback_keywords?: string[];
 }
 
 export type SemanticSearchContext = Pick<
@@ -100,6 +140,8 @@ export const semanticSearchService = {
         source: 'crud',
         mode: requestedMode === 'intelligent' ? 'intelligent' : 'keyword',
         requested_mode: requestedMode,
+        result_type: 'deterministic',
+        degraded: false,
       };
     }
 
@@ -125,6 +167,7 @@ export const semanticSearchService = {
         }
 
         const mode = payload.mode === 'intelligent' ? 'intelligent' : 'keyword';
+        const fallbackKeywords = parseStringArray(payload.fallback_keywords);
         return {
           items: mapAcpProductsToUi(results),
           source: 'agent',
@@ -135,6 +178,13 @@ export const semanticSearchService = {
           subqueries: Array.isArray(payload.subqueries)
             ? payload.subqueries.filter((value: unknown): value is string => typeof value === 'string')
             : [],
+          answer_source: typeof payload.answer_source === 'string' ? payload.answer_source : undefined,
+          result_type: parseSearchResultType(payload.result_type),
+          degraded: payload.degraded === true,
+          degraded_reason: parseSearchDegradedReason(payload.degraded_reason),
+          degraded_message:
+            typeof payload.degraded_message === 'string' ? payload.degraded_message : undefined,
+          fallback_keywords: fallbackKeywords.length > 0 ? fallbackKeywords : undefined,
         };
       } catch (error) {
         console.error('Semantic search failed:', error);
@@ -154,6 +204,8 @@ export const semanticSearchService = {
             ? 'agent_mock'
             : 'agent_unavailable'
           : undefined,
+      result_type: 'deterministic',
+      degraded: false,
     };
   },
 };

--- a/apps/ui/tests/unit/SearchPage.test.tsx
+++ b/apps/ui/tests/unit/SearchPage.test.tsx
@@ -220,6 +220,43 @@ describe('SearchPage', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('shows degraded fallback warning when agent model synthesis fails', () => {
+    mockUseIntelligentSearch.mockReturnValue({
+      data: {
+        items: [],
+        source: 'agent',
+        mode: 'intelligent',
+        requested_mode: 'intelligent',
+        degraded: true,
+        degraded_reason: 'model_timeout',
+        degraded_message:
+          'Showing the best available catalog guidance while intelligent generation is temporarily unavailable.',
+        fallback_keywords: ['winter', 'jacket', 'boots'],
+        intent: null,
+        subqueries: [],
+      },
+      isLoading: false,
+      error: null,
+      isFetching: false,
+      refetch: jest.fn(),
+      isReranking: false,
+      baselineData: {
+        items: [],
+        source: 'agent',
+        mode: 'intelligent',
+      },
+      rerankedData: undefined,
+      preference: 'intelligent',
+      setPreference,
+      resolvedMode: 'intelligent',
+    });
+
+    render(<SearchPage />);
+
+    expect(screen.getByText('Intelligent synthesis is temporarily degraded')).toBeInTheDocument();
+    expect(screen.getByText('Fallback keywords: winter, jacket, boots')).toBeInTheDocument();
+  });
+
   it('announces reranking progress with a polite status message', () => {
     mockUseIntelligentSearch.mockReturnValue({
       data: {

--- a/apps/ui/tests/unit/semanticSearchService.test.ts
+++ b/apps/ui/tests/unit/semanticSearchService.test.ts
@@ -98,4 +98,35 @@ describe('semanticSearchService.searchWithMode', () => {
     expect(result.items[0].sku).toBe('SKU-2');
     expect(productService.search).not.toHaveBeenCalled();
   });
+
+  it('maps degraded fallback metadata from agent responses', async () => {
+    (agentApiClient.post as jest.Mock).mockResolvedValue({
+      data: {
+        results: [
+          {
+            item_id: 'SKU-9',
+            title: 'Winter Shell Jacket',
+          },
+        ],
+        mode: 'intelligent',
+        answer_source: 'agent_fallback',
+        result_type: 'degraded_fallback',
+        degraded: true,
+        degraded_reason: 'model_timeout',
+        degraded_message:
+          'Showing the best available catalog guidance while intelligent generation is temporarily unavailable.',
+        fallback_keywords: ['winter', 'jacket'],
+      },
+    });
+
+    const result = await semanticSearchService.searchWithMode('winter jacket', 'intelligent', 20);
+
+    expect(result.source).toBe('agent');
+    expect(result.answer_source).toBe('agent_fallback');
+    expect(result.result_type).toBe('degraded_fallback');
+    expect(result.degraded).toBe(true);
+    expect(result.degraded_reason).toBe('model_timeout');
+    expect(result.fallback_keywords).toEqual(['winter', 'jacket']);
+    expect(productService.search).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary\n- add explicit degraded fallback metadata on catalog agent responses when model synthesis times out or errors\n- preserve deterministic and model-answer semantics via esult_type, degraded, and model execution markers\n- surface degraded agent fallback messaging and fallback keywords in UI search flows\n- extend backend and UI unit tests for degraded timeout/error and contract mapping\n\n## Validation\n- python -m pytest apps/ecommerce-catalog-search/tests/test_agents.py -q\n- python -m pytest apps/ecommerce-catalog-search/tests -q\n- cd apps/ui && yarn test --runInBand tests/unit/semanticSearchService.test.ts tests/unit/SearchPage.test.tsx\n\nCloses #701