### PR TITLE
ci: make update deploys image-only by default

### DIFF
--- a/.github/workflows/deploy-azd-dev.yml
+++ b/.github/workflows/deploy-azd-dev.yml
@@ -31,10 +31,10 @@ on:
         required: false
         default: ''
       skipProvision:
-        description: Skip azd provision and reuse the current dev infrastructure for a manual emergency redeploy
+        description: Reuse the current provisioned infrastructure and skip azd provision for normal code updates; set false only when infrastructure reconciliation is required
         required: true
         type: boolean
-        default: false
+        default: true
       serviceFilter:
         description: Optional comma-separated AKS service names to deploy (empty = all changed services)
         required: false
@@ -50,10 +50,20 @@ on:
         type: boolean
         default: false
       forceApimSync:
-        description: Force APIM sync and smoke checks even when no changed services are detected
+        description: Explicitly force APIM sync and smoke checks during an image-only update
+        required: true
+        type: boolean
+        default: false
+      autoAllowAcrRunnerIp:
+        description: Temporarily allow GitHub runner egress IP in ACR firewall during deploy and remove it afterward
         required: true
         type: boolean
         default: true
+      skipApiSmokeChecks:
+        description: Skip API smoke checks (use only for urgent UI-only rollouts)
+        required: true
+        type: boolean
+        default: false
 
 permissions:
   id-token: write
@@ -84,8 +94,8 @@ jobs:
       skipProvision: ${{ github.event_name != 'workflow_dispatch' || inputs.skipProvision }}
       serviceFilter: ${{ github.event_name == 'workflow_dispatch' && inputs.serviceFilter || '' }}
       forceApimSync: ${{ github.event_name == 'workflow_dispatch' && inputs.forceApimSync }}
-      autoAllowAcrRunnerIp: true
-      skipApiSmokeChecks: false
+      autoAllowAcrRunnerIp: ${{ github.event_name != 'workflow_dispatch' || inputs.autoAllowAcrRunnerIp }}
+      skipApiSmokeChecks: ${{ github.event_name == 'workflow_dispatch' && inputs.skipApiSmokeChecks }}
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/deploy-azd-prod.yml
+++ b/.github/workflows/deploy-azd-prod.yml
@@ -64,7 +64,8 @@ jobs:
       uiOnly: false
       apiBaseUrl: ''
       deployChangedOnly: true
-      forceApimSync: true
+      skipProvision: true
+      forceApimSync: false
       autoAllowAcrRunnerIp: false
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}

--- a/.github/workflows/deploy-azd-truth.yml
+++ b/.github/workflows/deploy-azd-truth.yml
@@ -16,10 +16,10 @@ on:
         required: true
         default: latest
       forceApimSync:
-        description: Force APIM sync after deploying truth agents
+        description: Explicitly force APIM sync after deploying truth agents during an image-only update
         required: true
         type: boolean
-        default: true
+        default: false
       autoAllowAcrRunnerIp:
         description: Temporarily allow GitHub runner egress IP in ACR firewall during deploy
         required: true
@@ -50,6 +50,7 @@ jobs:
       uiOnly: false
       apiBaseUrl: ''
       deployChangedOnly: true
+      skipProvision: true
       forceApimSync: ${{ inputs.forceApimSync }}
       autoAllowAcrRunnerIp: ${{ inputs.autoAllowAcrRunnerIp }}
       skipApiSmokeChecks: false

--- a/.github/workflows/deploy-azd.yml
+++ b/.github/workflows/deploy-azd.yml
@@ -72,7 +72,7 @@ on:
         type: string
         default: ''
       skipProvision:
-        description: Skip azd provision and reuse the current azd environment plus existing infrastructure for an emergency redeploy
+        description: Skip azd provision and reuse the current azd environment plus existing infrastructure for image-only code updates
         required: false
         type: boolean
         default: false
@@ -690,7 +690,7 @@ jobs:
 
           echo "Event Hub and consumer group declarations are present in IaC."
 
-      - name: Validate skip-provision mode
+      - name: Validate image-only update mode
         if: ${{ inputs.skipProvision }}
         shell: bash
         run: |
@@ -702,7 +702,7 @@ jobs:
             echo "::warning::skipProvision is active but infrastructure files changed. Provisioning will be skipped. If you need infra reconciliation, rerun with skipProvision=false."
           fi
 
