### PR TITLE
ci: restore GitHub runner access to private ACR

### DIFF
--- a/.github/workflows/deploy-azd.yml
+++ b/.github/workflows/deploy-azd.yml
@@ -637,6 +637,42 @@ jobs:
           echo "Provision infrastructure failed with non-ignorable errors." >&2
           exit 1
 
+      - name: Ensure deploy principal has AcrPush on ACR
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          RG_NAME="${{ inputs.projectName }}-${{ inputs.environment }}-rg"
+          ACR_NAME=$(echo "${{ inputs.projectName }}${{ inputs.environment }}acr" | tr -cd '[:alnum:]' | tr '[:upper:]' '[:lower:]')
+          DEPLOY_SP_OBJECT_ID=$(az ad sp show --id "${AZURE_CLIENT_ID}" --query id -o tsv)
+          ACR_ID=$(az acr show --resource-group "$RG_NAME" --name "$ACR_NAME" --query id -o tsv)
+
+          EXISTING=$(az role assignment list \
+            --scope "$ACR_ID" \
+            --assignee-object-id "$DEPLOY_SP_OBJECT_ID" \
+            --query "[?roleDefinitionName=='AcrPush'] | length(@)" -o tsv)
+
+          if [ "$EXISTING" = "0" ]; then
+            echo "Assigning AcrPush to deploy principal on ACR $ACR_NAME."
+            az role assignment create \
+              --assignee-object-id "$DEPLOY_SP_OBJECT_ID" \
+              --assignee-principal-type ServicePrincipal \
+              --role "AcrPush" \
+              --scope "$ACR_ID"
+          else
+            echo "Deploy principal already has AcrPush on ACR $ACR_NAME."
+          fi
+
+          VERIFIED=$(az role assignment list \
+            --scope "$ACR_ID" \
+            --assignee-object-id "$DEPLOY_SP_OBJECT_ID" \
+            --query "[?roleDefinitionName=='AcrPush'] | length(@)" -o tsv)
+
+          if [ "$VERIFIED" = "0" ]; then
+            echo "Failed to verify AcrPush assignment for deploy principal on scope $ACR_ID."
+            exit 1
+          fi
+
       - name: Ensure AKS identity can read Key Vault secrets
         run: |
           AKS_RG="${{ inputs.projectName }}-${{ inputs.environment }}-rg"
@@ -704,12 +740,148 @@ jobs:
             echo "AGC_FRONTEND_REFERENCE=${AGC_FRONTEND_REFERENCE}"
           } >> "$GITHUB_OUTPUT"
 
