### PR TITLE
chore(ci): AKS DNS probe + SAGA compensation ADR update

### DIFF
--- a/.github/workflows/deploy-azd.yml
+++ b/.github/workflows/deploy-azd.yml
@@ -1390,6 +1390,25 @@ jobs:
             --name "${{ inputs.projectName }}-${{ inputs.environment }}-aks" \
             --overwrite-existing
 
+      - name: Verify AKS API connectivity
+        shell: bash
+        run: |
+          set -euo pipefail
+          AKS_FQDN=$(kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}' | sed 's|https://||;s|:.*||')
+          echo "Probing AKS API server DNS: $AKS_FQDN"
+          for attempt in $(seq 1 10); do
+            if kubectl cluster-info >/dev/null 2>&1; then
+              echo "AKS API reachable (attempt $attempt)."
+              exit 0
+            fi
+            BACKOFF=$((5 * attempt))
+            echo "Attempt $attempt/10 failed (DNS or TCP). Retrying in ${BACKOFF}s..."
+            sleep "$BACKOFF"
+          done
+          echo "AKS API DNS resolution failed after 10 attempts for $AKS_FQDN." >&2
+          nslookup "$AKS_FQDN" || true
+          exit 1
+
       - name: Resolve AKS managed identity client ID
         run: |
           AKS_MI_CLIENT_ID=$(az aks show \
@@ -2085,6 +2104,25 @@ jobs:
             --name "${{ inputs.projectName }}-${{ inputs.environment }}-aks" \
             --overwrite-existing
 
+      - name: Verify AKS API connectivity
+        shell: bash
+        run: |
+          set -euo pipefail
+          AKS_FQDN=$(kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}' | sed 's|https://||;s|:.*||')
+          echo "Probing AKS API server DNS: $AKS_FQDN"
+          for attempt in $(seq 1 10); do
+            if kubectl cluster-info >/dev/null 2>&1; then
+              echo "AKS API reachable (attempt $attempt)."
+              exit 0
+            fi
+            BACKOFF=$((5 * attempt))
+            echo "Attempt $attempt/10 failed (DNS or TCP). Retrying in ${BACKOFF}s..."
+            sleep "$BACKOFF"
+          done
+          echo "AKS API DNS resolution failed after 10 attempts for $AKS_FQDN." >&2
+          nslookup "$AKS_FQDN" || true
+          exit 1
+
       - name: Resolve AKS managed identity client ID
         run: |
           AKS_MI_CLIENT_ID=$(az aks show \
@@ -2238,6 +2276,25 @@ jobs:
             --name "${{ inputs.projectName }}-${{ inputs.environment }}-aks" \
             --overwrite-existing
 
+      - name: Verify AKS API connectivity
+        shell: bash
+        run: |
+          set -euo pipefail
+          AKS_FQDN=$(kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}' | sed 's|https://||;s|:.*||')
+          echo "Probing AKS API server DNS: $AKS_FQDN"
+          for attempt in $(seq 1 10); do
+            if kubectl cluster-info >/dev/null 2>&1; then
+              echo "AKS API reachable (attempt $attempt)."
+              exit 0
+            fi
+            BACKOFF=$((5 * attempt))
+            echo "Attempt $attempt/10 failed (DNS or TCP). Retrying in ${BACKOFF}s..."
+            sleep "$BACKOFF"
+          done
+          echo "AKS API DNS resolution failed after 10 attempts for $AKS_FQDN." >&2
+          nslookup "$AKS_FQDN" || true
+          exit 1
+
       - name: Validate AGC gateway class and direct CRUD health
         shell: bash
         run: |
@@ -2302,6 +2359,25 @@ jobs:
             --resource-group "${{ inputs.projectName }}-${{ inputs.environment }}-rg" \
             --name "${{ inputs.projectName }}-${{ inputs.environment }}-aks" \
             --overwrite-existing
+
+      - name: Verify AKS API connectivity
+        shell: bash
+        run: |
+          set -euo pipefail
+          AKS_FQDN=$(kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}' | sed 's|https://||;s|:.*||')
+          echo "Probing AKS API server DNS: $AKS_FQDN"
+          for attempt in $(seq 1 10); do
+            if kubectl cluster-info >/dev/null 2>&1; then
+              echo "AKS API reachable (attempt $attempt)."
+              exit 0
+            fi
+            BACKOFF=$((5 * attempt))
+            echo "Attempt $attempt/10 failed (DNS or TCP). Retrying in ${BACKOFF}s..."
+            sleep "$BACKOFF"
+          done
+          echo "AKS API DNS resolution failed after 10 attempts for $AKS_FQDN." >&2
+          nslookup "$AKS_FQDN" || true
+          exit 1
 
       - name: Sync APIM agent APIs
         run: |
@@ -2580,6 +2656,25 @@ jobs:
             --resource-group "${{ inputs.projectName }}-${{ inputs.environment }}-rg" \
             --name "${{ inputs.projectName }}-${{ inputs.environment }}-aks" \
             --overwrite-existing
+
+      - name: Verify AKS API connectivity
+        shell: bash
+        run: |
+          set -euo pipefail
+          AKS_FQDN=$(kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}' | sed 's|https://||;s|:.*||')
+          echo "Probing AKS API server DNS: $AKS_FQDN"
+          for attempt in $(seq 1 10); do
+            if kubectl cluster-info >/dev/null 2>&1; then
+              echo "AKS API reachable (attempt $attempt)."
+              exit 0
+            fi
+            BACKOFF=$((5 * attempt))
+            echo "Attempt $attempt/10 failed (DNS or TCP). Retrying in ${BACKOFF}s..."
+            sleep "$BACKOFF"
+          done
+          echo "AKS API DNS resolution failed after 10 attempts for $AKS_FQDN." >&2
+          nslookup "$AKS_FQDN" || true
+          exit 1
 
       - name: Ensure hook scripts executable
         shell: bash

--- a/docs/architecture/adrs/adr-007-saga-choreography.md
+++ b/docs/architecture/adrs/adr-007-saga-choreography.md
@@ -11,20 +11,52 @@ Services must coordinate across domains (e.g., order placement → inventory res
 
 **Use SAGA choreography pattern with Azure Event Hubs** for async service coordination.
 
-## Implementation Status (2026-03-19)
+## Implementation Status (2026-04-09)
 
-- **Implemented in part**: Event-driven pub/sub is active across CRUD and agent services through Azure Event Hubs producers, subscriptions, and lifespan wiring.
-- **Coverage is mixed by topic**: Some topics are fully aligned publisher/subscriber paths, while others remain partially wired or intentionally pending.
-- **Canonical coverage contract**: Topic-level topology status and wiring gaps are maintained in [Event Hub topology matrix](../eventhub-topology-matrix.md) and governed by issue #299.
-- **Deferred/diverged**: Full end-to-end business sagas with uniform compensating transactions are not consistently implemented across domains; compensation remains service-specific.
+- **Implemented**: Event-driven pub/sub is active across CRUD and agent services through Azure Event Hubs producers, subscriptions, and lifespan wiring.
+- **Namespace split complete**: Retail choreography topics bind to `EVENT_HUB_NAMESPACE`; platform job topics bind to `PLATFORM_JOBS_EVENT_HUB_NAMESPACE` (#735 closed).
+- **Canonical coverage contract**: Topic-level topology status and wiring coverage tracked in [Event Hub topology matrix](../eventhub-topology-matrix.md).
+- **Compensation framework**: Standardized in `holiday_peak_lib.utils.compensation` with `CompensationAction`, `CompensationResult`, and `execute_compensation`. Inventory reservation rollback serves as the reference integration path.
+- **Event envelope versioning**: All retail and connector envelopes carry `schema_version: "1.0"` and are validated by `check_event_schema_contracts.py` in CI and pre-push.
 
-## Gap Tracking (2026-03-21)
+## Compensation Semantics by Domain
 
-The following implementation gaps are explicitly tracked as separate issues:
+| Domain | Compensation path | Status |
+|--------|------------------|--------|
+| Inventory | `execute_compensation` on reservation failure rolls back stock holds | Implemented (#447) |
+| Checkout | Client-side cart rollback on payment/reservation failure | Implemented |
+| Order | CRUD order status set to `cancelled`; no cross-service undo | Partial — manual |
+| Logistics | No automated compensation; shipment cancellation is manual | Deferred |
+| CRM | Stateless event consumers; no compensation needed | N/A |
+
+## Event Topology Migration Policy
+
+### Compatibility window
+
+When adding, renaming, or retiring an Event Hub topic:
+
+1. **Dual-publish phase** (minimum 1 deploy cycle): Publishers emit to both old and new topics. Consumers subscribe to both.
+2. **Cutover**: Remove the old topic subscription from consumers. Confirm zero lag on the old consumer group via Azure Monitor.
+3. **Cleanup**: Remove the old topic from IaC after confirming no active producers or consumers.
+
+### Rollback steps
+
+1. Re-add the old topic subscription to consumer `lifespan` wiring.
+2. Re-enable dual-publish in the CRUD or agent publisher path.
+3. Redeploy affected services. The shared `EventHubSettings` and `build_event_hub_consumer` patterns support runtime topic/consumer-group override via environment variables, enabling rollback without code changes.
+
+### Constraints
+
+- Never delete an Event Hub topic from IaC while there are active consumer groups with uncommitted checkpoints.
+- The Standard tier 10-hub limit per namespace is enforced by the namespace split (#735). Adding new retail topics requires capacity review.
+- Schema-breaking changes require a major version bump and updated contract gate fixtures under `lib/tests/fixtures/event_schema_contracts/`.
+
+## Gap Tracking (2026-04-09)
+
+Remaining implementation gaps tracked as separate issues:
 
 - Product-events publisher coverage: #445
 - Shipment-events subscriber wiring: #446
-- Compensating transaction consistency framework: #447
 
 ### Pattern
 Each service:


### PR DESCRIPTION
## Summary

### AKS DNS Probe (#682)
Adds a **Verify AKS API connectivity** step after all 5 \Get AKS credentials\ locations in \deploy-azd.yml\. The probe:
- Extracts the AKS API FQDN from kubeconfig
- Retries \kubectl cluster-info\ up to 10 times with linear backoff (5s, 10s, ..., 50s)
- On failure, runs \
slookup\ diagnostics for GitHub Actions troubleshooting, then exits 1

This prevents transient DNS resolution failures from cascading into failed Helm deployments.

### SAGA Compensation ADR (#743)
Updates **ADR-007 (SAGA Choreography)** with:
- **Compensation semantics by domain** — tabular status of automated vs manual compensation paths
- **Event topology migration policy** — dual-publish compatibility window, cutover procedure, rollback steps
- **Constraints** — Standard-tier hub limits, schema versioning requirements, checkpoint safety
- Reflects completed namespace split (#735) and compensation framework in \holiday_peak_lib.utils.compensation\

## Test Results
- 654 app tests passed
- Pre-push lint (isort, black, pylint, mypy) + markdown link + event schema contract gates passed

Closes #682
Closes #743