-          echo "skipProvision=true: reusing the current azd environment values and existing infrastructure for this deploy."
+          echo "skipProvision=true: reusing the current azd environment values and existing infrastructure for this image-only update."
 
       - name: Provision infrastructure
         if: ${{ !inputs.skipProvision }}
@@ -1657,10 +1657,10 @@ jobs:
 
   deploy-foundry-models:
     runs-on: ubuntu-latest
+    if: ${{ !inputs.uiOnly && !inputs.skipProvision && needs.detect-changes.outputs.agents_changed == 'true' }}
     needs:
       - provision
       - detect-changes
-    if: ${{ !inputs.skipProvision && needs.detect-changes.outputs.infra_changed == 'true' }}
     environment: ${{ inputs.environment }}
     env:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
@@ -2671,7 +2671,7 @@ jobs:
 
   validate-agc-readiness:
     runs-on: ubuntu-latest
-    if: ${{ always() && !cancelled() && !inputs.uiOnly && (inputs.forceApimSync || needs.detect-changes.outputs.changed_agent_services_csv != '' || needs.detect-changes.outputs.crud_changed == 'true' || needs.detect-changes.outputs.ui_changed == 'true') && (needs.deploy-crud.result == 'success' || needs.deploy-crud.result == 'skipped') && (needs.deploy-agents.result == 'success' || needs.deploy-agents.result == 'skipped') }}
+    if: ${{ always() && !cancelled() && !inputs.uiOnly && inputs.forceApimSync && (needs.deploy-crud.result == 'success' || needs.deploy-crud.result == 'skipped') && (needs.deploy-agents.result == 'success' || needs.deploy-agents.result == 'skipped') }}
     needs:
       - provision
       - deploy-crud
@@ -2810,7 +2810,7 @@ jobs:
 
   sync-apim:
     runs-on: ubuntu-latest
-    if: ${{ always() && !cancelled() && !inputs.uiOnly && (inputs.forceApimSync || needs.detect-changes.outputs.changed_agent_services_csv != '' || needs.detect-changes.outputs.crud_changed == 'true' || needs.detect-changes.outputs.ui_changed == 'true') && (needs.deploy-crud.result == 'success' || needs.deploy-crud.result == 'skipped') && (needs.deploy-agents.result == 'success' || needs.deploy-agents.result == 'skipped') && needs.validate-agc-readiness.result == 'success' }}
+    if: ${{ always() && !cancelled() && !inputs.uiOnly && inputs.forceApimSync && (needs.deploy-crud.result == 'success' || needs.deploy-crud.result == 'skipped') && (needs.deploy-agents.result == 'success' || needs.deploy-agents.result == 'skipped') && needs.validate-agc-readiness.result == 'success' }}
     needs:
       - deploy-crud
       - deploy-agents
@@ -2821,7 +2821,7 @@ jobs:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-      CHANGED_SERVICES: ${{ needs.detect-changes.outputs.changed_aks_services_csv != '' && needs.detect-changes.outputs.changed_aks_services_csv || (needs.detect-changes.outputs.ui_changed == 'true' && 'crud-service' || '') }}
+      CHANGED_SERVICES: ${{ needs.detect-changes.outputs.changed_aks_services_csv }}
       APIM_APPROVED_BACKEND_HOSTNAMES: ${{ needs.validate-agc-readiness.outputs.approved_backend_hostnames }}
       APIM_APPROVED_BACKEND_SCHEME: ${{ needs.validate-agc-readiness.outputs.approved_backend_scheme }}
     steps:
@@ -2912,7 +2912,7 @@ jobs:
 
   smoke-apim:
     runs-on: ubuntu-latest