+  prepare-acr-build-access:
+    runs-on: ubuntu-latest
+    if: ${{ !inputs.uiOnly && needs.detect-changes.outputs.changed_aks_services_csv != '' }}
+    needs:
+      - provision
+      - detect-changes
+    environment: ${{ inputs.environment }}
+    outputs:
+      acr_name: ${{ steps.registry.outputs.acr_name }}
+      rg_name: ${{ steps.registry.outputs.rg_name }}
+      login_server: ${{ steps.registry.outputs.login_server }}
+      public_network_access_before: ${{ steps.access.outputs.public_network_access_before }}
+      default_action_before: ${{ steps.access.outputs.default_action_before }}
+      public_access_temporarily_enabled: ${{ steps.access.outputs.public_access_temporarily_enabled }}
+    env:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+    steps:
+      - name: Azure login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ env.AZURE_CLIENT_ID }}
+          tenant-id: ${{ env.AZURE_TENANT_ID }}
+          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Resolve ACR registry
+        id: registry
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          RG_NAME="${{ inputs.projectName }}-${{ inputs.environment }}-rg"
+          ACR_NAME=$(echo "${{ inputs.projectName }}${{ inputs.environment }}acr" | tr -cd '[:alnum:]' | tr '[:upper:]' '[:lower:]')
+
+          if ! az acr show --resource-group "$RG_NAME" --name "$ACR_NAME" >/dev/null 2>&1; then
+            echo "ACR registry '$ACR_NAME' was not found in resource group '$RG_NAME'." >&2
+            exit 1
+          fi
+
+          ACR_LOGIN_SERVER=$(az acr show \
+            --resource-group "$RG_NAME" \
+            --name "$ACR_NAME" \
+            --query "loginServer" -o tsv)
+
+          echo "acr_name=${ACR_NAME}" >> "$GITHUB_OUTPUT"
+          echo "rg_name=${RG_NAME}" >> "$GITHUB_OUTPUT"
+          echo "login_server=${ACR_LOGIN_SERVER}" >> "$GITHUB_OUTPUT"
+
+      - name: Prepare temporary ACR public access for tested-image builds
+        id: access
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          ACR_NAME="${{ steps.registry.outputs.acr_name }}"
+          RG_NAME="${{ steps.registry.outputs.rg_name }}"
+          RESTORE_ON_ERROR=false
+
+          cleanup() {
+            if [ "$RESTORE_ON_ERROR" != "true" ]; then
+              return
+            fi
+
+            if [ -n "${DEFAULT_ACTION_BEFORE:-}" ]; then
+              az acr update \
+                --name "$ACR_NAME" \
+                --resource-group "$RG_NAME" \
+                --default-action "$DEFAULT_ACTION_BEFORE" >/dev/null || true
+            fi
+
+            if [ "${PUBLIC_NETWORK_ACCESS_BEFORE:-}" = "Disabled" ]; then
+              az acr update \
+                --name "$ACR_NAME" \
+                --resource-group "$RG_NAME" \
+                --public-network-enabled false >/dev/null || true
+            fi
+          }
+          trap cleanup EXIT
+
+          PUBLIC_NETWORK_ACCESS_BEFORE=$(az acr show \
+            --resource-group "$RG_NAME" \
+            --name "$ACR_NAME" \
+            --query "publicNetworkAccess" -o tsv)
+          DEFAULT_ACTION_BEFORE=$(az acr show \
+            --resource-group "$RG_NAME" \
+            --name "$ACR_NAME" \
+            --query "networkRuleSet.defaultAction" -o tsv)
+
+          if [ -z "$DEFAULT_ACTION_BEFORE" ] || [ "$DEFAULT_ACTION_BEFORE" = "null" ]; then
+            DEFAULT_ACTION_BEFORE="Allow"
+          fi
+
+          echo "public_network_access_before=${PUBLIC_NETWORK_ACCESS_BEFORE}" >> "$GITHUB_OUTPUT"
+          echo "default_action_before=${DEFAULT_ACTION_BEFORE}" >> "$GITHUB_OUTPUT"
+          echo "public_access_temporarily_enabled=false" >> "$GITHUB_OUTPUT"
+
+          if [ "${{ inputs.autoAllowAcrRunnerIp }}" != "true" ] || [ "$PUBLIC_NETWORK_ACCESS_BEFORE" != "Disabled" ]; then
+            exit 0
+          fi
+
+          RESTORE_ON_ERROR=true
+          az acr update \
+            --name "$ACR_NAME" \
+            --resource-group "$RG_NAME" \
+            --public-network-enabled true \
+            --default-action Deny >/dev/null
+
+          CURRENT_PUBLIC_NETWORK_ACCESS=""
+          CURRENT_DEFAULT_ACTION=""
+          for attempt in 1 2 3 4 5; do
+            CURRENT_PUBLIC_NETWORK_ACCESS=$(az acr show \
+              --resource-group "$RG_NAME" \
+              --name "$ACR_NAME" \
+              --query "publicNetworkAccess" -o tsv)
+            CURRENT_DEFAULT_ACTION=$(az acr show \
+              --resource-group "$RG_NAME" \
+              --name "$ACR_NAME" \
+              --query "networkRuleSet.defaultAction" -o tsv)
+
+            if [ "$CURRENT_PUBLIC_NETWORK_ACCESS" = "Enabled" ] && [ "$CURRENT_DEFAULT_ACTION" = "Deny" ]; then
+              break
+            fi
+
+            sleep 10
+          done
+
+          if [ "$CURRENT_PUBLIC_NETWORK_ACCESS" != "Enabled" ] || [ "$CURRENT_DEFAULT_ACTION" != "Deny" ]; then
+            echo "Failed to temporarily enable least-open ACR public access on ${ACR_NAME} for GitHub-hosted tested-image builds." >&2
+            exit 1
+          fi
+
+          echo "public_access_temporarily_enabled=true" >> "$GITHUB_OUTPUT"
+          RESTORE_ON_ERROR=false
+
   build-aks-images:
     runs-on: ubuntu-latest
     if: ${{ !inputs.uiOnly && needs.detect-changes.outputs.changed_aks_services_csv != '' }}
     needs:
       - provision
       - detect-changes
