### PR TITLE
ci: allow targeted dev redeploys without provision

### DIFF
--- a/.github/workflows/deploy-azd-dev.yml
+++ b/.github/workflows/deploy-azd-dev.yml
@@ -30,6 +30,15 @@ on:
         description: Optional tested source ref to deploy (empty = current ref)
         required: false
         default: ''
+      skipProvision:
+        description: Skip azd provision and reuse the current dev infrastructure for a manual emergency redeploy
+        required: true
+        type: boolean
+        default: false
+      serviceFilter:
+        description: Optional comma-separated AKS service names to deploy (empty = all changed services)
+        required: false
+        default: ''
       deployStatic:
         description: Provision static web app resources
         required: true
@@ -86,6 +95,8 @@ jobs:
       uiOnly: ${{ github.event_name == 'workflow_dispatch' && inputs.uiOnly }}
       apiBaseUrl: ${{ github.event_name == 'workflow_dispatch' && inputs.apiBaseUrl || '' }}
       deployChangedOnly: true
+      skipProvision: ${{ github.event_name == 'workflow_dispatch' && inputs.skipProvision }}
+      serviceFilter: ${{ github.event_name == 'workflow_dispatch' && inputs.serviceFilter || '' }}
       forceApimSync: ${{ github.event_name != 'workflow_dispatch' || inputs.forceApimSync }}
       autoAllowAcrRunnerIp: ${{ github.event_name != 'workflow_dispatch' || inputs.autoAllowAcrRunnerIp }}
       skipApiSmokeChecks: ${{ github.event_name == 'workflow_dispatch' && inputs.skipApiSmokeChecks }}

--- a/.github/workflows/deploy-azd.yml
+++ b/.github/workflows/deploy-azd.yml
@@ -71,6 +71,11 @@ on:
         required: false
         type: string
         default: ''
+      skipProvision:
+        description: Skip azd provision and reuse the current azd environment plus existing infrastructure for an emergency redeploy
+        required: false
+        type: boolean
+        default: false
     secrets:
       AZURE_CLIENT_ID:
         required: true
@@ -616,7 +621,21 @@ jobs:
 
           echo "Event Hub and consumer group declarations are present in IaC."
 
+      - name: Validate skip-provision emergency redeploy mode
+        if: ${{ inputs.skipProvision }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "${{ inputs.environment }}" != "dev" ]; then
+            echo "skipProvision is reserved for manual dev emergency redeploys against already-provisioned infrastructure." >&2
+            exit 1
+          fi
+
+          echo "skipProvision=true: reusing the current azd environment values and existing infrastructure for this dev redeploy."
+
       - name: Provision infrastructure
+        if: ${{ !inputs.skipProvision }}
         shell: bash
         run: |
           set -euo pipefail

--- a/docs/README.md
+++ b/docs/README.md
@@ -51,7 +51,7 @@ Use environment-specific entry workflows:
 - `.github/workflows/protected-dev-live-agent-readiness.yml` runs protected live validation against dev after successful `deploy-azd-dev` runs on `main`, or by explicit manual/scheduled execution through the `dev` environment boundary.
 - `.github/workflows/ci.yml` publishes GHCR images automatically for stable tags (`v*.*.*`) and can still be run manually for build/optional publish.
 
-> Provisioning is mandatory before frontend/backend consumption in any environment. Always run `azd provision` (and then `azd deploy`) before validating APIs or UI integration.
+> Provisioning remains the default path for all automatic deploys and normal manual rollouts. The only approved exception is a manual dev emergency redeploy through `deploy-azd-dev.yml` with `skipProvision=true`, which reuses the current azd environment values and already-provisioned infrastructure while still running the reusable workflow's auth, guard, build, deploy, and smoke paths.
 
 **Required repository/environment secrets**:
 
@@ -67,7 +67,7 @@ Repository code establishes this environment-scoped secret boundary. The `dev` e
 
 **Entry workflow inputs**:
 
-- Dev entrypoint (`deploy-azd-dev.yml`): `location`, `projectName`, `imageTag`, `testedSourceSha`, `testedSourceRef`, `deployStatic`, `uiOnly`, `apiBaseUrl`, `forceApimSync`, `autoAllowAcrRunnerIp`.
+- Dev entrypoint (`deploy-azd-dev.yml`): `location`, `projectName`, `imageTag`, `testedSourceSha`, `testedSourceRef`, `skipProvision`, `serviceFilter`, `deployStatic`, `uiOnly`, `apiBaseUrl`, `forceApimSync`, `autoAllowAcrRunnerIp`, `skipApiSmokeChecks`.
 - Prod entrypoint (`deploy-azd-prod.yml`): no manual inputs; runs only from stable release tags and deploys using the tag name as `imageTag`.
 
 **Manual trigger examples**:
@@ -83,6 +83,14 @@ gh workflow run deploy-azd-dev.yml -f location=eastus2 -f projectName=holidaypea
 ```bash
 gh workflow run deploy-azd-dev.yml -f location=eastus2 -f projectName=holidaypeakhub405 -f imageTag=latest -f deployStatic=true -f forceApimSync=false -f autoAllowAcrRunnerIp=true
 ```
+
+- Manual dev emergency redeploy on already-provisioned infrastructure, scoped to a subset of AKS services:
+
+```bash
+gh workflow run deploy-azd-dev.yml -f location=eastus2 -f projectName=holidaypeakhub405 -f imageTag=latest -f skipProvision=true -f serviceFilter=ecommerce-catalog-search -f forceApimSync=true -f autoAllowAcrRunnerIp=true
+```
+
+Use this only when dev infrastructure already exists and the immediate goal is to redeploy specific runtime changes without reconciling shared infrastructure.
 
 - Production rollout (stable release tag + published GitHub Release):
 