-    if: ${{ always() && !cancelled() && !inputs.uiOnly && (inputs.forceApimSync || needs.detect-changes.outputs.changed_agent_services_csv != '' || needs.detect-changes.outputs.crud_changed == 'true' || needs.detect-changes.outputs.ui_changed == 'true') && needs.validate-agc-readiness.result == 'success' && (needs.sync-apim.result == 'success' || needs.sync-apim.result == 'skipped') && (needs.ensure-foundry-agents.result == 'success' || needs.ensure-foundry-agents.result == 'skipped') }}
+    if: ${{ always() && !cancelled() && !inputs.uiOnly && inputs.forceApimSync && needs.validate-agc-readiness.result == 'success' && (needs.sync-apim.result == 'success' || needs.sync-apim.result == 'skipped') && (needs.ensure-foundry-agents.result == 'success' || needs.ensure-foundry-agents.result == 'skipped') }}
     needs:
       - detect-changes
       - sync-apim

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@
 - AKS deployments migrated to Flux CD GitOps (PR #785 / ADR-033).
 - Self-healing epic complete (PR #771): incident lifecycle kernel, remediation policy, and audit trail across all agent surfaces.
 - CRUD Entra ID auth rollout contracts hardened (PR #776).
+- Update entrypoints now treat routine code updates as image-only deploys by default: they reuse already-provisioned infrastructure, skip `azd provision`, and leave APIM sync plus Foundry model deployment as explicit reconciliation actions instead of normal rollout side effects.
 - Validation status: **1796 tests passed** (1136 lib + 660 app), 0 failures.
 - 35 Architecture Decision Records (ADR-001 through ADR-035).
 
@@ -51,7 +52,7 @@ Use environment-specific entry workflows:
 - `.github/workflows/protected-dev-live-agent-readiness.yml` runs protected live validation against dev after successful `deploy-azd-dev` runs on `main`, or by explicit manual/scheduled execution through the `dev` environment boundary.
 - `.github/workflows/ci.yml` publishes GHCR images automatically for stable tags (`v*.*.*`) and can still be run manually for build/optional publish.
 
-> Provisioning remains the default path for all automatic deploys and normal manual rollouts. The only approved exception is a manual dev emergency redeploy through `deploy-azd-dev.yml` with `skipProvision=true`, which reuses the current azd environment values and already-provisioned infrastructure while still running the reusable workflow's auth, guard, build, deploy, and smoke paths.
+> Routine update entrypoints now default to image-only deploys. They reuse the current azd environment values and already-provisioned infrastructure with `skipProvision=true`, while still running the reusable workflow's auth, guard, build, deploy, and health-validation paths. Explicit infrastructure reconciliation remains opt-in by setting `skipProvision=false` on the dev entrypoint.
 
 **Required repository/environment secrets**:
 
@@ -75,22 +76,22 @@ Repository code establishes this environment-scoped secret boundary. The `dev` e
 - Day-to-day development rollout (recommended default):
 
 ```bash
-gh workflow run deploy-azd-dev.yml -f location=eastus2 -f projectName=holidaypeakhub405 -f imageTag=latest -f deployStatic=true -f autoAllowAcrRunnerIp=true
+gh workflow run deploy-azd-dev.yml -f location=eastus2 -f projectName=holidaypeakhub405 -f imageTag=latest -f skipProvision=true -f deployStatic=true -f autoAllowAcrRunnerIp=true
 ```
 
-- Fast development rerun without APIM sync:
+- Development rerun that also reconciles infrastructure and APIM explicitly:
 
 ```bash
-gh workflow run deploy-azd-dev.yml -f location=eastus2 -f projectName=holidaypeakhub405 -f imageTag=latest -f deployStatic=true -f forceApimSync=false -f autoAllowAcrRunnerIp=true
+gh workflow run deploy-azd-dev.yml -f location=eastus2 -f projectName=holidaypeakhub405 -f imageTag=latest -f skipProvision=false -f forceApimSync=true -f deployStatic=true -f autoAllowAcrRunnerIp=true
 ```
 
-- Manual dev emergency redeploy on already-provisioned infrastructure, scoped to a subset of AKS services:
+- Manual dev image-only redeploy on already-provisioned infrastructure, scoped to a subset of AKS services:
 
 ```bash
-gh workflow run deploy-azd-dev.yml -f location=eastus2 -f projectName=holidaypeakhub405 -f imageTag=latest -f skipProvision=true -f serviceFilter=ecommerce-catalog-search -f forceApimSync=true -f autoAllowAcrRunnerIp=true
+gh workflow run deploy-azd-dev.yml -f location=eastus2 -f projectName=holidaypeakhub405 -f imageTag=latest -f skipProvision=true -f serviceFilter=ecommerce-catalog-search -f forceApimSync=false -f autoAllowAcrRunnerIp=true
 ```
 
-Use this only when dev infrastructure already exists and the immediate goal is to redeploy specific runtime changes without reconciling shared infrastructure.
+Use this when dev infrastructure already exists and the immediate goal is to redeploy specific runtime changes without reconciling shared infrastructure or APIM configuration.
 
 - Production rollout (stable release tag + published GitHub Release):
 
@@ -105,12 +106,12 @@ Core workflow note: `.github/workflows/deploy-azd.yml` is reusable-only and not 
 
 **Execution order**:
 
-1. `provision` job: sets azd env values, runs `azd provision`, and idempotently ensures the OIDC deploy principal has `Azure Kubernetes Service RBAC Cluster Admin` on the environment resource group plus `AcrPush` on the environment ACR.
+1. `provision` job: sets azd env values and idempotently ensures the OIDC deploy principal has `Azure Kubernetes Service RBAC Cluster Admin` on the environment resource group plus `AcrPush` on the environment ACR. It runs `azd provision` only when the entrypoint requests explicit infrastructure reconciliation (`skipProvision=false`).
 2. `build-aks-images` job: builds changed AKS workloads from the tested source SHA into the existing ACR (or reuses an existing per-SHA image), retries `az acr login` with bounded backoff to absorb RBAC propagation delay, and then records immutable digest refs for downstream deploy jobs. When `autoAllowAcrRunnerIp=true`, the workflow also reuses the existing runner-IP allowlist path; if the ACR public endpoint is disabled, it first enables public access with `defaultAction=Deny`, adds only the active GitHub-hosted runner IP, and restores the original public-access setting after the build phase. This is required because disabling ACR public network access overrides firewall rules, and GitHub-hosted runners do not have private network line of sight to a private-only registry.
 3. `deploy-crud` job: renders and applies the `crud-service` Helm manifest pinned to the tested image digest when CRUD/lib changes are detected.
-4. `deploy-foundry-models` and `deploy-agents` jobs: run after provision; `deploy-agents` deploys changed agent services from prebuilt digest-pinned manifests (and can proceed when `deploy-crud` is skipped for agent-only changes).
+4. `deploy-foundry-models` and `deploy-agents` jobs: `deploy-agents` deploys changed agent services from prebuilt digest-pinned manifests (and can proceed when `deploy-crud` is skipped for agent-only changes). `deploy-foundry-models` only runs during explicit infrastructure reconciliation when changed agent services also require model-deployment reconciliation.
 5. `ensure-foundry-agents` job: re-renders changed agent manifests with the workflow's strict/auto-ensure contract, compares rendered env values against live AKS Deployments, then validates `POST /foundry/agents/ensure` plus `/ready` for each changed agent service.
-6. `sync-apim` and `smoke-apim` jobs: run when CRUD/agent changes are present or `forceApimSync=true`.
+6. `sync-apim` and `smoke-apim` jobs: run only when `forceApimSync=true`.
 7. `deploy-ui` job (when `deployStatic=true`): runs after APIM sync/smoke gates, resolves APIM URL with fail-fast validation, fetches the SWA deployment token from Azure, and deploys `apps/ui` via `Azure/static-web-apps-deploy@v1` (framework-aware build for dynamic Next.js routes).
 8. Demo data seeding is operator-driven and must be run locally (outside CI) when needed.
 
@@ -118,8 +119,10 @@ Core workflow note: `.github/workflows/deploy-azd.yml` is reusable-only and not 
 
 - Keep `deployShared=true` for all shared-environment rollouts.
 - Dev AKS rollouts must use the tested source checkout plus immutable image digests (`repo@sha256:...`); deploy jobs render/apply Kubernetes manifests directly and must not rebuild service images inline.
-- `skipProvision=true` is a manual dev-only emergency path for already-provisioned infrastructure. It skips only the `azd provision` step; Azure login, azd environment setup, AKS/ACR/Key Vault guards, output export, image build, deploy, Foundry ensure, and downstream smoke/deploy gates remain active.
+- Routine update entrypoints use `skipProvision=true` by default for already-provisioned environments. This skips only the `azd provision` step; Azure login, azd environment setup, AKS/ACR/Key Vault guards, output export, image build, deploy, Foundry ensure, and downstream health gates remain active.
+- Set `skipProvision=false` only when an operator explicitly wants infrastructure reconciliation as part of the deploy.
 - For GitHub-hosted tested-image builds, `autoAllowAcrRunnerIp=true` preserves OIDC-only auth and the existing ACR IP allowlist flow. If the environment registry is private-only (`publicNetworkAccess=Disabled`), the workflow temporarily reopens the public endpoint with `defaultAction=Deny`, scopes access to the current runner IP, and restores the original ACR public-access state immediately after the build phase.
+- `forceApimSync=false` is now the normal update posture. Set it to `true` only when an operator intends to reconcile APIM configuration as part of the rollout.
 - For changed AKS agent services, treat the Foundry runtime contract as a blocking gate: expected `FOUNDRY_STRICT_ENFORCEMENT=true` and `FOUNDRY_AUTO_ENSURE_ON_STARTUP=true` must survive render and rollout, and `/ready` is only accepted when it matches successful Foundry ensure results.
 - UI deployment intentionally uses the SWA GitHub Action path (not `azd deploy --service ui`) so App Router dynamic segments (`[id]`, `[slug]`) are built in the same mode as standard SWA workflows.
 - Frontend API calls must always use APIM via validated runtime env aliases (`NEXT_PUBLIC_API_URL` and `NEXT_PUBLIC_CRUD_API_URL` are set together in deployment workflows).

--- a/docs/governance/infrastructure-governance.md
+++ b/docs/governance/infrastructure-governance.md
@@ -22,7 +22,7 @@ Infrastructure provisioning, deployment orchestration, identity, security contro
 
 ### Core policy
 
-- **azd-first deployment is mandatory** (ADR-021). The only approved exception is the manual dev emergency redeploy path in `deploy-azd-dev.yml` with `skipProvision=true`, which reuses already-provisioned infrastructure and skips only `azd provision`.
+- **azd-first deployment is mandatory** (ADR-021). Routine update entrypoints use image-only deploys by default: they set `skipProvision=true`, reuse already-provisioned infrastructure, and skip only `azd provision`. Explicit infrastructure reconciliation remains opt-in.
 - Reusable workflow `deploy-azd.yml` is not the primary operator entrypoint; use env-specific entrypoint workflows.
 - OIDC Azure login is required in CI/CD; no static cloud credentials committed to repository.
 - Provisioning must fail fast when `projectName` is not `holidaypeakhub405` or when `resourceGroupName`/`AZURE_RESOURCE_GROUP` are not `holidaypeakhub405-<environment>-rg`; this is enforced through azd `preprovision` hooks.
@@ -38,10 +38,10 @@ Infrastructure provisioning, deployment orchestration, identity, security contro
 | Main lineage gate | Not required | Required: tagged commit must be reachable from `main` | N/A |
 | Demo data seeding mode | Local/manual only (not part of CI deploy) | Local/manual only | Local/manual only |
 | Changed-only deployment | Enabled | Enabled | N/A |
-| Manual skip-provision redeploy | Allowed only through `workflow_dispatch` on `deploy-azd-dev.yml` for already-provisioned infrastructure; may optionally set `serviceFilter` to scope AKS services | Not exposed | Not exposed |
-| Force APIM sync default | `true` | `true` | N/A |
+| Skip-provision update mode | Default for routine `workflow_run` and `workflow_dispatch` code updates on `deploy-azd-dev.yml`; set `skipProvision=false` only when explicit infrastructure reconciliation is required. May optionally set `serviceFilter` to scope AKS services | Enabled by default in `deploy-azd-prod.yml` tag updates; infrastructure reconciliation is not part of the release update path | Would follow the same image-only update policy if introduced |
+| Force APIM sync default | `false` | `false` | N/A |
 | Auto allow ACR runner IP | `true` default | `false` default | N/A |
-| Non-prod drift remediation | Enabled | Disabled | Would be treated as non-prod if introduced |
+| Non-prod drift remediation | Disabled in the normal update path; use explicit infrastructure reconciliation when drift must be addressed | Disabled | Would be treated the same if introduced |
 
 ### Workflow deduplication policy
 
@@ -80,13 +80,12 @@ Infrastructure provisioning, deployment orchestration, identity, security contro
 - Before `build-aks-images` runs, the reusable deploy workflow must verify or create `AcrPush` for the OIDC deploy principal at the environment ACR scope.
 - AKS service deployment must build or resolve immutable per-SHA images first, then render/apply manifests pinned by digest (`repo@sha256:...`); deploy jobs must not rebuild service images during manifest rollout.
 - Changed-service detection to reduce blast radius and deployment duration.
-- Manual dev emergency redeploys may set `serviceFilter` to scope AKS rollout to a comma-separated subset of already-defined services; services outside the filter remain untouched.
+- Image-only update entrypoints may set `serviceFilter` to scope AKS rollout to a comma-separated subset of already-defined services; services outside the filter remain untouched.
 - Reusable deploy workflows must accept an explicit tested source SHA/ref and use that checkout consistently across detection, build, render, sync, and validation jobs.
-- When the dev entrypoint explicitly sets `skipProvision=true`, the reusable deploy workflow may skip only the `azd provision` step. OIDC login, azd auth/context setup, AKS/ACR/Key Vault role guards, azd env output export, image build, deploy, Foundry ensure, and downstream smoke/deploy gates must remain active.
+- When an update entrypoint sets `skipProvision=true`, the reusable deploy workflow may skip only the `azd provision` step. OIDC login, azd auth/context setup, AKS/ACR/Key Vault role guards, azd env output export, image build, deploy, Foundry ensure, and downstream health gates must remain active.
 - ACR login in tested-image build jobs must use the OIDC Azure CLI session and bounded retry with actionable failure text to absorb ARM-to-data-plane RBAC propagation delay; admin-user and static registry credentials are prohibited.
 - Push-event changed-service detection must diff `${{ github.event.before }}...${{ github.sha }}` to avoid empty comparisons against `origin/main` after merge.
-- APIM sync/smoke checks for API path health after relevant changes.
-- Deployment workflows must validate AGC GatewayClass readiness and direct CRUD `/ready` reachability on the approved AGC frontend hostname before APIM sync so PostgreSQL, Redis, and Cosmos dependency regressions fail rollout validation.
+- APIM sync/smoke checks are explicit reconciliation actions triggered when an entrypoint sets `forceApimSync=true`; when active, deployment workflows must validate AGC GatewayClass readiness and direct CRUD `/ready` reachability on the approved AGC frontend hostname before APIM sync so PostgreSQL, Redis, and Cosmos dependency regressions fail rollout validation.
 - APIM sync determinism is required: ingress sync must resolve against an explicit AGC target in workflow execution.
 - APIM smoke coverage must include direct AGC CRUD health, APIM CRUD health, CRUD CORS preflight behavior, and at least one negative CRUD path that proves failures are not masked as upstream 5xx responses.
 - Transitional workflow or manifest logic may still detect legacy ingress classes during migration, but AGC is the canonical target state and must take precedence in governance and cutover planning.
@@ -96,6 +95,7 @@ Infrastructure provisioning, deployment orchestration, identity, security contro
 - Helm render hooks must not inject a passwordless `REDIS_URL` when `REDIS_HOST` is available for deployed services; that contract would bypass the runtime Key Vault resolution path for Redis credentials and can surface false-ready process health with broken hot-memory access.
 - Agent-service deployments must enforce the Foundry runtime contract end to end: workflow intent currently requires `FOUNDRY_STRICT_ENFORCEMENT=true` and `FOUNDRY_AUTO_ENSURE_ON_STARTUP=true`, render hooks must emit both keys into Helm output, and the post-deploy gate must compare workflow intent, rendered manifests, live Deployment env values, `POST /foundry/agents/ensure`, and live `/ready` behavior for each changed agent service.
 - A changed agent service is a hard deployment failure when any Foundry contract seam drifts: missing rendered keys, rendered-versus-live env mismatch, ensure responses without resolved `fast` and `rich` agent ids, or `/ready` responses that remain healthy while the strict Foundry contract is not actually enforced.
+- Foundry model deployment is not part of the normal image-only update path; run it only during explicit reconciliation when changed agent services require model or project updates.
 - During migration, legacy AGIC or Web App Routing configuration may exist only as transitional state and must not be described as the target architecture.
 - Optional UI-only deployment path constrained by SWA token flow and health checks.
 - ACR runner-IP allowlist exceptions may be applied/removed automatically when enabled.


### PR DESCRIPTION
## Summary
- make update entrypoints reuse existing infrastructure and skip zd provision by default
- make APIM sync and smoke checks explicit via orceApimSync=true instead of a routine update side effect
- limit Foundry model deployment to explicit reconciliation runs while keeping image build and rollout paths intact
- update the deployment runbook and infrastructure governance docs to reflect the new image-only update policy

## Validation
- verified workflow files with get_errors and found no editor errors in the edited YAML files
- git diff --check
- branch push completed through the repository pre-push lint and test gates

## Notes
- lib fan-out remains intact: lib/ changes still redeploy CRUD plus all agent services
- CRUD-first rollout ordering remains unchanged in this PR; image builds remain parallel and agent deploys remain parallel within their matrix

Closes #733