+      - prepare-acr-build-access
     environment: ${{ inputs.environment }}
     strategy:
       fail-fast: false
@@ -735,36 +907,18 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Resolve ACR registry
-        id: registry
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          RG_NAME="${{ inputs.projectName }}-${{ inputs.environment }}-rg"
-          ACR_NAME=$(echo "${{ inputs.projectName }}${{ inputs.environment }}acr" | tr -cd '[:alnum:]' | tr '[:upper:]' '[:lower:]')
-
-          if ! az acr show --resource-group "$RG_NAME" --name "$ACR_NAME" >/dev/null 2>&1; then
-            echo "ACR registry '$ACR_NAME' was not found in resource group '$RG_NAME'." >&2
-            exit 1
-          fi
-
-          ACR_LOGIN_SERVER=$(az acr show \
-            --resource-group "$RG_NAME" \
-            --name "$ACR_NAME" \
-            --query "loginServer" -o tsv)
-
-          echo "acr_name=${ACR_NAME}" >> "$GITHUB_OUTPUT"
-          echo "rg_name=${RG_NAME}" >> "$GITHUB_OUTPUT"
-          echo "login_server=${ACR_LOGIN_SERVER}" >> "$GITHUB_OUTPUT"
-
       - name: Preflight ACR data-plane accessibility
         id: acr_preflight_build
         shell: bash
         run: |
           set -euo pipefail
 
-          ACR_LOGIN_SERVER="${{ steps.registry.outputs.login_server }}"
+          ACR_NAME="${{ needs.prepare-acr-build-access.outputs.acr_name }}"
+          RG_NAME="${{ needs.prepare-acr-build-access.outputs.rg_name }}"
+          ACR_LOGIN_SERVER="${{ needs.prepare-acr-build-access.outputs.login_server }}"
+
+          echo "runner_ip=" >> "$GITHUB_OUTPUT"
+          echo "runner_ip_allowlist_added=false" >> "$GITHUB_OUTPUT"
 
           if ! STATUS_CODE=$(curl -sS -o /tmp/acr-v2-probe-build.txt -w "%{http_code}" --max-time 25 "https://${ACR_LOGIN_SERVER}/v2/"); then
             STATUS_CODE="000"
@@ -781,10 +935,20 @@ jobs:
           fi
 
           if [ -n "$RUNNER_IP" ] && [ "${{ inputs.autoAllowAcrRunnerIp }}" = "true" ] && [ "$STATUS_CODE" = "403" ]; then