@@ -110,6 +118,7 @@ Core workflow note: `.github/workflows/deploy-azd.yml` is reusable-only and not 
 
 - Keep `deployShared=true` for all shared-environment rollouts.
 - Dev AKS rollouts must use the tested source checkout plus immutable image digests (`repo@sha256:...`); deploy jobs render/apply Kubernetes manifests directly and must not rebuild service images inline.
+- `skipProvision=true` is a manual dev-only emergency path for already-provisioned infrastructure. It skips only the `azd provision` step; Azure login, azd environment setup, AKS/ACR/Key Vault guards, output export, image build, deploy, Foundry ensure, and downstream smoke/deploy gates remain active.
 - For GitHub-hosted tested-image builds, `autoAllowAcrRunnerIp=true` preserves OIDC-only auth and the existing ACR IP allowlist flow. If the environment registry is private-only (`publicNetworkAccess=Disabled`), the workflow temporarily reopens the public endpoint with `defaultAction=Deny`, scopes access to the current runner IP, and restores the original ACR public-access state immediately after the build phase.
 - For changed AKS agent services, treat the Foundry runtime contract as a blocking gate: expected `FOUNDRY_STRICT_ENFORCEMENT=true` and `FOUNDRY_AUTO_ENSURE_ON_STARTUP=true` must survive render and rollout, and `/ready` is only accepted when it matches successful Foundry ensure results.
 - UI deployment intentionally uses the SWA GitHub Action path (not `azd deploy --service ui`) so App Router dynamic segments (`[id]`, `[slug]`) are built in the same mode as standard SWA workflows.

--- a/docs/governance/infrastructure-governance.md
+++ b/docs/governance/infrastructure-governance.md
@@ -22,7 +22,7 @@ Infrastructure provisioning, deployment orchestration, identity, security contro
 
 ### Core policy
 
-- **azd-first deployment is mandatory** (ADR-021).
+- **azd-first deployment is mandatory** (ADR-021). The only approved exception is the manual dev emergency redeploy path in `deploy-azd-dev.yml` with `skipProvision=true`, which reuses already-provisioned infrastructure and skips only `azd provision`.
 - Reusable workflow `deploy-azd.yml` is not the primary operator entrypoint; use env-specific entrypoint workflows.
 - OIDC Azure login is required in CI/CD; no static cloud credentials committed to repository.
 - Provisioning must fail fast when `projectName` is not `holidaypeakhub405` or when `resourceGroupName`/`AZURE_RESOURCE_GROUP` are not `holidaypeakhub405-<environment>-rg`; this is enforced through azd `preprovision` hooks.
@@ -38,6 +38,7 @@ Infrastructure provisioning, deployment orchestration, identity, security contro
 | Main lineage gate | Not required | Required: tagged commit must be reachable from `main` | N/A |
 | Demo data seeding mode | Local/manual only (not part of CI deploy) | Local/manual only | Local/manual only |
 | Changed-only deployment | Enabled | Enabled | N/A |
+| Manual skip-provision redeploy | Allowed only through `workflow_dispatch` on `deploy-azd-dev.yml` for already-provisioned infrastructure; may optionally set `serviceFilter` to scope AKS services | Not exposed | Not exposed |
 | Force APIM sync default | `true` | `true` | N/A |
 | Auto allow ACR runner IP | `true` default | `false` default | N/A |
 | Non-prod drift remediation | Enabled | Disabled | Would be treated as non-prod if introduced |
@@ -79,7 +80,9 @@ Infrastructure provisioning, deployment orchestration, identity, security contro
 - Before `build-aks-images` runs, the reusable deploy workflow must verify or create `AcrPush` for the OIDC deploy principal at the environment ACR scope.
 - AKS service deployment must build or resolve immutable per-SHA images first, then render/apply manifests pinned by digest (`repo@sha256:...`); deploy jobs must not rebuild service images during manifest rollout.
 - Changed-service detection to reduce blast radius and deployment duration.
+- Manual dev emergency redeploys may set `serviceFilter` to scope AKS rollout to a comma-separated subset of already-defined services; services outside the filter remain untouched.
 - Reusable deploy workflows must accept an explicit tested source SHA/ref and use that checkout consistently across detection, build, render, sync, and validation jobs.
+- When the dev entrypoint explicitly sets `skipProvision=true`, the reusable deploy workflow may skip only the `azd provision` step. OIDC login, azd auth/context setup, AKS/ACR/Key Vault role guards, azd env output export, image build, deploy, Foundry ensure, and downstream smoke/deploy gates must remain active.
 - ACR login in tested-image build jobs must use the OIDC Azure CLI session and bounded retry with actionable failure text to absorb ARM-to-data-plane RBAC propagation delay; admin-user and static registry credentials are prohibited.
 - Push-event changed-service detection must diff `${{ github.event.before }}...${{ github.sha }}` to avoid empty comparisons against `origin/main` after merge.
 - APIM sync/smoke checks for API path health after relevant changes.


### PR DESCRIPTION
## Summary
- add a manual dev-only skipProvision path that reuses existing azd environment values and infrastructure for emergency redeploys
- expose serviceFilter on the dev entry workflow so manual redeploys can scope to specific AKS services
- preserve the existing OIDC, ACR, AKS, Foundry, and smoke-check guards while avoiding the current Event Hubs provision blocker

Closes #729
