### PR TITLE
docs: reflect protected dev environment policy

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -58,7 +58,7 @@ Use environment-specific entry workflows:
 
 For the protected live suite, store these values in the GitHub Environment `dev` and keep Azure authentication OIDC-only. Do not add client secrets, connection strings, or API keys for live validation.
 
-Repository code establishes this environment-scoped secret boundary. To complete the protected-environment model, a repo admin must enable selected-branch deployment protection on `main` for the `dev` environment.
+Repository code establishes this environment-scoped secret boundary. The `dev` environment must remain configured with selected-branch deployment protection on `main`.
 
 **Entry workflow inputs**:
 
@@ -107,7 +107,7 @@ Core workflow note: `.github/workflows/deploy-azd.yml` is reusable-only and not 
 - UI deployment intentionally uses the SWA GitHub Action path (not `azd deploy --service ui`) so App Router dynamic segments (`[id]`, `[slug]`) are built in the same mode as standard SWA workflows.
 - Frontend API calls must always use APIM via validated runtime env aliases (`NEXT_PUBLIC_API_URL` and `NEXT_PUBLIC_CRUD_API_URL` are set together in deployment workflows).
 - Demo seeding uses a curated catalog of 10 categories and 100 products with realistic retail data. Re-runs are idempotent by item ID (`cat-*`, `prd-*`): existing seeded records are updated instead of duplicated.
-- Use GitHub Environment protection rules for privileged `dev` validation and for `staging`/`prod` deployment paths; for `dev`, enabling selected-branch deployment protection on `main` is a repo-admin follow-up.
+- Use GitHub Environment protection rules for privileged `dev` validation and for `staging`/`prod` deployment paths; for `dev`, selected-branch deployment protection on `main` is required.
 - Keep image tags immutable for reproducible rollback.
 
 **Local demo seeding (manual)**:

--- a/docs/governance/README.md
+++ b/docs/governance/README.md
@@ -73,7 +73,7 @@ Detailed policy is defined in [Infrastructure Governance](infrastructure-governa
 - `.github/workflows/protected-dev-live-agent-readiness.yml` is the only approved privileged live validation workflow for the dev environment.
 - The workflow is bound to the GitHub Environment `dev` with environment-scoped `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_SUBSCRIPTION_ID` values for Azure OIDC login.
 - Allowed triggers are `workflow_run` after successful `deploy-azd-dev (entrypoint)` runs on `main`, `workflow_dispatch`, and `schedule`.
-- Repository code establishes the privileged workflow and environment-scoped secret boundary. To complete the protected-environment model, a repo admin must enable selected-branch deployment protection on `main` for the `dev` environment.
+- Repository code establishes the privileged workflow and environment-scoped secret boundary. The `dev` environment must remain configured with selected-branch deployment protection on `main`.
 - The workflow must not run on `pull_request`, `pull_request_target`, or other untrusted contributor contexts because it reaches live Azure resources behind a privileged environment boundary.
 
 ## Enforcement Model

--- a/docs/governance/infrastructure-governance.md
+++ b/docs/governance/infrastructure-governance.md
@@ -33,7 +33,7 @@ Infrastructure provisioning, deployment orchestration, identity, security contro
 | --- | --- | --- | --- |
 | Entrypoint workflow | `deploy-azd-dev.yml` | `deploy-azd-prod.yml` | Not currently provisioned as dedicated workflow |
 | Trigger model | `push` to `main` + `workflow_dispatch` | Stable tag push `v*.*.*` | Manual via reusable workflow only if explicitly configured |
-| Protected live validation | `protected-dev-live-agent-readiness.yml` via the `dev` environment boundary on trusted `workflow_run`, `workflow_dispatch`, and `schedule`; selected-branch deployment protection on `main` remains a repo-admin step | N/A | N/A |
+| Protected live validation | `protected-dev-live-agent-readiness.yml` via the `dev` environment boundary on trusted `workflow_run`, `workflow_dispatch`, and `schedule`; the `dev` environment must remain restricted to the selected branch `main` | N/A | N/A |
 | Release gate | Not required | Required: published, non-draft, non-prerelease GitHub Release | N/A |
 | Main lineage gate | Not required | Required: tagged commit must be reachable from `main` | N/A |
 | Demo data seeding mode | Local/manual only (not part of CI deploy) | Local/manual only | Local/manual only |
@@ -55,7 +55,7 @@ Infrastructure provisioning, deployment orchestration, identity, security contro
 - Forbidden triggers are `pull_request`, `pull_request_target`, and other untrusted contributor contexts.
 - Authentication must use OIDC-backed `azure/login`; do not introduce Azure client secrets, API keys, connection strings, or repository-committed credentials.
 - Store `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_SUBSCRIPTION_ID` in the `dev` environment so privileged live checks remain isolated from standard PR automation.
-- Repository code establishes the privileged workflow and environment-scoped secret boundary, but GitHub Environment protection rules are external to repository code. A repo admin must enable selected-branch deployment protection on `main` for `dev` to complete the protected-environment model.
+- Repository code establishes the privileged workflow and environment-scoped secret boundary, while GitHub Environment protection rules remain external to repository code. The `dev` environment must remain configured with selected-branch deployment protection on `main`.
 - This workflow is operational evidence and must not be added to required PR status checks.
 
 ## Security and Access Controls
@@ -120,7 +120,7 @@ Infrastructure provisioning, deployment orchestration, identity, security contro
 4. Smoke checks passed for CRUD/API/UI scope deployed.
 5. Any temporary firewall exceptions removed after deployment.
 6. Architecture/governance docs updated when policy changes.
-7. Privileged live validation remains bound to the `dev` environment and excluded from PR contexts; selected-branch deployment protection on `main` must be enabled on that environment by a repo admin.
+7. Privileged live validation remains bound to the `dev` environment, excluded from PR contexts, and constrained by selected-branch deployment protection on `main`.
 8. Changed agent services passed the Foundry runtime contract gate across workflow intent, rendered manifests, live Deployment env values, ensure responses, and `/ready` validation.
 
 ## ADR References


### PR DESCRIPTION
## Summary
- update governance docs to reflect that the dev GitHub Environment now enforces selected-branch deployment protection on main
- keep the live-readiness workflow guidance aligned with the active environment boundary
- remove stale wording that described the admin-only environment step as pending

## Validation
- gh api repos/Azure-Samples/holiday-peak-hub/environments/dev
- gh api repos/Azure-Samples/holiday-peak-hub/environments/dev/deployment-branch-policies
- git diff --check

Closes #716