-            az acr network-rule add \
-              --name "${{ steps.registry.outputs.acr_name }}" \
-              --resource-group "${{ steps.registry.outputs.rg_name }}" \
-              --ip-address "$RUNNER_IP" >/dev/null
+            EXISTING_RULE_COUNT=$(az acr network-rule list \
+              --name "$ACR_NAME" \
+              --resource-group "$RG_NAME" \
+              --query "ipRules[].value" -o tsv 2>/dev/null | grep -Ec "^${RUNNER_IP}(/32)?$" || true)
+            EXISTING_RULE_COUNT="${EXISTING_RULE_COUNT:-0}"
+
+            if [ "$EXISTING_RULE_COUNT" = "0" ]; then
+              az acr network-rule add \
+                --name "$ACR_NAME" \
+                --resource-group "$RG_NAME" \
+                --ip-address "$RUNNER_IP" >/dev/null
+              echo "runner_ip_allowlist_added=true" >> "$GITHUB_OUTPUT"
+            fi
+
             echo "runner_ip=${RUNNER_IP}" >> "$GITHUB_OUTPUT"
             sleep 15
             if ! RETRY_CODE=$(curl -sS -o /tmp/acr-v2-probe-build-retry.txt -w "%{http_code}" --max-time 25 "https://${ACR_LOGIN_SERVER}/v2/"); then
@@ -802,7 +966,39 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          az acr login --name "${{ steps.registry.outputs.acr_name }}"
+
+          ACR_NAME="${{ needs.prepare-acr-build-access.outputs.acr_name }}"
+          ACR_SCOPE=$(az acr show \
+            --resource-group "${{ needs.prepare-acr-build-access.outputs.rg_name }}" \
+            --name "$ACR_NAME" \
+            --query id -o tsv)
+          DEPLOY_SP_OBJECT_ID=$(az ad sp show --id "${AZURE_CLIENT_ID}" --query id -o tsv)
+          RETRY_DELAYS=(15 30 60 90)
+          LOGIN_SUCCESS=false
+
+          for attempt in 1 2 3 4 5; do
+            if az acr login --name "$ACR_NAME"; then
+              LOGIN_SUCCESS=true
+              break
+            fi
+
+            ACR_PUSH_ASSIGNMENTS=$(az role assignment list \
+              --scope "$ACR_SCOPE" \
+              --assignee-object-id "$DEPLOY_SP_OBJECT_ID" \
+              --query "[?roleDefinitionName=='AcrPush'] | length(@)" -o tsv 2>/dev/null || true)
+            ACR_PUSH_ASSIGNMENTS="${ACR_PUSH_ASSIGNMENTS:-0}"
+
+            if [ "$attempt" -lt 5 ]; then
+              delay=${RETRY_DELAYS[$((attempt-1))]}
+              echo "::warning::az acr login failed on attempt ${attempt}/5 for ${ACR_NAME}. Visible AcrPush assignments for deploy principal ${DEPLOY_SP_OBJECT_ID} at ${ACR_SCOPE}: ${ACR_PUSH_ASSIGNMENTS}. This usually indicates RBAC propagation delay between ARM and the ACR data plane. Retrying in ${delay}s."
+              sleep "$delay"
+            fi
+          done
+
+          if [ "$LOGIN_SUCCESS" != "true" ]; then
+            echo "ACR login failed after 5 attempts for ${ACR_NAME}. Verify deploy principal object id ${DEPLOY_SP_OBJECT_ID} has AcrPush on ${ACR_SCOPE}, then rerun after RBAC propagation completes. OIDC-only auth is required; do not enable admin-user or add static registry credentials." >&2
+            exit 1
+          fi
 
       - name: Resolve Docker build inputs
         id: docker_inputs
@@ -911,7 +1107,7 @@ jobs:
 
           SERVICE_NAME="${{ matrix.service }}"
           SOURCE_SHA="${DEPLOY_SOURCE_SHA}"
-          IMAGE_REPOSITORY="${{ steps.registry.outputs.login_server }}/${SERVICE_NAME}"
+          IMAGE_REPOSITORY="${{ needs.prepare-acr-build-access.outputs.login_server }}/${SERVICE_NAME}"
           IMAGE_TAGGED_REF="${IMAGE_REPOSITORY}:${SOURCE_SHA}"
           EXISTING_DIGEST=""
 
@@ -959,14 +1155,86 @@ jobs:
           retention-days: 7
 
       - name: Cleanup temporary ACR runner IP allowlist (build)
