### PR TITLE
Merge pending catalog-search change set

### DIFF
--- a/apps/ecommerce-catalog-search/src/Dockerfile
+++ b/apps/ecommerce-catalog-search/src/Dockerfile
@@ -30,9 +30,11 @@ USER appuser
 CMD ["uvicorn", "ecommerce_catalog_search.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
 
 FROM base AS prod-builder
+ARG CACHE_BUST=0
 ENV APP_ENV=prod
 COPY pyproject.toml uv.lock ./
 COPY . ./
+RUN echo "cache_bust=${CACHE_BUST}" > /tmp/cache-bust.txt
 ENV PYTHONPATH=/app/src
 ENV PATH="/app/src/.venv/bin:$PATH"
 RUN uv sync --frozen --no-dev

--- a/apps/ecommerce-catalog-search/src/ecommerce_catalog_search/agents.py
+++ b/apps/ecommerce-catalog-search/src/ecommerce_catalog_search/agents.py
@@ -95,6 +95,7 @@ GENERIC_KEYWORD_STOPWORDS = frozenset(
         "are",
         "be",
         "best",
+        "buy",
         "by",
         "for",
         "from",
@@ -110,11 +111,13 @@ GENERIC_KEYWORD_STOPWORDS = frozenset(
         "or",
         "please",
         "recommend",
+        "should",
         "show",
         "suggest",
         "that",
         "the",
         "to",
+        "want",
         "what",
         "which",
         "with",
@@ -126,6 +129,9 @@ GENERIC_KEYWORD_STOPWORDS = frozenset(
 LEXICAL_CANONICAL_OVERRIDES: dict[str, str] = {
     "bags": "bag",
     "backpacks": "backpack",
+    "cloth": "clothing",
+    "clothes": "clothing",
+    "clothing": "clothing",
     "headphones": "headphone",
     "laptops": "laptop",
     "phones": "phone",
@@ -753,6 +759,14 @@ def _product_search_text(product: CatalogProduct) -> str:
     return " ".join(values).lower()
 
 
+def _search_relevance_tokens(value: str) -> set[str]:
+    return {
+        token
+        for token in _tokenize_lexical_terms(value)
+        if token not in GENERIC_KEYWORD_STOPWORDS and len(token) >= 3
+    }
+
+
 def _rank_products_by_query_relevance(
     *,
     query: str,
@@ -762,10 +776,10 @@ def _rank_products_by_query_relevance(
     if limit <= 0:
         return []
 
-    query_tokens = _tokenize_lexical_terms(query)
+    query_tokens = _search_relevance_tokens(query)
     ranked_entries: dict[str, tuple[CatalogProduct, int, int]] = {}
     for index, product in enumerate(products):
-        product_tokens = _tokenize_lexical_terms(_product_search_text(product))
+        product_tokens = _search_relevance_tokens(_product_search_text(product))
         overlap_score = len(query_tokens & product_tokens)
         existing = ranked_entries.get(product.sku)
         if existing is None or overlap_score > existing[1]:
@@ -776,6 +790,18 @@ def _rank_products_by_query_relevance(
         key=lambda entry: (-entry[1], entry[2], entry[0].sku),
     )
     return [entry[0] for entry in ranked[:limit]]
+
+
+def _max_query_overlap(query: str, products: list[CatalogProduct]) -> int:
+    if not products:
+        return 0
+
+    query_tokens = _search_relevance_tokens(query)
+    max_overlap = 0
+    for product in products:
+        product_tokens = _search_relevance_tokens(_product_search_text(product))
+        max_overlap = max(max_overlap, len(query_tokens & product_tokens))
+    return max_overlap
 
 
 async def _expand_products_with_sub_queries(
@@ -822,11 +848,14 @@ async def _expand_products_with_sub_queries(
                 product for product in batch if isinstance(product, CatalogProduct)
             )
 
-    return _rank_products_by_query_relevance(
+    ranked_products = _rank_products_by_query_relevance(
         query=query,
         products=expanded_products,
         limit=limit,
     )
+    if _max_query_overlap(query, ranked_products) <= 0:
+        return []
+    return ranked_products
 
 
 async def _search_products_text_fallback(
@@ -898,7 +927,13 @@ async def _search_products_keyword(
         )
         ai_search_products = [product for product in resolved_products if product is not None]
         if ai_search_products:
-            return ai_search_products[:limit]
+            ranked_products = _rank_products_by_query_relevance(
+                query=query,
+                products=ai_search_products,
+                limit=limit,
+            )
+            if ranked_products and _max_query_overlap(query, ranked_products) > 0:
+                return ranked_products
 
     if ai_search_result.fallback_reason is not None:
         logger.warning(
@@ -928,7 +963,17 @@ async def _search_products_keyword(
             limit=limit,
         )
         if text_fallback_products:
-            return text_fallback_products
+            ranked_text_fallback = _rank_products_by_query_relevance(
+                query=query,
+                products=text_fallback_products,
+                limit=limit,
+            )
+            if _max_query_overlap(query, ranked_text_fallback) > 0:
+                return ranked_text_fallback
+
+        # Avoid hash-based SKU fallbacks for natural-language queries; they create
+        # unrelated recommendations and degrade trust in search results.
+        return []
 
     primary_sku = _coerce_query_to_sku(query)
     primary = await adapters.products.get_product(primary_sku)
@@ -974,7 +1019,18 @@ async def _search_products_intelligent(
         limit,
     )
     if intelligent_products:
-        return intelligent_products, enrichment_by_sku, intent
+        ranked_intelligent = _rank_products_by_query_relevance(
+            query=query,
+            products=intelligent_products,
+            limit=limit,
+        )
+        if _max_query_overlap(query, ranked_intelligent) > 0:
+            filtered_enrichment = {
+                sku: enrichment_by_sku[sku]
+                for sku in [product.sku for product in ranked_intelligent]
+                if sku in enrichment_by_sku
+            }
+            return ranked_intelligent, filtered_enrichment, intent
 
     expanded_products = await _expand_products_with_sub_queries(
         adapters=adapters,

--- a/apps/ecommerce-catalog-search/src/ecommerce_catalog_search/ai_search.py
+++ b/apps/ecommerce-catalog-search/src/ecommerce_catalog_search/ai_search.py
@@ -75,17 +75,6 @@ class AISearchSeedResult:
     reason: str | None = None
 
 
-_SEARCH_SELECT_FIELDS = [
-    "sku",
-    "id",
-    "title",
-    "description",
-    "content",
-    "use_cases",
-    "complementary_products",
-    "substitute_products",
-    "enriched_description",
-]
 _ENRICHED_FIELDS = (
     "use_cases",
     "complementary_products",
@@ -287,15 +276,15 @@ async def _search_documents(
         credential=credential,
     )
     filter_expression = _as_search_filter(filters)
+    search_kwargs: dict[str, Any] = {
+        "search_text": search_text,
+        "top": top_k,
+        "filter": filter_expression,
+        "vector_queries": vector_queries,
+    }
 
     try:
-        results = await client.search(
-            search_text=search_text,
-            top=top_k,
-            select=_SEARCH_SELECT_FIELDS,
-            filter=filter_expression,
-            vector_queries=vector_queries,
-        )
+        results = await client.search(**search_kwargs)
         documents: list[AISearchDocumentResult] = []
         async for document in results:
             parsed = _normalize_result_document(document)
@@ -691,8 +680,12 @@ def _to_search_document(product: dict[str, Any]) -> dict[str, Any] | None:
 
     title = str(product.get("name") or sku).strip() or sku
     description = str(product.get("description") or "")
-    category = str(product.get("category") or "")
+    category = str(product.get("category") or product.get("category_id") or "")
     brand = str(product.get("brand") or "")
+    features_raw = product.get("features")
+    features: list[str] = []
+    if isinstance(features_raw, list):
+        features = [str(item).strip() for item in features_raw if str(item).strip()]
 
     price_raw = product.get("price")
     try:
@@ -705,7 +698,17 @@ def _to_search_document(product: dict[str, Any]) -> dict[str, Any] | None:
         "sku": sku,
         "title": title,
         "description": description,
-        "content": " ".join(part for part in (title, description, category, brand) if part).strip(),
+        "content": " ".join(
+            part
+            for part in (
+                title,
+                description,
+                category,
+                brand,
+                " ".join(features),
+            )
+            if part
+        ).strip(),
         "category": category,
         "brand": brand,
         "availability": _resolve_availability_from_product(product),

--- a/apps/ecommerce-catalog-search/src/uv.lock
+++ b/apps/ecommerce-catalog-search/src/uv.lock
@@ -1033,7 +1033,7 @@ wheels = [
 [[package]]
 name = "holiday-peak-lib"
 version = "0.1.0"
-source = { git = "https://github.com/Azure-Samples/holiday-peak-hub.git?subdirectory=lib%2Fsrc&branch=main#b23caf979509f3ad5a4734473c892e2896e57952" }
+source = { git = "https://github.com/Azure-Samples/holiday-peak-hub.git?subdirectory=lib%2Fsrc&branch=main#5c5157611f33996e4b77b3e043e22f629f7e7d12" }
 dependencies = [
     { name = "agent-framework" },
     { name = "aiohttp" },

--- a/apps/ecommerce-catalog-search/tests/test_agents.py
+++ b/apps/ecommerce-catalog-search/tests/test_agents.py
@@ -386,7 +386,7 @@ class TestCatalogSearchAgent:
 
             await agent.handle(
                 {
-                    "query": "test product",
+                    "query": "SKU-001",
                     "limit": 5,
                     "mode": "keyword",
                     "search_stage": "rerank",
@@ -514,18 +514,18 @@ class TestCatalogSearchAgent:
             )
 
             agent = CatalogSearchAgent(config=agent_dependencies)
-            result = await agent.handle({"query": "running shoes", "limit": 5, "mode": "keyword"})
+            result = await agent.handle({"query": "test product", "limit": 5, "mode": "keyword"})
 
             assert len(result["results"]) == 1
             assert result["results"][0]["item_id"] == "SKU-001"
-            mock_search.assert_awaited_once_with(query="running shoes", limit=5)
+            mock_search.assert_awaited_once_with(query="test product", limit=5)
             mock_products.get_related.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_handle_falls_back_when_ai_search_empty(
         self, agent_dependencies, mock_catalog_product
     ):
-        """Test fallback path remains active when AI Search has no hits."""
+        """Natural-language keyword queries should return empty when retrieval has no relevant hits."""
         mock_inventory_item = InventoryItem(sku="SKU-001", available=10, reserved=0)
 
         with (
@@ -552,9 +552,9 @@ class TestCatalogSearchAgent:
             agent = CatalogSearchAgent(config=agent_dependencies)
             result = await agent.handle({"query": "fallback query", "limit": 3, "mode": "keyword"})
 
-            assert len(result["results"]) == 1
+            assert len(result["results"]) == 0
             mock_search.assert_awaited_once_with(query="fallback query", limit=3)
-            mock_products.get_related.assert_awaited_once()
+            mock_products.get_related.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_handle_uses_text_search_fallback_when_ai_search_empty(
@@ -570,7 +570,14 @@ class TestCatalogSearchAgent:
             mock_search.return_value = AISearchSkuResult(skus=[])
 
             mock_products = AsyncMock()
-            mock_products.search = AsyncMock(return_value=[mock_catalog_product])
+            text_match_product = mock_catalog_product.model_copy(
+                update={
+                    "name": "Rain Jacket",
+                    "description": "Waterproof rain jacket for cold weather travel.",
+                    "category": "clothing",
+                }
+            )
+            mock_products.search = AsyncMock(return_value=[text_match_product])
             mock_products.get_product = AsyncMock(return_value=None)
             mock_products.get_related = AsyncMock(return_value=[])
 
@@ -760,8 +767,7 @@ class TestCatalogSearchAgent:
                     {"query": "show me travel accessories", "limit": 5, "mode": "intelligent"}
                 )
 
-            assert len(result["results"]) == 1
-            assert result["results"][0]["item_id"] == "SKU-001"
+            assert len(result["results"]) == 0
             mock_multi.assert_not_awaited()
             assert mock_search.await_count >= 1
 
@@ -793,7 +799,14 @@ class TestCatalogSearchAgent:
             ]
 
             mock_products = AsyncMock()
-            mock_products.get_product = AsyncMock(return_value=mock_catalog_product)
+            relevant_product = mock_catalog_product.model_copy(
+                update={
+                    "name": "Travel Headphones Pro",
+                    "description": "Noise-canceling headphones for travel and commute.",
+                    "category": "audio",
+                }
+            )
+            mock_products.get_product = AsyncMock(return_value=relevant_product)
             mock_products.get_related = AsyncMock(return_value=[])
 
             mock_inventory = AsyncMock()

--- a/apps/ecommerce-catalog-search/tests/test_ai_search.py
+++ b/apps/ecommerce-catalog-search/tests/test_ai_search.py
@@ -6,7 +6,11 @@ import logging
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
-from azure.core.exceptions import ClientAuthenticationError, ServiceRequestError
+from azure.core.exceptions import (
+    ClientAuthenticationError,
+    HttpResponseError,
+    ServiceRequestError,
+)
 from ecommerce_catalog_search.ai_search import (
     AISearchDocumentResult,
     AISearchIndexStatus,
@@ -242,6 +246,146 @@ async def test_vector_search_uses_vector_index_and_returns_enriched_fields(
     assert len(result) == 1
     assert result[0].sku == "SKU-101"
     assert result[0].enriched_fields["use_cases"] == ["gaming", "streaming"]
+    assert client.search.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_vector_search_sends_no_select_restriction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AI Search queries must not include a $select clause so the index schema never blocks results."""
+    monkeypatch.setenv("AI_SEARCH_ENDPOINT", "https://example.search.windows.net")
+    monkeypatch.setenv("AI_SEARCH_VECTOR_INDEX", "product_search_index")
+
+    credential = Mock()
+    credential.close = AsyncMock()
+
+    client = Mock()
+    client.close = AsyncMock()
+    client.search = AsyncMock(
+        return_value=_AsyncResults(
+            [{"sku": "SKU-303", "@search.score": 1.0, "title": "Trail Jacket"}]
+        )
+    )
+
+    with (
+        patch("ecommerce_catalog_search.ai_search._resolve_credential", return_value=credential),
+        patch("ecommerce_catalog_search.ai_search.SearchClient", return_value=client),
+    ):
+        result = await vector_search(
+            query_text="outdoor jacket",
+            filters=None,
+            top_k=2,
+        )
+
+    assert [item.sku for item in result] == ["SKU-303"]
+    assert client.search.await_count == 1
+    call_kwargs = client.search.await_args_list[0].kwargs
+    assert "select" not in call_kwargs
+
+
+@pytest.mark.asyncio
+async def test_vector_search_returns_all_document_fields_for_model_filtering(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """All fields returned by the index are available on the document for model-side filtering."""
+    monkeypatch.setenv("AI_SEARCH_ENDPOINT", "https://example.search.windows.net")
+    monkeypatch.setenv("AI_SEARCH_VECTOR_INDEX", "product_search_index")
+
+    credential = Mock()
+    credential.close = AsyncMock()
+
+    document = {
+        "sku": "SKU-101",
+        "@search.score": 0.95,
+        "title": "Merino Wool Base Layer",
+        "description": "Lightweight thermal layer for cold weather.",
+        "category": "clothing",
+        "brand": "Contoso",
+        "price": "49.99 usd",
+    }
+    client = Mock()
+    client.close = AsyncMock()
+    client.search = AsyncMock(return_value=_AsyncResults([document]))
+
+    with (
+        patch(
+            "ecommerce_catalog_search.ai_search._resolve_credential",
+            return_value=Mock(close=AsyncMock()),
+        ),
+        patch("ecommerce_catalog_search.ai_search.SearchClient", return_value=client),
+    ):
+        result = await vector_search(
+            query_text="warm clothing for winter travel",
+            filters=None,
+            top_k=3,
+        )
+
+    assert len(result) == 1
+    assert result[0].sku == "SKU-101"
+    assert result[0].document["title"] == "Merino Wool Base Layer"
+    assert result[0].document["category"] == "clothing"
+    assert result[0].document["price"] == "49.99 usd"
+
+
+@pytest.mark.asyncio
+async def test_vector_search_returns_empty_on_http_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AI_SEARCH_ENDPOINT", "https://example.search.windows.net")
+    monkeypatch.setenv("AI_SEARCH_VECTOR_INDEX", "product_search_index")
+
+    credential = Mock()
+    credential.close = AsyncMock()
+
+    client = Mock()
+    client.close = AsyncMock()
+    client.search = AsyncMock(
+        side_effect=HttpResponseError(message="Query syntax error in filter expression")
+    )
+
+    with (
+        patch("ecommerce_catalog_search.ai_search._resolve_credential", return_value=credential),
+        patch("ecommerce_catalog_search.ai_search.SearchClient", return_value=client),
+    ):
+        result = await vector_search(
+            query_text="wireless headset",
+            filters=None,
+            top_k=2,
+        )
+
+    assert result == []
+    assert client.search.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_vector_search_returns_empty_on_permission_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AI_SEARCH_ENDPOINT", "https://example.search.windows.net")
+    monkeypatch.setenv("AI_SEARCH_VECTOR_INDEX", "product_search_index")
+
+    forbidden_error = HttpResponseError(message="Access denied")
+    forbidden_error.status_code = 403
+
+    client = Mock()
+    client.close = AsyncMock()
+    client.search = AsyncMock(side_effect=forbidden_error)
+
+    with (
+        patch(
+            "ecommerce_catalog_search.ai_search._resolve_credential",
+            return_value=Mock(close=AsyncMock()),
+        ),
+        patch("ecommerce_catalog_search.ai_search.SearchClient", return_value=client),
+    ):
+        result = await vector_search(
+            query_text="wireless headset",
+            filters=None,
+            top_k=2,
+        )
+
+    assert result == []
     assert client.search.await_count == 1
 
 

--- a/apps/ecommerce-catalog-search/tests/test_mcp_tools.py
+++ b/apps/ecommerce-catalog-search/tests/test_mcp_tools.py
@@ -29,6 +29,7 @@ def fixture_mock_agent(mock_catalog_product, mock_inventory_item):
     mock_products = AsyncMock()
     mock_products.get_product = AsyncMock(return_value=mock_catalog_product)
     mock_products.get_related = AsyncMock(return_value=[])
+    mock_products.search = AsyncMock(return_value=[mock_catalog_product])
 
     mock_inventory = AsyncMock()
     mock_inventory.get_item = AsyncMock(return_value=mock_inventory_item)

--- a/apps/ui/INTEGRATION.md
+++ b/apps/ui/INTEGRATION.md
@@ -62,7 +62,7 @@ Shared resolver module: `app/api/_shared/base-url-resolver.ts`
   - Local loopback hosts (`localhost`, `127.0.0.1`, `::1`) are allowed for development/test runtime.
   - Optional local-only override: `UI_ALLOW_NON_APIM_PROXY_URL=true` (must remain disabled in production).
 - Catalog read resiliency policy (`/api/categories`, `/api/products`):
-  - Strategy retries transient upstream failures (`502`, `503`, `504`) with up to 2 attempts.
+  - Strategy retries transient upstream failures (`500`, `502`, `503`, `504`) with up to 2 attempts.
   - Each fallback-protected upstream attempt is capped at 10 seconds with `AbortSignal.timeout(...)` so stalled APIM reads fail fast into the existing fallback path.
   - If transient failures persist (or network fetch fails), the proxy returns HTTP `200` with an empty array fallback payload.
   - Fallback responses include diagnostics headers for triage:

--- a/apps/ui/app/api/[...path]/route.ts
+++ b/apps/ui/app/api/[...path]/route.ts
@@ -327,7 +327,7 @@ const CATALOG_READ_FALLBACK_STRATEGIES: readonly EndpointFallbackStrategy[] = [
     path: '/api/categories',
     retry: {
       maxAttempts: 2,
-      retryableStatuses: [502, 503, 504] as const,
+      retryableStatuses: [500, 502, 503, 504] as const,
     },
     buildPayload: () => [],
   },
@@ -337,7 +337,7 @@ const CATALOG_READ_FALLBACK_STRATEGIES: readonly EndpointFallbackStrategy[] = [
     path: '/api/products',
     retry: {
       maxAttempts: 2,
-      retryableStatuses: [502, 503, 504] as const,
+      retryableStatuses: [500, 502, 503, 504] as const,
     },
     buildPayload: () => [],
   },

--- a/apps/ui/tests/unit/apiProxyRouteEnv.test.ts
+++ b/apps/ui/tests/unit/apiProxyRouteEnv.test.ts
@@ -345,6 +345,38 @@ describe('/api proxy route env handling', () => {
     await expect(response.json()).resolves.toEqual([]);
   });
 
+  it('returns fallback payload when /api/products upstream responds with 500 after retry', async () => {
+    process.env.NEXT_PUBLIC_CRUD_API_URL = 'https://apim.example.azure-api.net';
+    (global.fetch as jest.Mock).mockResolvedValue(
+      {
+        body: null,
+        status: 500,
+        statusText: 'Internal Server Error',
+        headers: new Headers({
+          'content-type': 'application/json',
+          'x-request-id': 'upstream-req-500',
+        }),
+        json: jest.fn(async () => ({
+          error: 'Internal server error',
+        })),
+        text: jest.fn(async () => ''),
+      },
+    );
+
+    const route = await import('../../app/api/[...path]/route');
+    const response = await route.GET(makeRequest('http://localhost/api/products'), {
+      params: Promise.resolve({ path: ['products'] }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(response.headers.get('x-holiday-peak-proxy-source')).toBe('NEXT_PUBLIC_CRUD_API_URL');
+    expect(response.headers.get('x-holiday-peak-proxy-failure-kind')).toBe('upstream');
+    expect(response.headers.get('x-holiday-peak-proxy-fallback')).toBe('products-read-empty-upstream-500');
+    expect(response.headers.get('x-holiday-peak-proxy-fallback-upstream-status')).toBe('500');
+    await expect(response.json()).resolves.toEqual([]);
+  });
+
   it('returns fallback payload when /api/categories upstream responds with 502', async () => {
     process.env.NEXT_PUBLIC_CRUD_API_URL = 'https://apim.example.azure-api.net';
     (global.fetch as jest.Mock).mockResolvedValue(

--- a/tests/e2e/test_search_flow.py
+++ b/tests/e2e/test_search_flow.py
@@ -19,7 +19,9 @@ async def test_simple_keyword_query_uses_keyword_path(
     harness = build_catalog_harness(products_by_sku={"SKU-100": catalog_product})
 
     with (
-        patch("ecommerce_catalog_search.agents.build_catalog_adapters", return_value=harness.adapters),
+        patch(
+            "ecommerce_catalog_search.agents.build_catalog_adapters", return_value=harness.adapters
+        ),
         patch(
             "ecommerce_catalog_search.agents.search_catalog_skus_detailed",
             return_value=AISearchSkuResult(skus=["SKU-100"]),
@@ -54,7 +56,9 @@ async def test_complex_query_uses_intelligent_path_with_intent_and_hybrid_search
     ]
 
     with (
-        patch("ecommerce_catalog_search.agents.build_catalog_adapters", return_value=harness.adapters),
+        patch(
+            "ecommerce_catalog_search.agents.build_catalog_adapters", return_value=harness.adapters
+        ),
         patch(
             "ecommerce_catalog_search.agents.search_catalog_skus_detailed",
             return_value=AISearchSkuResult(skus=[]),
@@ -111,7 +115,9 @@ async def test_use_case_intent_matches_include_use_cases(
     harness = build_catalog_harness(products_by_sku={"SKU-100": catalog_product})
 
     with (
-        patch("ecommerce_catalog_search.agents.build_catalog_adapters", return_value=harness.adapters),
+        patch(
+            "ecommerce_catalog_search.agents.build_catalog_adapters", return_value=harness.adapters
+        ),
         patch(
             "ecommerce_catalog_search.agents.search_catalog_skus_detailed",
             return_value=AISearchSkuResult(skus=[]),
@@ -166,7 +172,9 @@ async def test_complementary_resolution_includes_readable_related_products(
     harness = build_catalog_harness(products_by_sku={"SKU-100": catalog_product})
 
     with (
-        patch("ecommerce_catalog_search.agents.build_catalog_adapters", return_value=harness.adapters),
+        patch(
+            "ecommerce_catalog_search.agents.build_catalog_adapters", return_value=harness.adapters
+        ),
         patch(
             "ecommerce_catalog_search.agents.search_catalog_skus_detailed",
             return_value=AISearchSkuResult(skus=[]),
@@ -218,11 +226,15 @@ async def test_complementary_resolution_includes_readable_related_products(
     assert all(isinstance(item, str) and len(item.strip().split()) >= 1 for item in related)
 
 
-async def test_indexer_lag_returns_no_results(agent_config_without_models, build_catalog_harness) -> None:
+async def test_indexer_lag_returns_no_results(
+    agent_config_without_models, build_catalog_harness
+) -> None:
     harness = build_catalog_harness(products_by_sku={}, default_product=None, related_products=[])
 
     with (
-        patch("ecommerce_catalog_search.agents.build_catalog_adapters", return_value=harness.adapters),
+        patch(
+            "ecommerce_catalog_search.agents.build_catalog_adapters", return_value=harness.adapters
+        ),
         patch(
             "ecommerce_catalog_search.agents.search_catalog_skus_detailed",
             return_value=AISearchSkuResult(skus=[]),
@@ -247,18 +259,21 @@ async def test_ai_search_unavailable_uses_fallback_path(
     monkeypatch.setenv("CATALOG_SEARCH_REQUIRE_AI_SEARCH", "false")
 
     harness = build_catalog_harness(default_product=catalog_product, related_products=[])
+    harness.products.search = AsyncMock(return_value=[catalog_product])
 
     caplog.set_level(logging.WARNING, logger="ecommerce_catalog_search.agents")
 
     with (
-        patch("ecommerce_catalog_search.agents.build_catalog_adapters", return_value=harness.adapters),
+        patch(
+            "ecommerce_catalog_search.agents.build_catalog_adapters", return_value=harness.adapters
+        ),
         patch(
             "ecommerce_catalog_search.agents.search_catalog_skus_detailed",
             return_value=AISearchSkuResult(skus=[], fallback_reason="ai_search_transport_error"),
         ),
     ):
         agent = CatalogSearchAgent(config=agent_config_without_models)
-        result = await agent.handle({"query": "wireless earbuds", "limit": 4})
+        result = await agent.handle({"query": "explorer headphones", "limit": 4})
 
     assert result["results"]
     assert result["results"][0]["item_id"] == "SKU-100"

--- a/tests/e2e/test_search_flow.py
+++ b/tests/e2e/test_search_flow.py
@@ -240,7 +240,12 @@ async def test_ai_search_unavailable_uses_fallback_path(
     build_catalog_harness,
     catalog_product,
     caplog,
+    monkeypatch,
 ) -> None:
+    # Disable strict mode so the fallback path is exercised regardless of
+    # CI environment (KUBERNETES_SERVICE_HOST may enable strict mode by default).
+    monkeypatch.setenv("CATALOG_SEARCH_REQUIRE_AI_SEARCH", "false")
+
     harness = build_catalog_harness(default_product=catalog_product, related_products=[])
 
     caplog.set_level(logging.WARNING, logger="ecommerce_catalog_search.agents")


### PR DESCRIPTION
## Summary
- improve catalog search relevance ranking for natural-language queries
- avoid irrelevant fallback results when query-product overlap is zero
- remove brittle AI Search select restriction and broaden indexed content features
- align and expand tests for AI Search error/no-select behavior and keyword/intelligent search outcomes
- include related formatting/lock updates in this pending change set

## Validation
- `python -m isort` on modified Python files
- `python -m black` on modified Python files
- `python -m pytest apps/ecommerce-catalog-search/tests/test_ai_search.py apps/ecommerce-catalog-search/tests/test_agents.py lib/tests/test_memory.py -q`

Closes #780