-        if: ${{ always() && inputs.autoAllowAcrRunnerIp && steps.acr_preflight_build.outputs.runner_ip != '' }}
+        if: ${{ always() && steps.acr_preflight_build.outputs.runner_ip_allowlist_added == 'true' }}
         shell: bash
         run: |
           set -euo pipefail
           az acr network-rule remove \
-            --name "${{ steps.registry.outputs.acr_name }}" \
-            --resource-group "${{ steps.registry.outputs.rg_name }}" \
+            --name "${{ needs.prepare-acr-build-access.outputs.acr_name }}" \
+            --resource-group "${{ needs.prepare-acr-build-access.outputs.rg_name }}" \
             --ip-address "${{ steps.acr_preflight_build.outputs.runner_ip }}" >/dev/null || true
+
+  restore-acr-build-access:
+    runs-on: ubuntu-latest
+    if: ${{ always() && !inputs.uiOnly && needs.detect-changes.outputs.changed_aks_services_csv != '' }}
+    needs:
+      - detect-changes
+      - prepare-acr-build-access
+      - build-aks-images
+    environment: ${{ inputs.environment }}
+    env:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+    steps:
+      - name: Azure login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ env.AZURE_CLIENT_ID }}
+          tenant-id: ${{ env.AZURE_TENANT_ID }}
+          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Restore ACR public access state
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "${{ needs.prepare-acr-build-access.outputs.public_access_temporarily_enabled }}" != "true" ]; then
+            echo "ACR public access state did not require temporary changes."
+            exit 0
+          fi
+
+          ACR_NAME="${{ needs.prepare-acr-build-access.outputs.acr_name }}"
+          RG_NAME="${{ needs.prepare-acr-build-access.outputs.rg_name }}"
+          PUBLIC_NETWORK_ACCESS_BEFORE="${{ needs.prepare-acr-build-access.outputs.public_network_access_before }}"
+          DEFAULT_ACTION_BEFORE="${{ needs.prepare-acr-build-access.outputs.default_action_before }}"
+
+          if [ -n "$DEFAULT_ACTION_BEFORE" ] && [ "$DEFAULT_ACTION_BEFORE" != "null" ]; then
+            az acr update \
+              --name "$ACR_NAME" \
+              --resource-group "$RG_NAME" \
+              --default-action "$DEFAULT_ACTION_BEFORE" >/dev/null
+          fi
+
+          if [ "$PUBLIC_NETWORK_ACCESS_BEFORE" = "Disabled" ]; then
+            az acr update \
+              --name "$ACR_NAME" \
+              --resource-group "$RG_NAME" \
+              --public-network-enabled false >/dev/null
+          fi
+
+          CURRENT_PUBLIC_NETWORK_ACCESS=$(az acr show \
+            --resource-group "$RG_NAME" \
+            --name "$ACR_NAME" \
+            --query "publicNetworkAccess" -o tsv)
+          CURRENT_DEFAULT_ACTION=$(az acr show \
+            --resource-group "$RG_NAME" \
+            --name "$ACR_NAME" \
+            --query "networkRuleSet.defaultAction" -o tsv)
+
+          if [ -z "$CURRENT_DEFAULT_ACTION" ] || [ "$CURRENT_DEFAULT_ACTION" = "null" ]; then
+            CURRENT_DEFAULT_ACTION="Allow"
+          fi
+
+          if [ "$CURRENT_PUBLIC_NETWORK_ACCESS" != "$PUBLIC_NETWORK_ACCESS_BEFORE" ]; then
+            echo "Failed to restore ACR public network access state for ${ACR_NAME}: expected ${PUBLIC_NETWORK_ACCESS_BEFORE}, got ${CURRENT_PUBLIC_NETWORK_ACCESS}." >&2
+            exit 1
+          fi
+
+          if [ "$CURRENT_DEFAULT_ACTION" != "$DEFAULT_ACTION_BEFORE" ]; then
+            echo "Failed to restore ACR default network action for ${ACR_NAME}: expected ${DEFAULT_ACTION_BEFORE}, got ${CURRENT_DEFAULT_ACTION}." >&2
+            exit 1
+          fi
 
   deploy-foundry-models:
     runs-on: ubuntu-latest
@@ -1003,6 +1271,7 @@ jobs:
       - provision
       - detect-changes
       - build-aks-images
+      - restore-acr-build-access
     if: ${{ !inputs.uiOnly && needs.detect-changes.outputs.crud_changed == 'true' }}
     environment: ${{ inputs.environment }}
     env:
@@ -1709,6 +1978,7 @@ jobs:
       - deploy-foundry-models
       - detect-changes
       - build-aks-images
+      - restore-acr-build-access
     environment: ${{ inputs.environment }}
     strategy:
       fail-fast: false

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,11 +1,12 @@
 # Holiday Peak Hub - Architecture Documentation
 
-**Last Updated**: April 7, 2026
+**Last Updated**: April 8, 2026
 **Version**: main (post PR #559)  
 **Status**: Active Development
 
-## Latest Update Snapshot (April 6, 2026)
+## Latest Update Snapshot (April 8, 2026)
 
+- Reusable deployment now temporarily re-enables ACR public access with `defaultAction=Deny` for GitHub-hosted tested-image builds when the registry public endpoint is disabled, reuses the existing runner-IP allowlist, and restores the original ACR network posture after the build phase.
 - Enrichment/search orchestration hardening merged via PR #559 (Issue #558).
 - Truth flow now enforces human-gated enrichment validation (`pending_review`) with dual HITL publish (`export-jobs` and `search-enrichment-jobs`).
 - Search flow now supports two-stage UX (baseline first, background rerank) and request context propagation.
@@ -16,6 +17,7 @@
 - Protected dev live validation now has a dedicated GitHub Actions workflow with trusted triggers, OIDC-only Azure auth, and the `dev` environment boundary; final environment protection remains a repo-admin step.
 - Dev deployment now promotes tested `main` commits only: `deploy-azd-dev` auto-starts from successful `test` workflow runs on `main`, builds changed AKS images once per tested SHA, and deploys rendered manifests pinned to immutable image digests.
 - Reusable deployment now includes a blocking Foundry contract drift gate that compares workflow intent, rendered Helm manifests, live AKS Deployment env values, ensure results, and `/ready` responses for changed agent services.
+- Reusable deployment now idempotently ensures `AcrPush` on the environment ACR for the OIDC deploy principal and retries `az acr login` with bounded backoff so tested-image builds survive RBAC propagation delay without adding static registry credentials.
 
 ## Overview
 
@@ -57,6 +59,8 @@ Use environment-specific entry workflows:
 - `AZURE_TENANT_ID`
 - `AZURE_SUBSCRIPTION_ID`
 
+The OIDC deploy principal behind `AZURE_CLIENT_ID` must be allowed to manage the environment-scoped RBAC assignments used by the reusable deployment workflow. `deploy-azd.yml` now idempotently verifies `Azure Kubernetes Service RBAC Cluster Admin` on the environment resource group and `AcrPush` on the environment ACR before tested-image builds start.
+
 For the protected live suite, store these values in the GitHub Environment `dev` and keep Azure authentication OIDC-only. Do not add client secrets, connection strings, or API keys for live validation.
 
 Repository code establishes this environment-scoped secret boundary. The `dev` environment must remain configured with selected-branch deployment protection on `main`.
@@ -93,8 +97,8 @@ Core workflow note: `.github/workflows/deploy-azd.yml` is reusable-only and not 
 
 **Execution order**:
 
-1. `provision` job: sets azd env values and runs `azd provision`.
-2. `build-aks-images` job: builds changed AKS workloads from the tested source SHA into the existing ACR (or reuses an existing per-SHA image), then records immutable digest refs for downstream deploy jobs.
+1. `provision` job: sets azd env values, runs `azd provision`, and idempotently ensures the OIDC deploy principal has `Azure Kubernetes Service RBAC Cluster Admin` on the environment resource group plus `AcrPush` on the environment ACR.
+2. `build-aks-images` job: builds changed AKS workloads from the tested source SHA into the existing ACR (or reuses an existing per-SHA image), retries `az acr login` with bounded backoff to absorb RBAC propagation delay, and then records immutable digest refs for downstream deploy jobs. When `autoAllowAcrRunnerIp=true`, the workflow also reuses the existing runner-IP allowlist path; if the ACR public endpoint is disabled, it first enables public access with `defaultAction=Deny`, adds only the active GitHub-hosted runner IP, and restores the original public-access setting after the build phase. This is required because disabling ACR public network access overrides firewall rules, and GitHub-hosted runners do not have private network line of sight to a private-only registry.
 3. `deploy-crud` job: renders and applies the `crud-service` Helm manifest pinned to the tested image digest when CRUD/lib changes are detected.
 4. `deploy-foundry-models` and `deploy-agents` jobs: run after provision; `deploy-agents` deploys changed agent services from prebuilt digest-pinned manifests (and can proceed when `deploy-crud` is skipped for agent-only changes).
 5. `ensure-foundry-agents` job: re-renders changed agent manifests with the workflow's strict/auto-ensure contract, compares rendered env values against live AKS Deployments, then validates `POST /foundry/agents/ensure` plus `/ready` for each changed agent service.
@@ -106,6 +110,7 @@ Core workflow note: `.github/workflows/deploy-azd.yml` is reusable-only and not 
 
 - Keep `deployShared=true` for all shared-environment rollouts.
 - Dev AKS rollouts must use the tested source checkout plus immutable image digests (`repo@sha256:...`); deploy jobs render/apply Kubernetes manifests directly and must not rebuild service images inline.
+- For GitHub-hosted tested-image builds, `autoAllowAcrRunnerIp=true` preserves OIDC-only auth and the existing ACR IP allowlist flow. If the environment registry is private-only (`publicNetworkAccess=Disabled`), the workflow temporarily reopens the public endpoint with `defaultAction=Deny`, scopes access to the current runner IP, and restores the original ACR public-access state immediately after the build phase.
 - For changed AKS agent services, treat the Foundry runtime contract as a blocking gate: expected `FOUNDRY_STRICT_ENFORCEMENT=true` and `FOUNDRY_AUTO_ENSURE_ON_STARTUP=true` must survive render and rollout, and `/ready` is only accepted when it matches successful Foundry ensure results.
 - UI deployment intentionally uses the SWA GitHub Action path (not `azd deploy --service ui`) so App Router dynamic segments (`[id]`, `[slug]`) are built in the same mode as standard SWA workflows.
 - Frontend API calls must always use APIM via validated runtime env aliases (`NEXT_PUBLIC_API_URL` and `NEXT_PUBLIC_CRUD_API_URL` are set together in deployment workflows).
@@ -185,6 +190,8 @@ az acr network-rule list -n <acrName> -o table
 ```
 
 4. **Temporarily unblock ACR publish from operator IP (if `azd deploy` fails with DENIED/IP blocked)**
+
+When ACR `publicNetworkAccess` is disabled, firewall rules are ignored until the public endpoint is re-enabled. GitHub-hosted runners and local operators without private network line of sight must temporarily reopen the registry before an IP allowlist can take effect.
 
 ```bash
 az acr update -n <acrName> --allow-exports true

--- a/docs/governance/infrastructure-governance.md
+++ b/docs/governance/infrastructure-governance.md
@@ -1,7 +1,7 @@
 # Infrastructure Governance and Compliance Guidelines
 
-**Version**: 2.3
-**Last Updated**: 2026-04-07
+**Version**: 2.4
+**Last Updated**: 2026-04-08
 **Owner**: Infrastructure Team
 
 ## Scope
@@ -63,8 +63,10 @@ Infrastructure provisioning, deployment orchestration, identity, security contro
 - Use Managed Identity and Entra-based federation for deployment identities.
 - Keep Key Vault as secret authority; no direct secret literals in IaC templates or workflows.
 - Enforce RBAC-scoped assignments for deployment principal operations.
+- The GitHub OIDC deploy principal (`AZURE_CLIENT_ID`) must retain permission to write RBAC assignments at the environment scope so `deploy-azd.yml` can idempotently ensure `Azure Kubernetes Service RBAC Cluster Admin` on the environment resource group and `AcrPush` on the environment ACR.
 - Use private networking posture for backend services where configured.
 - Protected live validation must use GitHub-hosted runners plus OIDC-backed Azure auth; do not rely on self-hosted managed-identity runners for this public repository path.
+- GitHub-hosted runners do not have private network line of sight to a private-only ACR. When `autoAllowAcrRunnerIp=true` and `publicNetworkAccess=Disabled`, `deploy-azd.yml` may temporarily enable the registry public endpoint with `defaultAction=Deny`, reuse the existing runner-IP allowlist behavior for the active build window, and then restore the original ACR public-access state.
 
 ## Runtime Deployment Controls
 
@@ -74,9 +76,11 @@ Infrastructure provisioning, deployment orchestration, identity, security contro
 - APIM backends must not target pod IPs, node IPs, `ClusterIP` addresses, or `*.svc.cluster.local` names.
 - AKS services published through APIM must remain `ClusterIP` unless a newer accepted ADR documents an exception.
 - CRUD-first sequencing before dependent agent rollouts.
+- Before `build-aks-images` runs, the reusable deploy workflow must verify or create `AcrPush` for the OIDC deploy principal at the environment ACR scope.
 - AKS service deployment must build or resolve immutable per-SHA images first, then render/apply manifests pinned by digest (`repo@sha256:...`); deploy jobs must not rebuild service images during manifest rollout.
 - Changed-service detection to reduce blast radius and deployment duration.
 - Reusable deploy workflows must accept an explicit tested source SHA/ref and use that checkout consistently across detection, build, render, sync, and validation jobs.
+- ACR login in tested-image build jobs must use the OIDC Azure CLI session and bounded retry with actionable failure text to absorb ARM-to-data-plane RBAC propagation delay; admin-user and static registry credentials are prohibited.
 - Push-event changed-service detection must diff `${{ github.event.before }}...${{ github.sha }}` to avoid empty comparisons against `origin/main` after merge.
 - APIM sync/smoke checks for API path health after relevant changes.
 - Deployment workflows must validate AGC GatewayClass readiness and direct CRUD `/health` reachability on the approved AGC frontend hostname before APIM sync.
@@ -90,7 +94,8 @@ Infrastructure provisioning, deployment orchestration, identity, security contro
 - A changed agent service is a hard deployment failure when any Foundry contract seam drifts: missing rendered keys, rendered-versus-live env mismatch, ensure responses without resolved `fast` and `rich` agent ids, or `/ready` responses that remain healthy while the strict Foundry contract is not actually enforced.
 - During migration, legacy AGIC or Web App Routing configuration may exist only as transitional state and must not be described as the target architecture.
 - Optional UI-only deployment path constrained by SWA token flow and health checks.
-- ACR network-rule temporary exceptions may be applied/removed automatically when enabled.
+- ACR runner-IP allowlist exceptions may be applied/removed automatically when enabled.
+- If the environment ACR public endpoint is disabled, the tested-image build guard must temporarily enable public access with `defaultAction=Deny`, reuse the runner-IP allowlist flow, and restore the prior `publicNetworkAccess` and `networkRuleSet.defaultAction` after the build phase completes.
 
 ## Data Connectivity Guardrails
 


### PR DESCRIPTION
## Summary
- temporarily reopen a private-only ACR for GitHub-hosted tested-image builds when autoAllowAcrRunnerIp is enabled
- keep the OIDC deploy principal AcrPush guard and bounded ACR login retry in the reusable deploy workflow
- restore the original ACR public-access posture after the build phase and document the control in deployment governance

Closes #727
