### PR TITLE
deploy: seed rendered manifests for Flux reconciliation

### DIFF
--- a/.kubernetes/rendered/crm-campaign-intelligence/all.yaml
+++ b/.kubernetes/rendered/crm-campaign-intelligence/all.yaml
@@ -1,0 +1,197 @@
+---
+# Source: holiday-peak-service/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: crm-campaign-intelligence
+  namespace: holiday-peak
+  labels:
+    app: crm-campaign-intelligence
+  annotations:
+    azure.workload.identity/client-id: "036f4fd2-9093-4948-b0dd-beb5c87aa6dc"
+---
+# Source: holiday-peak-service/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: crm-campaign-intelligence-crm-campaign-intelligence
+  namespace: holiday-peak
+  labels:
+    app: crm-campaign-intelligence
+spec:
+  selector:
+    app: crm-campaign-intelligence
+    # When canary is disabled, select all pods
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8000
+  type: ClusterIP
+---
+# Source: holiday-peak-service/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: crm-campaign-intelligence-crm-campaign-intelligence
+  namespace: holiday-peak
+  labels:
+    app: crm-campaign-intelligence
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  selector:
+    matchLabels:
+      app: crm-campaign-intelligence
+  template:
+    metadata:
+      labels:
+        app: crm-campaign-intelligence
+        canary: "false"
+        azure.workload.identity/use: "true"
+    spec:
+      serviceAccountName: crm-campaign-intelligence
+      nodeSelector:
+        agentpool: agents
+      tolerations:
+        - effect: NoSchedule
+          key: workload
+          operator: Equal
+          value: agents
+      containers:
+        - name: crm-campaign-intelligence
+          image: "holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/crm-campaign-intelligence-dev:azd-deploy-1775344528"
+          env:
+            - name: AI_SEARCH_AUTH_MODE
+              value: "managed_identity"
+            - name: AI_SEARCH_ENDPOINT
+              value: "https://holidaypeakhub405devsearch.search.windows.net"
+            - name: AI_SEARCH_INDEX
+              value: "catalog-products"
+            - name: AI_SEARCH_INDEXER_NAME
+              value: "search-enriched-products-indexer"
+            - name: AI_SEARCH_VECTOR_INDEX
+              value: "product_search_index"
+            - name: APPLICATIONINSIGHTS_CONNECTION_STRING
+              value: "InstrumentationKey=d2fb45bc-e648-4da2-9345-d278636aede5;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=d8eb64c4-956d-46ab-a02e-d481deadaa0b"
+            - name: AZURE_CLIENT_ID
+              value: "036f4fd2-9093-4948-b0dd-beb5c87aa6dc"
+            - name: AZURE_TENANT_ID
+              value: "16b3c013-d300-468d-ac64-7eda0820b6d3"
+            - name: BLOB_ACCOUNT_URL
+              value: "https://holidaypeakhub405devstor.blob.core.windows.net"
+            - name: BLOB_CONTAINER
+              value: "agent-memory"
+            - name: CATALOG_SEARCH_REQUIRE_AI_SEARCH
+              value: "true"
+            - name: COSMOS_ACCOUNT_URI
+              value: "https://holidaypeakhub405-dev-cosmos.documents.azure.com:443/"
+            - name: COSMOS_CONTAINER
+              value: "agent-memory"
+            - name: COSMOS_DATABASE
+              value: "holiday-peak-db"
+            - name: EMBEDDING_DEPLOYMENT_NAME
+              value: "text-embedding-3-large"
+            - name: EVENT_HUB_NAMESPACE
+              value: "holidaypeakhub405-dev-eventhub"
+            - name: FOUNDRY_AGENT_NAME_FAST
+              value: "crm-campaign-intelligence-fast"
+            - name: FOUNDRY_AGENT_NAME_RICH
+              value: "crm-campaign-intelligence-rich"
+            - name: FOUNDRY_AUTO_ENSURE_ON_STARTUP
+              value: "true"
+            - name: FOUNDRY_STREAM
+              value: "false"
+            - name: FOUNDRY_STRICT_ENFORCEMENT
+              value: "false"
+            - name: KEY_VAULT_URI
+              value: "https://holidaypeakhub405-dev-kv.vault.azure.net/"
+            - name: MODEL_DEPLOYMENT_NAME_FAST
+              value: "gpt-5-nano"
+            - name: MODEL_DEPLOYMENT_NAME_RICH
+              value: "gpt-5"
+            - name: POSTGRES_AUTH_MODE
+              value: "password"
+            - name: POSTGRES_DATABASE
+              value: "holiday_peak_crud"
+            - name: POSTGRES_HOST
+              value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
+            - name: POSTGRES_PORT
+              value: "5432"
+            - name: POSTGRES_SSL
+              value: "true"
+            - name: POSTGRES_USER
+              value: "crud_workload"
+            - name: PROJECT_ENDPOINT
+              value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
+            - name: PROJECT_NAME
+              value: "aipholidaris"
+            - name: REDIS_HOST
+              value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
+            - name: REDIS_PASSWORD_SECRET_NAME
+              value: "redis-primary-key"
+            - name: REDIS_URL
+              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
+          ports:
+            - containerPort: 8000
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 250m
+              memory: 256Mi
+---
+# Source: holiday-peak-service/templates/agc-routing.yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: crm-campaign-intelligence-crm-campaign-intelligence-agc
+  namespace: holiday-peak
+  labels:
+    app: crm-campaign-intelligence
+spec:
+  parentRefs:
+    - name: "holiday-peak-agc"
+      namespace: "holiday-peak"
+  hostnames:
+    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/crm-campaign-intelligence"
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: "/"
+      backendRefs:
+        - name: crm-campaign-intelligence-crm-campaign-intelligence
+          port: 80

--- a/.kubernetes/rendered/crm-profile-aggregation/all.yaml
+++ b/.kubernetes/rendered/crm-profile-aggregation/all.yaml
@@ -1,0 +1,197 @@
+---
+# Source: holiday-peak-service/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: crm-profile-aggregation
+  namespace: holiday-peak
+  labels:
+    app: crm-profile-aggregation
+  annotations:
+    azure.workload.identity/client-id: "036f4fd2-9093-4948-b0dd-beb5c87aa6dc"
+---
+# Source: holiday-peak-service/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: crm-profile-aggregation-crm-profile-aggregation
+  namespace: holiday-peak
+  labels:
+    app: crm-profile-aggregation
+spec:
+  selector:
+    app: crm-profile-aggregation
+    # When canary is disabled, select all pods
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8000
+  type: ClusterIP
+---
+# Source: holiday-peak-service/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: crm-profile-aggregation-crm-profile-aggregation
+  namespace: holiday-peak
+  labels:
+    app: crm-profile-aggregation
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  selector:
+    matchLabels:
+      app: crm-profile-aggregation
+  template:
+    metadata:
+      labels:
+        app: crm-profile-aggregation
+        canary: "false"
+        azure.workload.identity/use: "true"
+    spec:
+      serviceAccountName: crm-profile-aggregation
+      nodeSelector:
+        agentpool: agents
+      tolerations:
+        - effect: NoSchedule
+          key: workload
+          operator: Equal
+          value: agents
+      containers:
+        - name: crm-profile-aggregation
+          image: "holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/crm-profile-aggregation-dev:azd-deploy-1775344626"
+          env:
+            - name: AI_SEARCH_AUTH_MODE
+              value: "managed_identity"
+            - name: AI_SEARCH_ENDPOINT
+              value: "https://holidaypeakhub405devsearch.search.windows.net"
+            - name: AI_SEARCH_INDEX
+              value: "catalog-products"
+            - name: AI_SEARCH_INDEXER_NAME
+              value: "search-enriched-products-indexer"
+            - name: AI_SEARCH_VECTOR_INDEX
+              value: "product_search_index"
+            - name: APPLICATIONINSIGHTS_CONNECTION_STRING
+              value: "InstrumentationKey=d2fb45bc-e648-4da2-9345-d278636aede5;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=d8eb64c4-956d-46ab-a02e-d481deadaa0b"
+            - name: AZURE_CLIENT_ID
+              value: "036f4fd2-9093-4948-b0dd-beb5c87aa6dc"
+            - name: AZURE_TENANT_ID
+              value: "16b3c013-d300-468d-ac64-7eda0820b6d3"
+            - name: BLOB_ACCOUNT_URL
+              value: "https://holidaypeakhub405devstor.blob.core.windows.net"
+            - name: BLOB_CONTAINER
+              value: "agent-memory"
+            - name: CATALOG_SEARCH_REQUIRE_AI_SEARCH
+              value: "true"
+            - name: COSMOS_ACCOUNT_URI
+              value: "https://holidaypeakhub405-dev-cosmos.documents.azure.com:443/"
+            - name: COSMOS_CONTAINER
+              value: "agent-memory"
+            - name: COSMOS_DATABASE
+              value: "holiday-peak-db"
+            - name: EMBEDDING_DEPLOYMENT_NAME
+              value: "text-embedding-3-large"
+            - name: EVENT_HUB_NAMESPACE
+              value: "holidaypeakhub405-dev-eventhub"
+            - name: FOUNDRY_AGENT_NAME_FAST
+              value: "crm-profile-aggregation-fast"
+            - name: FOUNDRY_AGENT_NAME_RICH
+              value: "crm-profile-aggregation-rich"
+            - name: FOUNDRY_AUTO_ENSURE_ON_STARTUP
+              value: "true"
+            - name: FOUNDRY_STREAM
+              value: "false"
+            - name: FOUNDRY_STRICT_ENFORCEMENT
+              value: "false"
+            - name: KEY_VAULT_URI
+              value: "https://holidaypeakhub405-dev-kv.vault.azure.net/"
+            - name: MODEL_DEPLOYMENT_NAME_FAST
+              value: "gpt-5-nano"
+            - name: MODEL_DEPLOYMENT_NAME_RICH
+              value: "gpt-5"
+            - name: POSTGRES_AUTH_MODE
+              value: "password"
+            - name: POSTGRES_DATABASE
+              value: "holiday_peak_crud"
+            - name: POSTGRES_HOST
+              value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
+            - name: POSTGRES_PORT
+              value: "5432"
+            - name: POSTGRES_SSL
+              value: "true"
+            - name: POSTGRES_USER
+              value: "crud_workload"
+            - name: PROJECT_ENDPOINT
+              value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
+            - name: PROJECT_NAME
+              value: "aipholidaris"
+            - name: REDIS_HOST
+              value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
+            - name: REDIS_PASSWORD_SECRET_NAME
+              value: "redis-primary-key"
+            - name: REDIS_URL
+              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
+          ports:
+            - containerPort: 8000
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 250m
+              memory: 256Mi
+---
+# Source: holiday-peak-service/templates/agc-routing.yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: crm-profile-aggregation-crm-profile-aggregation-agc
+  namespace: holiday-peak
+  labels:
+    app: crm-profile-aggregation
+spec:
+  parentRefs:
+    - name: "holiday-peak-agc"
+      namespace: "holiday-peak"
+  hostnames:
+    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/crm-profile-aggregation"
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: "/"
+      backendRefs:
+        - name: crm-profile-aggregation-crm-profile-aggregation
+          port: 80

--- a/.kubernetes/rendered/crm-segmentation-personalization/all.yaml
+++ b/.kubernetes/rendered/crm-segmentation-personalization/all.yaml
@@ -1,0 +1,197 @@
+---
+# Source: holiday-peak-service/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: crm-segmentation-personalization
+  namespace: holiday-peak
+  labels:
+    app: crm-segmentation-personalization
+  annotations:
+    azure.workload.identity/client-id: "036f4fd2-9093-4948-b0dd-beb5c87aa6dc"
+---
+# Source: holiday-peak-service/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: crm-segmentation-personalization-crm-segmentation-personalizati
+  namespace: holiday-peak
+  labels:
+    app: crm-segmentation-personalization
+spec:
+  selector:
+    app: crm-segmentation-personalization
+    # When canary is disabled, select all pods
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8000
+  type: ClusterIP
+---
+# Source: holiday-peak-service/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: crm-segmentation-personalization-crm-segmentation-personalizati
+  namespace: holiday-peak
+  labels:
+    app: crm-segmentation-personalization
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  selector:
+    matchLabels:
+      app: crm-segmentation-personalization
+  template:
+    metadata:
+      labels:
+        app: crm-segmentation-personalization
+        canary: "false"
+        azure.workload.identity/use: "true"
+    spec:
+      serviceAccountName: crm-segmentation-personalization
+      nodeSelector:
+        agentpool: agents
+      tolerations:
+        - effect: NoSchedule
+          key: workload
+          operator: Equal
+          value: agents
+      containers:
+        - name: crm-segmentation-personalization
+          image: "holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/crm-segmentation-personalization-dev:azd-deploy-1775344793"
+          env:
+            - name: AI_SEARCH_AUTH_MODE
+              value: "managed_identity"
+            - name: AI_SEARCH_ENDPOINT
+              value: "https://holidaypeakhub405devsearch.search.windows.net"
+            - name: AI_SEARCH_INDEX
+              value: "catalog-products"
+            - name: AI_SEARCH_INDEXER_NAME
+              value: "search-enriched-products-indexer"
+            - name: AI_SEARCH_VECTOR_INDEX
+              value: "product_search_index"
+            - name: APPLICATIONINSIGHTS_CONNECTION_STRING
+              value: "InstrumentationKey=d2fb45bc-e648-4da2-9345-d278636aede5;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=d8eb64c4-956d-46ab-a02e-d481deadaa0b"
+            - name: AZURE_CLIENT_ID
+              value: "036f4fd2-9093-4948-b0dd-beb5c87aa6dc"
+            - name: AZURE_TENANT_ID
+              value: "16b3c013-d300-468d-ac64-7eda0820b6d3"
+            - name: BLOB_ACCOUNT_URL
+              value: "https://holidaypeakhub405devstor.blob.core.windows.net"
+            - name: BLOB_CONTAINER
+              value: "agent-memory"
+            - name: CATALOG_SEARCH_REQUIRE_AI_SEARCH
+              value: "true"
+            - name: COSMOS_ACCOUNT_URI
+              value: "https://holidaypeakhub405-dev-cosmos.documents.azure.com:443/"
+            - name: COSMOS_CONTAINER
+              value: "agent-memory"
+            - name: COSMOS_DATABASE
+              value: "holiday-peak-db"
+            - name: EMBEDDING_DEPLOYMENT_NAME
+              value: "text-embedding-3-large"
+            - name: EVENT_HUB_NAMESPACE
+              value: "holidaypeakhub405-dev-eventhub"
+            - name: FOUNDRY_AGENT_NAME_FAST
+              value: "crm-segmentation-personalization-fast"
+            - name: FOUNDRY_AGENT_NAME_RICH
+              value: "crm-segmentation-personalization-rich"
+            - name: FOUNDRY_AUTO_ENSURE_ON_STARTUP
+              value: "true"
+            - name: FOUNDRY_STREAM
+              value: "false"
+            - name: FOUNDRY_STRICT_ENFORCEMENT
+              value: "false"
+            - name: KEY_VAULT_URI
+              value: "https://holidaypeakhub405-dev-kv.vault.azure.net/"
+            - name: MODEL_DEPLOYMENT_NAME_FAST
+              value: "gpt-5-nano"
+            - name: MODEL_DEPLOYMENT_NAME_RICH
+              value: "gpt-5"
+            - name: POSTGRES_AUTH_MODE
+              value: "password"
+            - name: POSTGRES_DATABASE
+              value: "holiday_peak_crud"
+            - name: POSTGRES_HOST
+              value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
+            - name: POSTGRES_PORT
+              value: "5432"
+            - name: POSTGRES_SSL
+              value: "true"
+            - name: POSTGRES_USER
+              value: "crud_workload"
+            - name: PROJECT_ENDPOINT
+              value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
+            - name: PROJECT_NAME
+              value: "aipholidaris"
+            - name: REDIS_HOST
+              value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
+            - name: REDIS_PASSWORD_SECRET_NAME
+              value: "redis-primary-key"
+            - name: REDIS_URL
+              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
+          ports:
+            - containerPort: 8000
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 250m
+              memory: 256Mi
+---
+# Source: holiday-peak-service/templates/agc-routing.yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: crm-segmentation-personalization-crm-segmentation-personalizati-agc
+  namespace: holiday-peak
+  labels:
+    app: crm-segmentation-personalization
+spec:
+  parentRefs:
+    - name: "holiday-peak-agc"
+      namespace: "holiday-peak"
+  hostnames:
+    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/crm-segmentation-personalization"
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: "/"
+      backendRefs:
+        - name: crm-segmentation-personalization-crm-segmentation-personalizati
+          port: 80

--- a/.kubernetes/rendered/crm-support-assistance/all.yaml
+++ b/.kubernetes/rendered/crm-support-assistance/all.yaml
@@ -1,0 +1,197 @@
+---
+# Source: holiday-peak-service/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: crm-support-assistance
+  namespace: holiday-peak
+  labels:
+    app: crm-support-assistance
+  annotations:
+    azure.workload.identity/client-id: "036f4fd2-9093-4948-b0dd-beb5c87aa6dc"
+---
+# Source: holiday-peak-service/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: crm-support-assistance-crm-support-assistance
+  namespace: holiday-peak
+  labels:
+    app: crm-support-assistance
+spec:
+  selector:
+    app: crm-support-assistance
+    # When canary is disabled, select all pods
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8000
+  type: ClusterIP
+---
+# Source: holiday-peak-service/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: crm-support-assistance-crm-support-assistance
+  namespace: holiday-peak
+  labels:
+    app: crm-support-assistance
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  selector:
+    matchLabels:
+      app: crm-support-assistance
+  template:
+    metadata:
+      labels:
+        app: crm-support-assistance
+        canary: "false"
+        azure.workload.identity/use: "true"
+    spec:
+      serviceAccountName: crm-support-assistance
+      nodeSelector:
+        agentpool: agents
+      tolerations:
+        - effect: NoSchedule
+          key: workload
+          operator: Equal
+          value: agents
+      containers:
+        - name: crm-support-assistance
+          image: "holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/crm-support-assistance-dev:azd-deploy-1775345018"
+          env:
+            - name: AI_SEARCH_AUTH_MODE
+              value: "managed_identity"
+            - name: AI_SEARCH_ENDPOINT
+              value: "https://holidaypeakhub405devsearch.search.windows.net"
+            - name: AI_SEARCH_INDEX
+              value: "catalog-products"
+            - name: AI_SEARCH_INDEXER_NAME
+              value: "search-enriched-products-indexer"
+            - name: AI_SEARCH_VECTOR_INDEX
+              value: "product_search_index"
+            - name: APPLICATIONINSIGHTS_CONNECTION_STRING
+              value: "InstrumentationKey=d2fb45bc-e648-4da2-9345-d278636aede5;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=d8eb64c4-956d-46ab-a02e-d481deadaa0b"
+            - name: AZURE_CLIENT_ID
+              value: "036f4fd2-9093-4948-b0dd-beb5c87aa6dc"
+            - name: AZURE_TENANT_ID
+              value: "16b3c013-d300-468d-ac64-7eda0820b6d3"
+            - name: BLOB_ACCOUNT_URL
+              value: "https://holidaypeakhub405devstor.blob.core.windows.net"
+            - name: BLOB_CONTAINER
+              value: "agent-memory"
+            - name: CATALOG_SEARCH_REQUIRE_AI_SEARCH
+              value: "true"
+            - name: COSMOS_ACCOUNT_URI
+              value: "https://holidaypeakhub405-dev-cosmos.documents.azure.com:443/"
+            - name: COSMOS_CONTAINER
+              value: "agent-memory"
+            - name: COSMOS_DATABASE
+              value: "holiday-peak-db"
+            - name: EMBEDDING_DEPLOYMENT_NAME
+              value: "text-embedding-3-large"
+            - name: EVENT_HUB_NAMESPACE
+              value: "holidaypeakhub405-dev-eventhub"
+            - name: FOUNDRY_AGENT_NAME_FAST
+              value: "crm-support-assistance-fast"
+            - name: FOUNDRY_AGENT_NAME_RICH
+              value: "crm-support-assistance-rich"
+            - name: FOUNDRY_AUTO_ENSURE_ON_STARTUP
+              value: "true"
+            - name: FOUNDRY_STREAM
+              value: "false"
+            - name: FOUNDRY_STRICT_ENFORCEMENT
+              value: "false"
+            - name: KEY_VAULT_URI
+              value: "https://holidaypeakhub405-dev-kv.vault.azure.net/"
+            - name: MODEL_DEPLOYMENT_NAME_FAST
+              value: "gpt-5-nano"
+            - name: MODEL_DEPLOYMENT_NAME_RICH
+              value: "gpt-5"
+            - name: POSTGRES_AUTH_MODE
+              value: "password"
+            - name: POSTGRES_DATABASE
+              value: "holiday_peak_crud"
+            - name: POSTGRES_HOST
+              value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
+            - name: POSTGRES_PORT
+              value: "5432"
+            - name: POSTGRES_SSL
+              value: "true"
+            - name: POSTGRES_USER
+              value: "crud_workload"
+            - name: PROJECT_ENDPOINT
+              value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
+            - name: PROJECT_NAME
+              value: "aipholidaris"
+            - name: REDIS_HOST
+              value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
+            - name: REDIS_PASSWORD_SECRET_NAME
+              value: "redis-primary-key"
+            - name: REDIS_URL
+              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
+          ports:
+            - containerPort: 8000
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 250m
+              memory: 256Mi
+---
+# Source: holiday-peak-service/templates/agc-routing.yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: crm-support-assistance-crm-support-assistance-agc
+  namespace: holiday-peak
+  labels:
+    app: crm-support-assistance
+spec:
+  parentRefs:
+    - name: "holiday-peak-agc"
+      namespace: "holiday-peak"
+  hostnames:
+    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/crm-support-assistance"
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: "/"
+      backendRefs:
+        - name: crm-support-assistance-crm-support-assistance
+          port: 80

--- a/.kubernetes/rendered/crud-service/all.yaml
+++ b/.kubernetes/rendered/crud-service/all.yaml
@@ -1,0 +1,223 @@
+---
+# Source: holiday-peak-service/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: crud-service
+  namespace: holiday-peak
+  labels:
+    app: crud-service
+  annotations:
+    azure.workload.identity/client-id: "b09349cf-547f-409f-8b96-f3288ddedf34"
+---
+# Source: holiday-peak-service/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: crud-service-crud-service
+  namespace: holiday-peak
+  labels:
+    app: crud-service
+spec:
+  selector:
+    app: crud-service
+    # When canary is disabled, select all pods
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8000
+  type: ClusterIP
+---
+# Source: holiday-peak-service/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: crud-service-crud-service
+  namespace: holiday-peak
+  labels:
+    app: crud-service
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 100%
+      maxSurge: 1
+  selector:
+    matchLabels:
+      app: crud-service
+  template:
+    metadata:
+      labels:
+        app: crud-service
+        canary: "false"
+        azure.workload.identity/use: "true"
+    spec:
+      serviceAccountName: crud-service
+      nodeSelector:
+        agentpool: crud
+      tolerations:
+        - effect: NoSchedule
+          key: workload
+          operator: Equal
+          value: crud
+      containers:
+        - name: crud-service
+          image: "holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/crud-service-dev:azd-deploy-1775825425"
+          env:
+            - name: AI_SEARCH_AUTH_MODE
+              value: "managed_identity"
+            - name: AI_SEARCH_ENDPOINT
+              value: "https://holidaypeakhub405devsearch.search.windows.net"
+            - name: AI_SEARCH_INDEX
+              value: "catalog-products"
+            - name: AI_SEARCH_INDEXER_NAME
+              value: "search-enriched-products-indexer"
+            - name: AI_SEARCH_VECTOR_INDEX
+              value: "product_search_index"
+            - name: APPLICATIONINSIGHTS_CONNECTION_STRING
+              value: "InstrumentationKey=d2fb45bc-e648-4da2-9345-d278636aede5;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=d8eb64c4-956d-46ab-a02e-d481deadaa0b"
+            - name: AZURE_CLIENT_ID
+              value: "b09349cf-547f-409f-8b96-f3288ddedf34"
+            - name: AZURE_TENANT_ID
+              value: "16b3c013-d300-468d-ac64-7eda0820b6d3"
+            - name: BLOB_ACCOUNT_URL
+              value: "https://holidaypeakhub405devstor.blob.core.windows.net"
+            - name: BLOB_CONTAINER
+              value: "agent-memory"
+            - name: CATALOG_SEARCH_REQUIRE_AI_SEARCH
+              value: "true"
+            - name: COSMOS_ACCOUNT_URI
+              value: "https://holidaypeakhub405-dev-cosmos.documents.azure.com:443/"
+            - name: COSMOS_CONTAINER
+              value: "agent-memory"
+            - name: COSMOS_DATABASE
+              value: "holiday-peak-db"
+            - name: EMBEDDING_DEPLOYMENT_NAME
+              value: "text-embedding-3-large"
+            - name: EVENT_HUB_NAMESPACE
+              value: "holidaypeakhub405-dev-eventhub"
+            - name: FOUNDRY_AUTO_ENSURE_ON_STARTUP
+              value: "true"
+            - name: FOUNDRY_STREAM
+              value: "false"
+            - name: FOUNDRY_STRICT_ENFORCEMENT
+              value: "false"
+            - name: KEY_VAULT_URI
+              value: "https://holidaypeakhub405-dev-kv.vault.azure.net/"
+            - name: MODEL_DEPLOYMENT_NAME_FAST
+              value: "gpt-5-nano"
+            - name: MODEL_DEPLOYMENT_NAME_RICH
+              value: "gpt-5"
+            - name: POSTGRES_AUTH_MODE
+              value: "entra"
+            - name: POSTGRES_DATABASE
+              value: "holiday_peak_crud"
+            - name: POSTGRES_HOST
+              value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
+            - name: POSTGRES_PORT
+              value: "5432"
+            - name: POSTGRES_SSL
+              value: "true"
+            - name: POSTGRES_USER
+              value: "holidaypeakhub405-dev-crud-identity"
+            - name: PROJECT_ENDPOINT
+              value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
+            - name: PROJECT_NAME
+              value: "aipholidaris"
+            - name: REDIS_HOST
+              value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
+            - name: REDIS_PASSWORD_SECRET_NAME
+              value: "redis-primary-key"
+          ports:
+            - containerPort: 8000
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 250m
+              memory: 256Mi
+---
+# Source: holiday-peak-service/templates/agc-routing.yaml
+apiVersion: alb.networking.azure.io/v1
+kind: ApplicationLoadBalancer
+metadata:
+  name: holiday-peak-agc
+  namespace: holiday-peak
+  labels:
+    app: crud-service
+spec:
+  associations:
+    - "/subscriptions/150e82e8-25db-4f1a-8e04-a2f6a77d26c4/resourceGroups/holidaypeakhub405-dev-rg/providers/Microsoft.Network/virtualNetworks/holidaypeakhub405-dev-vnet/subnets/agc"
+---
+# Source: holiday-peak-service/templates/agc-routing.yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: holiday-peak-agc
+  namespace: holiday-peak
+  labels:
+    app: crud-service
+spec:
+  gatewayClassName: "azure-alb-external"
+  listeners:
+    - name: "http"
+      protocol: "HTTP"
+      port: 80
+      hostname: "e3g0avgfauc3e4cp.fz87.alb.azure.com"
+      allowedRoutes:
+        namespaces:
+          from: Same
+---
+# Source: holiday-peak-service/templates/agc-routing.yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: crud-service-crud-service-agc
+  namespace: holiday-peak
+  labels:
+    app: crud-service
+spec:
+  parentRefs:
+    - name: "holiday-peak-agc"
+      namespace: "holiday-peak"
+  hostnames:
+    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/health"
+      backendRefs:
+        - name: crud-service-crud-service
+          port: 80
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/api"
+      backendRefs:
+        - name: crud-service-crud-service
+          port: 80

--- a/.kubernetes/rendered/ecommerce-cart-intelligence/all.yaml
+++ b/.kubernetes/rendered/ecommerce-cart-intelligence/all.yaml
@@ -1,0 +1,197 @@
+---
+# Source: holiday-peak-service/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ecommerce-cart-intelligence
+  namespace: holiday-peak
+  labels:
+    app: ecommerce-cart-intelligence
+  annotations:
+    azure.workload.identity/client-id: "036f4fd2-9093-4948-b0dd-beb5c87aa6dc"
+---
+# Source: holiday-peak-service/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: ecommerce-cart-intelligence-ecommerce-cart-intelligence
+  namespace: holiday-peak
+  labels:
+    app: ecommerce-cart-intelligence
+spec:
+  selector:
+    app: ecommerce-cart-intelligence
+    # When canary is disabled, select all pods
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8000
+  type: ClusterIP
+---
+# Source: holiday-peak-service/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ecommerce-cart-intelligence-ecommerce-cart-intelligence
+  namespace: holiday-peak
+  labels:
+    app: ecommerce-cart-intelligence
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  selector:
+    matchLabels:
+      app: ecommerce-cart-intelligence
+  template:
+    metadata:
+      labels:
+        app: ecommerce-cart-intelligence
+        canary: "false"
+        azure.workload.identity/use: "true"
+    spec:
+      serviceAccountName: ecommerce-cart-intelligence
+      nodeSelector:
+        agentpool: agents
+      tolerations:
+        - effect: NoSchedule
+          key: workload
+          operator: Equal
+          value: agents
+      containers:
+        - name: ecommerce-cart-intelligence
+          image: "holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/ecommerce-cart-intelligence-dev:azd-deploy-1775345183"
+          env:
+            - name: AI_SEARCH_AUTH_MODE
+              value: "managed_identity"
+            - name: AI_SEARCH_ENDPOINT
+              value: "https://holidaypeakhub405devsearch.search.windows.net"
+            - name: AI_SEARCH_INDEX
+              value: "catalog-products"
+            - name: AI_SEARCH_INDEXER_NAME
+              value: "search-enriched-products-indexer"
+            - name: AI_SEARCH_VECTOR_INDEX
+              value: "product_search_index"
+            - name: APPLICATIONINSIGHTS_CONNECTION_STRING
+              value: "InstrumentationKey=d2fb45bc-e648-4da2-9345-d278636aede5;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=d8eb64c4-956d-46ab-a02e-d481deadaa0b"
+            - name: AZURE_CLIENT_ID
+              value: "036f4fd2-9093-4948-b0dd-beb5c87aa6dc"
+            - name: AZURE_TENANT_ID
+              value: "16b3c013-d300-468d-ac64-7eda0820b6d3"
+            - name: BLOB_ACCOUNT_URL
+              value: "https://holidaypeakhub405devstor.blob.core.windows.net"
+            - name: BLOB_CONTAINER
+              value: "agent-memory"
+            - name: CATALOG_SEARCH_REQUIRE_AI_SEARCH
+              value: "true"
+            - name: COSMOS_ACCOUNT_URI
+              value: "https://holidaypeakhub405-dev-cosmos.documents.azure.com:443/"
+            - name: COSMOS_CONTAINER
+              value: "agent-memory"
+            - name: COSMOS_DATABASE
+              value: "holiday-peak-db"
+            - name: EMBEDDING_DEPLOYMENT_NAME
+              value: "text-embedding-3-large"
+            - name: EVENT_HUB_NAMESPACE
+              value: "holidaypeakhub405-dev-eventhub"
+            - name: FOUNDRY_AGENT_NAME_FAST
+              value: "ecommerce-cart-intelligence-fast"
+            - name: FOUNDRY_AGENT_NAME_RICH
+              value: "ecommerce-cart-intelligence-rich"
+            - name: FOUNDRY_AUTO_ENSURE_ON_STARTUP
+              value: "true"
+            - name: FOUNDRY_STREAM
+              value: "false"
+            - name: FOUNDRY_STRICT_ENFORCEMENT
+              value: "false"
+            - name: KEY_VAULT_URI
+              value: "https://holidaypeakhub405-dev-kv.vault.azure.net/"
+            - name: MODEL_DEPLOYMENT_NAME_FAST
+              value: "gpt-5-nano"
+            - name: MODEL_DEPLOYMENT_NAME_RICH
+              value: "gpt-5"
+            - name: POSTGRES_AUTH_MODE
+              value: "password"
+            - name: POSTGRES_DATABASE
+              value: "holiday_peak_crud"
+            - name: POSTGRES_HOST
+              value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
+            - name: POSTGRES_PORT
+              value: "5432"
+            - name: POSTGRES_SSL
+              value: "true"
+            - name: POSTGRES_USER
+              value: "crud_workload"
+            - name: PROJECT_ENDPOINT
+              value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
+            - name: PROJECT_NAME
+              value: "aipholidaris"
+            - name: REDIS_HOST
+              value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
+            - name: REDIS_PASSWORD_SECRET_NAME
+              value: "redis-primary-key"
+            - name: REDIS_URL
+              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
+          ports:
+            - containerPort: 8000
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 250m
+              memory: 256Mi
+---
+# Source: holiday-peak-service/templates/agc-routing.yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ecommerce-cart-intelligence-ecommerce-cart-intelligence-agc
+  namespace: holiday-peak
+  labels:
+    app: ecommerce-cart-intelligence
+spec:
+  parentRefs:
+    - name: "holiday-peak-agc"
+      namespace: "holiday-peak"
+  hostnames:
+    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/ecommerce-cart-intelligence"
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: "/"
+      backendRefs:
+        - name: ecommerce-cart-intelligence-ecommerce-cart-intelligence
+          port: 80

--- a/.kubernetes/rendered/ecommerce-catalog-search/all.yaml
+++ b/.kubernetes/rendered/ecommerce-catalog-search/all.yaml
@@ -1,0 +1,201 @@
+---
+# Source: holiday-peak-service/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ecommerce-catalog-search
+  namespace: holiday-peak
+  labels:
+    app: ecommerce-catalog-search
+  annotations:
+    azure.workload.identity/client-id: "036f4fd2-9093-4948-b0dd-beb5c87aa6dc"
+---
+# Source: holiday-peak-service/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: ecommerce-catalog-search-ecommerce-catalog-search
+  namespace: holiday-peak
+  labels:
+    app: ecommerce-catalog-search
+spec:
+  selector:
+    app: ecommerce-catalog-search
+    # When canary is disabled, select all pods
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8000
+  type: ClusterIP
+---
+# Source: holiday-peak-service/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ecommerce-catalog-search-ecommerce-catalog-search
+  namespace: holiday-peak
+  labels:
+    app: ecommerce-catalog-search
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  selector:
+    matchLabels:
+      app: ecommerce-catalog-search
+  template:
+    metadata:
+      labels:
+        app: ecommerce-catalog-search
+        canary: "false"
+        azure.workload.identity/use: "true"
+    spec:
+      serviceAccountName: ecommerce-catalog-search
+      nodeSelector:
+        agentpool: agents
+      tolerations:
+        - effect: NoSchedule
+          key: workload
+          operator: Equal
+          value: agents
+      containers:
+        - name: ecommerce-catalog-search
+          image: "holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/ecommerce-catalog-search-dev:azd-deploy-1775345403"
+          env:
+            - name: AI_SEARCH_AUTH_MODE
+              value: "managed_identity"
+            - name: AI_SEARCH_ENDPOINT
+              value: "https://holidaypeakhub405devsearch.search.windows.net"
+            - name: AI_SEARCH_INDEX
+              value: "catalog-products"
+            - name: AI_SEARCH_INDEXER_NAME
+              value: "search-enriched-products-indexer"
+            - name: AI_SEARCH_VECTOR_INDEX
+              value: "product_search_index"
+            - name: APPLICATIONINSIGHTS_CONNECTION_STRING
+              value: "InstrumentationKey=d2fb45bc-e648-4da2-9345-d278636aede5;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=d8eb64c4-956d-46ab-a02e-d481deadaa0b"
+            - name: AZURE_CLIENT_ID
+              value: "036f4fd2-9093-4948-b0dd-beb5c87aa6dc"
+            - name: AZURE_TENANT_ID
+              value: "16b3c013-d300-468d-ac64-7eda0820b6d3"
+            - name: BLOB_ACCOUNT_URL
+              value: "https://holidaypeakhub405devstor.blob.core.windows.net"
+            - name: BLOB_CONTAINER
+              value: "agent-memory"
+            - name: CATALOG_SEARCH_REQUIRE_AI_SEARCH
+              value: "true"
+            - name: COSMOS_ACCOUNT_URI
+              value: "https://holidaypeakhub405-dev-cosmos.documents.azure.com:443/"
+            - name: COSMOS_CONTAINER
+              value: "agent-memory"
+            - name: COSMOS_DATABASE
+              value: "holiday-peak-db"
+            - name: EMBEDDING_DEPLOYMENT_NAME
+              value: "text-embedding-3-large"
+            - name: EVENT_HUB_NAMESPACE
+              value: "holidaypeakhub405-dev-eventhub"
+            - name: FOUNDRY_AGENT_NAME_FAST
+              value: "ecommerce-catalog-search-fast"
+            - name: FOUNDRY_AGENT_NAME_RICH
+              value: "ecommerce-catalog-search-rich"
+            - name: FOUNDRY_AUTO_ENSURE_ON_STARTUP
+              value: "true"
+            - name: FOUNDRY_STREAM
+              value: "false"
+            - name: FOUNDRY_STRICT_ENFORCEMENT
+              value: "false"
+            - name: KEY_VAULT_URI
+              value: "https://holidaypeakhub405-dev-kv.vault.azure.net/"
+            - name: MODEL_DEPLOYMENT_NAME_FAST
+              value: "gpt-5-nano"
+            - name: MODEL_DEPLOYMENT_NAME_RICH
+              value: "gpt-5"
+            - name: POSTGRES_AUTH_MODE
+              value: "password"
+            - name: POSTGRES_DATABASE
+              value: "holiday_peak_crud"
+            - name: POSTGRES_HOST
+              value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
+            - name: POSTGRES_PORT
+              value: "5432"
+            - name: POSTGRES_SSL
+              value: "true"
+            - name: POSTGRES_USER
+              value: "crud_workload"
+            - name: PROJECT_ENDPOINT
+              value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
+            - name: PROJECT_NAME
+              value: "aipholidaris"
+            - name: REDIS_HOST
+              value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
+            - name: REDIS_PASSWORD_SECRET_NAME
+              value: "redis-primary-key"
+            - name: REDIS_URL
+              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
+            - name: SEARCH_ENRICHMENT_EVENT_HUB_CONSUMER_GROUP
+              value: "search-enrichment-consumer"
+            - name: SEARCH_ENRICHMENT_EVENT_HUB_NAME
+              value: "search-enrichment-jobs"
+          ports:
+            - containerPort: 8000
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 250m
+              memory: 256Mi
+---
+# Source: holiday-peak-service/templates/agc-routing.yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ecommerce-catalog-search-ecommerce-catalog-search-agc
+  namespace: holiday-peak
+  labels:
+    app: ecommerce-catalog-search
+spec:
+  parentRefs:
+    - name: "holiday-peak-agc"
+      namespace: "holiday-peak"
+  hostnames:
+    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/ecommerce-catalog-search"
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: "/"
+      backendRefs:
+        - name: ecommerce-catalog-search-ecommerce-catalog-search
+          port: 80

--- a/.kubernetes/rendered/ecommerce-checkout-support/all.yaml
+++ b/.kubernetes/rendered/ecommerce-checkout-support/all.yaml
@@ -1,0 +1,197 @@
+---
+# Source: holiday-peak-service/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ecommerce-checkout-support
+  namespace: holiday-peak
+  labels:
+    app: ecommerce-checkout-support
+  annotations:
+    azure.workload.identity/client-id: "036f4fd2-9093-4948-b0dd-beb5c87aa6dc"
+---
+# Source: holiday-peak-service/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: ecommerce-checkout-support-ecommerce-checkout-support
+  namespace: holiday-peak
+  labels:
+    app: ecommerce-checkout-support
+spec:
+  selector:
+    app: ecommerce-checkout-support
+    # When canary is disabled, select all pods
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8000
+  type: ClusterIP
+---
+# Source: holiday-peak-service/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ecommerce-checkout-support-ecommerce-checkout-support
+  namespace: holiday-peak
+  labels:
+    app: ecommerce-checkout-support
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  selector:
+    matchLabels:
+      app: ecommerce-checkout-support
+  template:
+    metadata:
+      labels:
+        app: ecommerce-checkout-support
+        canary: "false"
+        azure.workload.identity/use: "true"
+    spec:
+      serviceAccountName: ecommerce-checkout-support
+      nodeSelector:
+        agentpool: agents
+      tolerations:
+        - effect: NoSchedule
+          key: workload
+          operator: Equal
+          value: agents
+      containers:
+        - name: ecommerce-checkout-support
+          image: "holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/ecommerce-checkout-support-dev:azd-deploy-1775345620"
+          env:
+            - name: AI_SEARCH_AUTH_MODE
+              value: "managed_identity"
+            - name: AI_SEARCH_ENDPOINT
+              value: "https://holidaypeakhub405devsearch.search.windows.net"
+            - name: AI_SEARCH_INDEX
+              value: "catalog-products"
+            - name: AI_SEARCH_INDEXER_NAME
+              value: "search-enriched-products-indexer"
+            - name: AI_SEARCH_VECTOR_INDEX
+              value: "product_search_index"
+            - name: APPLICATIONINSIGHTS_CONNECTION_STRING
+              value: "InstrumentationKey=d2fb45bc-e648-4da2-9345-d278636aede5;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=d8eb64c4-956d-46ab-a02e-d481deadaa0b"
+            - name: AZURE_CLIENT_ID
+              value: "036f4fd2-9093-4948-b0dd-beb5c87aa6dc"
+            - name: AZURE_TENANT_ID
+              value: "16b3c013-d300-468d-ac64-7eda0820b6d3"
+            - name: BLOB_ACCOUNT_URL
+              value: "https://holidaypeakhub405devstor.blob.core.windows.net"
+            - name: BLOB_CONTAINER
+              value: "agent-memory"
+            - name: CATALOG_SEARCH_REQUIRE_AI_SEARCH
+              value: "true"
+            - name: COSMOS_ACCOUNT_URI
+              value: "https://holidaypeakhub405-dev-cosmos.documents.azure.com:443/"
+            - name: COSMOS_CONTAINER
+              value: "agent-memory"
+            - name: COSMOS_DATABASE
+              value: "holiday-peak-db"
+            - name: EMBEDDING_DEPLOYMENT_NAME
+              value: "text-embedding-3-large"
+            - name: EVENT_HUB_NAMESPACE
+              value: "holidaypeakhub405-dev-eventhub"
+            - name: FOUNDRY_AGENT_NAME_FAST
+              value: "ecommerce-checkout-support-fast"
+            - name: FOUNDRY_AGENT_NAME_RICH
+              value: "ecommerce-checkout-support-rich"
+            - name: FOUNDRY_AUTO_ENSURE_ON_STARTUP
+              value: "true"
+            - name: FOUNDRY_STREAM
+              value: "false"
+            - name: FOUNDRY_STRICT_ENFORCEMENT
+              value: "false"
+            - name: KEY_VAULT_URI
+              value: "https://holidaypeakhub405-dev-kv.vault.azure.net/"
+            - name: MODEL_DEPLOYMENT_NAME_FAST
+              value: "gpt-5-nano"
+            - name: MODEL_DEPLOYMENT_NAME_RICH
+              value: "gpt-5"
+            - name: POSTGRES_AUTH_MODE
+              value: "password"
+            - name: POSTGRES_DATABASE
+              value: "holiday_peak_crud"
+            - name: POSTGRES_HOST
+              value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
+            - name: POSTGRES_PORT
+              value: "5432"
+            - name: POSTGRES_SSL
+              value: "true"
+            - name: POSTGRES_USER
+              value: "crud_workload"
+            - name: PROJECT_ENDPOINT
+              value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
+            - name: PROJECT_NAME
+              value: "aipholidaris"
+            - name: REDIS_HOST
+              value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
+            - name: REDIS_PASSWORD_SECRET_NAME
+              value: "redis-primary-key"
+            - name: REDIS_URL
+              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
+          ports:
+            - containerPort: 8000
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 250m
+              memory: 256Mi
+---
+# Source: holiday-peak-service/templates/agc-routing.yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ecommerce-checkout-support-ecommerce-checkout-support-agc
+  namespace: holiday-peak
+  labels:
+    app: ecommerce-checkout-support
+spec:
+  parentRefs:
+    - name: "holiday-peak-agc"
+      namespace: "holiday-peak"
+  hostnames:
+    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/ecommerce-checkout-support"
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: "/"
+      backendRefs:
+        - name: ecommerce-checkout-support-ecommerce-checkout-support
+          port: 80

--- a/.kubernetes/rendered/ecommerce-order-status/all.yaml
+++ b/.kubernetes/rendered/ecommerce-order-status/all.yaml
@@ -1,0 +1,197 @@
+---
+# Source: holiday-peak-service/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ecommerce-order-status
+  namespace: holiday-peak
+  labels:
+    app: ecommerce-order-status
+  annotations:
+    azure.workload.identity/client-id: "036f4fd2-9093-4948-b0dd-beb5c87aa6dc"
+---
+# Source: holiday-peak-service/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: ecommerce-order-status-ecommerce-order-status
+  namespace: holiday-peak
+  labels:
+    app: ecommerce-order-status
+spec:
+  selector:
+    app: ecommerce-order-status
+    # When canary is disabled, select all pods
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8000
+  type: ClusterIP
+---
+# Source: holiday-peak-service/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ecommerce-order-status-ecommerce-order-status
+  namespace: holiday-peak
+  labels:
+    app: ecommerce-order-status
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  selector:
+    matchLabels:
+      app: ecommerce-order-status
+  template:
+    metadata:
+      labels:
+        app: ecommerce-order-status
+        canary: "false"
+        azure.workload.identity/use: "true"
+    spec:
+      serviceAccountName: ecommerce-order-status
+      nodeSelector:
+        agentpool: agents
+      tolerations:
+        - effect: NoSchedule
+          key: workload
+          operator: Equal
+          value: agents
+      containers:
+        - name: ecommerce-order-status
+          image: "holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/ecommerce-order-status-dev:azd-deploy-1775345850"
+          env:
+            - name: AI_SEARCH_AUTH_MODE
+              value: "managed_identity"
+            - name: AI_SEARCH_ENDPOINT
+              value: "https://holidaypeakhub405devsearch.search.windows.net"
+            - name: AI_SEARCH_INDEX
+              value: "catalog-products"
+            - name: AI_SEARCH_INDEXER_NAME
+              value: "search-enriched-products-indexer"
+            - name: AI_SEARCH_VECTOR_INDEX
+              value: "product_search_index"
+            - name: APPLICATIONINSIGHTS_CONNECTION_STRING
+              value: "InstrumentationKey=d2fb45bc-e648-4da2-9345-d278636aede5;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=d8eb64c4-956d-46ab-a02e-d481deadaa0b"
+            - name: AZURE_CLIENT_ID
+              value: "036f4fd2-9093-4948-b0dd-beb5c87aa6dc"
+            - name: AZURE_TENANT_ID
+              value: "16b3c013-d300-468d-ac64-7eda0820b6d3"
+            - name: BLOB_ACCOUNT_URL
+              value: "https://holidaypeakhub405devstor.blob.core.windows.net"
+            - name: BLOB_CONTAINER
+              value: "agent-memory"
+            - name: CATALOG_SEARCH_REQUIRE_AI_SEARCH
+              value: "true"
+            - name: COSMOS_ACCOUNT_URI
+              value: "https://holidaypeakhub405-dev-cosmos.documents.azure.com:443/"
+            - name: COSMOS_CONTAINER
+              value: "agent-memory"
+            - name: COSMOS_DATABASE
+              value: "holiday-peak-db"
+            - name: EMBEDDING_DEPLOYMENT_NAME
+              value: "text-embedding-3-large"
+            - name: EVENT_HUB_NAMESPACE
+              value: "holidaypeakhub405-dev-eventhub"
+            - name: FOUNDRY_AGENT_NAME_FAST
+              value: "ecommerce-order-status-fast"
+            - name: FOUNDRY_AGENT_NAME_RICH
+              value: "ecommerce-order-status-rich"
+            - name: FOUNDRY_AUTO_ENSURE_ON_STARTUP
+              value: "true"
+            - name: FOUNDRY_STREAM
+              value: "false"
+            - name: FOUNDRY_STRICT_ENFORCEMENT
+              value: "false"
+            - name: KEY_VAULT_URI
+              value: "https://holidaypeakhub405-dev-kv.vault.azure.net/"
+            - name: MODEL_DEPLOYMENT_NAME_FAST
+              value: "gpt-5-nano"
+            - name: MODEL_DEPLOYMENT_NAME_RICH
+              value: "gpt-5"
+            - name: POSTGRES_AUTH_MODE
+              value: "password"
+            - name: POSTGRES_DATABASE
+              value: "holiday_peak_crud"
+            - name: POSTGRES_HOST
+              value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
+            - name: POSTGRES_PORT
+              value: "5432"
+            - name: POSTGRES_SSL
+              value: "true"
+            - name: POSTGRES_USER
+              value: "crud_workload"
+            - name: PROJECT_ENDPOINT
+              value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
+            - name: PROJECT_NAME
+              value: "aipholidaris"
+            - name: REDIS_HOST
+              value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
+            - name: REDIS_PASSWORD_SECRET_NAME
+              value: "redis-primary-key"
+            - name: REDIS_URL
+              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
+          ports:
+            - containerPort: 8000
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 250m
+              memory: 256Mi
+---
+# Source: holiday-peak-service/templates/agc-routing.yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ecommerce-order-status-ecommerce-order-status-agc
+  namespace: holiday-peak
+  labels:
+    app: ecommerce-order-status
+spec:
+  parentRefs:
+    - name: "holiday-peak-agc"
+      namespace: "holiday-peak"
+  hostnames:
+    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/ecommerce-order-status"
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: "/"
+      backendRefs:
+        - name: ecommerce-order-status-ecommerce-order-status
+          port: 80

--- a/.kubernetes/rendered/ecommerce-product-detail-enrichment/all.yaml
+++ b/.kubernetes/rendered/ecommerce-product-detail-enrichment/all.yaml
@@ -1,0 +1,197 @@
+---
+# Source: holiday-peak-service/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ecommerce-product-detail-enrichment
+  namespace: holiday-peak
+  labels:
+    app: ecommerce-product-detail-enrichment
+  annotations:
+    azure.workload.identity/client-id: "036f4fd2-9093-4948-b0dd-beb5c87aa6dc"
+---
+# Source: holiday-peak-service/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: ecommerce-product-detail-enrichment-ecommerce-product-detail-en
+  namespace: holiday-peak
+  labels:
+    app: ecommerce-product-detail-enrichment
+spec:
+  selector:
+    app: ecommerce-product-detail-enrichment
+    # When canary is disabled, select all pods
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8000
+  type: ClusterIP
+---
+# Source: holiday-peak-service/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ecommerce-product-detail-enrichment-ecommerce-product-detail-en
+  namespace: holiday-peak
+  labels:
+    app: ecommerce-product-detail-enrichment
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  selector:
+    matchLabels:
+      app: ecommerce-product-detail-enrichment
+  template:
+    metadata:
+      labels:
+        app: ecommerce-product-detail-enrichment
+        canary: "false"
+        azure.workload.identity/use: "true"
+    spec:
+      serviceAccountName: ecommerce-product-detail-enrichment
+      nodeSelector:
+        agentpool: agents
+      tolerations:
+        - effect: NoSchedule
+          key: workload
+          operator: Equal
+          value: agents
+      containers:
+        - name: ecommerce-product-detail-enrichment
+          image: "holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/ecommerce-product-detail-enrichment-dev:azd-deploy-1775346091"
+          env:
+            - name: AI_SEARCH_AUTH_MODE
+              value: "managed_identity"
+            - name: AI_SEARCH_ENDPOINT
+              value: "https://holidaypeakhub405devsearch.search.windows.net"
+            - name: AI_SEARCH_INDEX
+              value: "catalog-products"
+            - name: AI_SEARCH_INDEXER_NAME
+              value: "search-enriched-products-indexer"
+            - name: AI_SEARCH_VECTOR_INDEX
+              value: "product_search_index"
+            - name: APPLICATIONINSIGHTS_CONNECTION_STRING
+              value: "InstrumentationKey=d2fb45bc-e648-4da2-9345-d278636aede5;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=d8eb64c4-956d-46ab-a02e-d481deadaa0b"
+            - name: AZURE_CLIENT_ID
+              value: "036f4fd2-9093-4948-b0dd-beb5c87aa6dc"
+            - name: AZURE_TENANT_ID
+              value: "16b3c013-d300-468d-ac64-7eda0820b6d3"
+            - name: BLOB_ACCOUNT_URL
+              value: "https://holidaypeakhub405devstor.blob.core.windows.net"
+            - name: BLOB_CONTAINER
+              value: "agent-memory"
+            - name: CATALOG_SEARCH_REQUIRE_AI_SEARCH
+              value: "true"
+            - name: COSMOS_ACCOUNT_URI
+              value: "https://holidaypeakhub405-dev-cosmos.documents.azure.com:443/"
+            - name: COSMOS_CONTAINER
+              value: "agent-memory"
+            - name: COSMOS_DATABASE
+              value: "holiday-peak-db"
+            - name: EMBEDDING_DEPLOYMENT_NAME
+              value: "text-embedding-3-large"
+            - name: EVENT_HUB_NAMESPACE
+              value: "holidaypeakhub405-dev-eventhub"
+            - name: FOUNDRY_AGENT_NAME_FAST
+              value: "ecommerce-product-detail-enrichment-fast"
+            - name: FOUNDRY_AGENT_NAME_RICH
+              value: "ecommerce-product-detail-enrichment-rich"
+            - name: FOUNDRY_AUTO_ENSURE_ON_STARTUP
+              value: "true"
+            - name: FOUNDRY_STREAM
+              value: "false"
+            - name: FOUNDRY_STRICT_ENFORCEMENT
+              value: "false"
+            - name: KEY_VAULT_URI
+              value: "https://holidaypeakhub405-dev-kv.vault.azure.net/"
+            - name: MODEL_DEPLOYMENT_NAME_FAST
+              value: "gpt-5-nano"
+            - name: MODEL_DEPLOYMENT_NAME_RICH
+              value: "gpt-5"
+            - name: POSTGRES_AUTH_MODE
+              value: "password"
+            - name: POSTGRES_DATABASE
+              value: "holiday_peak_crud"
+            - name: POSTGRES_HOST
+              value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
+            - name: POSTGRES_PORT
+              value: "5432"
+            - name: POSTGRES_SSL
+              value: "true"
+            - name: POSTGRES_USER
+              value: "crud_workload"
+            - name: PROJECT_ENDPOINT
+              value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
+            - name: PROJECT_NAME
+              value: "aipholidaris"
+            - name: REDIS_HOST
+              value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
+            - name: REDIS_PASSWORD_SECRET_NAME
+              value: "redis-primary-key"
+            - name: REDIS_URL
+              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
+          ports:
+            - containerPort: 8000
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 250m
+              memory: 256Mi
+---
+# Source: holiday-peak-service/templates/agc-routing.yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ecommerce-product-detail-enrichment-ecommerce-product-detail-en-agc
+  namespace: holiday-peak
+  labels:
+    app: ecommerce-product-detail-enrichment
+spec:
+  parentRefs:
+    - name: "holiday-peak-agc"
+      namespace: "holiday-peak"
+  hostnames:
+    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/ecommerce-product-detail-enrichment"
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: "/"
+      backendRefs:
+        - name: ecommerce-product-detail-enrichment-ecommerce-product-detail-en
+          port: 80

--- a/.kubernetes/rendered/inventory-alerts-triggers/all.yaml
+++ b/.kubernetes/rendered/inventory-alerts-triggers/all.yaml
@@ -1,0 +1,197 @@
+---
+# Source: holiday-peak-service/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: inventory-alerts-triggers
+  namespace: holiday-peak
+  labels:
+    app: inventory-alerts-triggers
+  annotations:
+    azure.workload.identity/client-id: "036f4fd2-9093-4948-b0dd-beb5c87aa6dc"
+---
+# Source: holiday-peak-service/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: inventory-alerts-triggers-inventory-alerts-triggers
+  namespace: holiday-peak
+  labels:
+    app: inventory-alerts-triggers
+spec:
+  selector:
+    app: inventory-alerts-triggers
+    # When canary is disabled, select all pods
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8000
+  type: ClusterIP
+---
+# Source: holiday-peak-service/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: inventory-alerts-triggers-inventory-alerts-triggers
+  namespace: holiday-peak
+  labels:
+    app: inventory-alerts-triggers
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  selector:
+    matchLabels:
+      app: inventory-alerts-triggers
+  template:
+    metadata:
+      labels:
+        app: inventory-alerts-triggers
+        canary: "false"
+        azure.workload.identity/use: "true"
+    spec:
+      serviceAccountName: inventory-alerts-triggers
+      nodeSelector:
+        agentpool: agents
+      tolerations:
+        - effect: NoSchedule
+          key: workload
+          operator: Equal
+          value: agents
+      containers:
+        - name: inventory-alerts-triggers
+          image: "holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/inventory-alerts-triggers-dev:azd-deploy-1775346297"
+          env:
+            - name: AI_SEARCH_AUTH_MODE
+              value: "managed_identity"
+            - name: AI_SEARCH_ENDPOINT
+              value: "https://holidaypeakhub405devsearch.search.windows.net"
+            - name: AI_SEARCH_INDEX
+              value: "catalog-products"
+            - name: AI_SEARCH_INDEXER_NAME
+              value: "search-enriched-products-indexer"
+            - name: AI_SEARCH_VECTOR_INDEX
+              value: "product_search_index"
+            - name: APPLICATIONINSIGHTS_CONNECTION_STRING
+              value: "InstrumentationKey=d2fb45bc-e648-4da2-9345-d278636aede5;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=d8eb64c4-956d-46ab-a02e-d481deadaa0b"
+            - name: AZURE_CLIENT_ID
+              value: "036f4fd2-9093-4948-b0dd-beb5c87aa6dc"
+            - name: AZURE_TENANT_ID
+              value: "16b3c013-d300-468d-ac64-7eda0820b6d3"
+            - name: BLOB_ACCOUNT_URL
+              value: "https://holidaypeakhub405devstor.blob.core.windows.net"
+            - name: BLOB_CONTAINER
+              value: "agent-memory"
+            - name: CATALOG_SEARCH_REQUIRE_AI_SEARCH
+              value: "true"
+            - name: COSMOS_ACCOUNT_URI
+              value: "https://holidaypeakhub405-dev-cosmos.documents.azure.com:443/"
+            - name: COSMOS_CONTAINER
+              value: "agent-memory"
+            - name: COSMOS_DATABASE
+              value: "holiday-peak-db"
+            - name: EMBEDDING_DEPLOYMENT_NAME
+              value: "text-embedding-3-large"
+            - name: EVENT_HUB_NAMESPACE
+              value: "holidaypeakhub405-dev-eventhub"
+            - name: FOUNDRY_AGENT_NAME_FAST
+              value: "inventory-alerts-triggers-fast"
+            - name: FOUNDRY_AGENT_NAME_RICH
+              value: "inventory-alerts-triggers-rich"
+            - name: FOUNDRY_AUTO_ENSURE_ON_STARTUP
+              value: "true"
+            - name: FOUNDRY_STREAM
+              value: "false"
+            - name: FOUNDRY_STRICT_ENFORCEMENT
+              value: "false"
+            - name: KEY_VAULT_URI
+              value: "https://holidaypeakhub405-dev-kv.vault.azure.net/"
+            - name: MODEL_DEPLOYMENT_NAME_FAST
+              value: "gpt-5-nano"
+            - name: MODEL_DEPLOYMENT_NAME_RICH
+              value: "gpt-5"
+            - name: POSTGRES_AUTH_MODE
+              value: "password"
+            - name: POSTGRES_DATABASE
+              value: "holiday_peak_crud"
+            - name: POSTGRES_HOST
+              value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
+            - name: POSTGRES_PORT
+              value: "5432"
+            - name: POSTGRES_SSL
+              value: "true"
+            - name: POSTGRES_USER
+              value: "crud_workload"
+            - name: PROJECT_ENDPOINT
+              value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
+            - name: PROJECT_NAME
+              value: "aipholidaris"
+            - name: REDIS_HOST
+              value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
+            - name: REDIS_PASSWORD_SECRET_NAME
+              value: "redis-primary-key"
+            - name: REDIS_URL
+              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
+          ports:
+            - containerPort: 8000
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 250m
+              memory: 256Mi
+---
+# Source: holiday-peak-service/templates/agc-routing.yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: inventory-alerts-triggers-inventory-alerts-triggers-agc
+  namespace: holiday-peak
+  labels:
+    app: inventory-alerts-triggers
+spec:
+  parentRefs:
+    - name: "holiday-peak-agc"
+      namespace: "holiday-peak"
+  hostnames:
+    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/inventory-alerts-triggers"
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: "/"
+      backendRefs:
+        - name: inventory-alerts-triggers-inventory-alerts-triggers
+          port: 80

--- a/.kubernetes/rendered/inventory-health-check/all.yaml
+++ b/.kubernetes/rendered/inventory-health-check/all.yaml
@@ -1,0 +1,197 @@
+---
+# Source: holiday-peak-service/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: inventory-health-check
+  namespace: holiday-peak
+  labels:
+    app: inventory-health-check
+  annotations:
+    azure.workload.identity/client-id: "036f4fd2-9093-4948-b0dd-beb5c87aa6dc"
+---
+# Source: holiday-peak-service/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: inventory-health-check-inventory-health-check
+  namespace: holiday-peak
+  labels:
+    app: inventory-health-check
+spec:
+  selector:
+    app: inventory-health-check
+    # When canary is disabled, select all pods
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8000
+  type: ClusterIP
+---
+# Source: holiday-peak-service/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: inventory-health-check-inventory-health-check
+  namespace: holiday-peak
+  labels:
+    app: inventory-health-check
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  selector:
+    matchLabels:
+      app: inventory-health-check
+  template:
+    metadata:
+      labels:
+        app: inventory-health-check
+        canary: "false"
+        azure.workload.identity/use: "true"
+    spec:
+      serviceAccountName: inventory-health-check
+      nodeSelector:
+        agentpool: agents
+      tolerations:
+        - effect: NoSchedule
+          key: workload
+          operator: Equal
+          value: agents
+      containers:
+        - name: inventory-health-check
+          image: "holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/inventory-health-check-dev:azd-deploy-1775346564"
+          env:
+            - name: AI_SEARCH_AUTH_MODE
+              value: "managed_identity"
+            - name: AI_SEARCH_ENDPOINT
+              value: "https://holidaypeakhub405devsearch.search.windows.net"
+            - name: AI_SEARCH_INDEX
+              value: "catalog-products"
+            - name: AI_SEARCH_INDEXER_NAME
+              value: "search-enriched-products-indexer"
+            - name: AI_SEARCH_VECTOR_INDEX
+              value: "product_search_index"
+            - name: APPLICATIONINSIGHTS_CONNECTION_STRING
+              value: "InstrumentationKey=d2fb45bc-e648-4da2-9345-d278636aede5;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=d8eb64c4-956d-46ab-a02e-d481deadaa0b"
+            - name: AZURE_CLIENT_ID
+              value: "036f4fd2-9093-4948-b0dd-beb5c87aa6dc"
+            - name: AZURE_TENANT_ID
+              value: "16b3c013-d300-468d-ac64-7eda0820b6d3"
+            - name: BLOB_ACCOUNT_URL
+              value: "https://holidaypeakhub405devstor.blob.core.windows.net"
+            - name: BLOB_CONTAINER
+              value: "agent-memory"
+            - name: CATALOG_SEARCH_REQUIRE_AI_SEARCH
+              value: "true"
+            - name: COSMOS_ACCOUNT_URI
+              value: "https://holidaypeakhub405-dev-cosmos.documents.azure.com:443/"
+            - name: COSMOS_CONTAINER
+              value: "agent-memory"
+            - name: COSMOS_DATABASE
+              value: "holiday-peak-db"
+            - name: EMBEDDING_DEPLOYMENT_NAME
+              value: "text-embedding-3-large"
+            - name: EVENT_HUB_NAMESPACE
+              value: "holidaypeakhub405-dev-eventhub"
+            - name: FOUNDRY_AGENT_NAME_FAST
+              value: "inventory-health-check-fast"
+            - name: FOUNDRY_AGENT_NAME_RICH
+              value: "inventory-health-check-rich"
+            - name: FOUNDRY_AUTO_ENSURE_ON_STARTUP
+              value: "true"
+            - name: FOUNDRY_STREAM
+              value: "false"
+            - name: FOUNDRY_STRICT_ENFORCEMENT
+              value: "false"
+            - name: KEY_VAULT_URI
+              value: "https://holidaypeakhub405-dev-kv.vault.azure.net/"
+            - name: MODEL_DEPLOYMENT_NAME_FAST
+              value: "gpt-5-nano"
+            - name: MODEL_DEPLOYMENT_NAME_RICH
+              value: "gpt-5"
+            - name: POSTGRES_AUTH_MODE
+              value: "password"
+            - name: POSTGRES_DATABASE
+              value: "holiday_peak_crud"
+            - name: POSTGRES_HOST
+              value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
+            - name: POSTGRES_PORT
+              value: "5432"
+            - name: POSTGRES_SSL
+              value: "true"
+            - name: POSTGRES_USER
+              value: "crud_workload"
+            - name: PROJECT_ENDPOINT
+              value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
+            - name: PROJECT_NAME
+              value: "aipholidaris"
+            - name: REDIS_HOST
+              value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
+            - name: REDIS_PASSWORD_SECRET_NAME
+              value: "redis-primary-key"
+            - name: REDIS_URL
+              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
+          ports:
+            - containerPort: 8000
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 250m
+              memory: 256Mi
+---
+# Source: holiday-peak-service/templates/agc-routing.yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: inventory-health-check-inventory-health-check-agc
+  namespace: holiday-peak
+  labels:
+    app: inventory-health-check
+spec:
+  parentRefs:
+    - name: "holiday-peak-agc"
+      namespace: "holiday-peak"
+  hostnames:
+    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/inventory-health-check"
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: "/"
+      backendRefs:
+        - name: inventory-health-check-inventory-health-check
+          port: 80

--- a/.kubernetes/rendered/inventory-jit-replenishment/all.yaml
+++ b/.kubernetes/rendered/inventory-jit-replenishment/all.yaml
@@ -1,0 +1,197 @@
+---
+# Source: holiday-peak-service/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: inventory-jit-replenishment
+  namespace: holiday-peak
+  labels:
+    app: inventory-jit-replenishment
+  annotations:
+    azure.workload.identity/client-id: "036f4fd2-9093-4948-b0dd-beb5c87aa6dc"
+---
+# Source: holiday-peak-service/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: inventory-jit-replenishment-inventory-jit-replenishment
+  namespace: holiday-peak
+  labels:
+    app: inventory-jit-replenishment
+spec:
+  selector:
+    app: inventory-jit-replenishment
+    # When canary is disabled, select all pods
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8000
+  type: ClusterIP
+---
+# Source: holiday-peak-service/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: inventory-jit-replenishment-inventory-jit-replenishment
+  namespace: holiday-peak
+  labels:
+    app: inventory-jit-replenishment
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  selector:
+    matchLabels:
+      app: inventory-jit-replenishment
+  template:
+    metadata:
+      labels:
+        app: inventory-jit-replenishment
+        canary: "false"
+        azure.workload.identity/use: "true"
+    spec:
+      serviceAccountName: inventory-jit-replenishment
+      nodeSelector:
+        agentpool: agents
+      tolerations:
+        - effect: NoSchedule
+          key: workload
+          operator: Equal
+          value: agents
+      containers:
+        - name: inventory-jit-replenishment
+          image: "holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/inventory-jit-replenishment-dev:azd-deploy-1775346858"
+          env:
+            - name: AI_SEARCH_AUTH_MODE
+              value: "managed_identity"
+            - name: AI_SEARCH_ENDPOINT
+              value: "https://holidaypeakhub405devsearch.search.windows.net"
+            - name: AI_SEARCH_INDEX
+              value: "catalog-products"
+            - name: AI_SEARCH_INDEXER_NAME
+              value: "search-enriched-products-indexer"
+            - name: AI_SEARCH_VECTOR_INDEX
+              value: "product_search_index"
+            - name: APPLICATIONINSIGHTS_CONNECTION_STRING
+              value: "InstrumentationKey=d2fb45bc-e648-4da2-9345-d278636aede5;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=d8eb64c4-956d-46ab-a02e-d481deadaa0b"
+            - name: AZURE_CLIENT_ID
+              value: "036f4fd2-9093-4948-b0dd-beb5c87aa6dc"
+            - name: AZURE_TENANT_ID
+              value: "16b3c013-d300-468d-ac64-7eda0820b6d3"
+            - name: BLOB_ACCOUNT_URL
+              value: "https://holidaypeakhub405devstor.blob.core.windows.net"
+            - name: BLOB_CONTAINER
+              value: "agent-memory"
+            - name: CATALOG_SEARCH_REQUIRE_AI_SEARCH
+              value: "true"
+            - name: COSMOS_ACCOUNT_URI
+              value: "https://holidaypeakhub405-dev-cosmos.documents.azure.com:443/"
+            - name: COSMOS_CONTAINER
+              value: "agent-memory"
+            - name: COSMOS_DATABASE
+              value: "holiday-peak-db"
+            - name: EMBEDDING_DEPLOYMENT_NAME
+              value: "text-embedding-3-large"
+            - name: EVENT_HUB_NAMESPACE
+              value: "holidaypeakhub405-dev-eventhub"
+            - name: FOUNDRY_AGENT_NAME_FAST
+              value: "inventory-jit-replenishment-fast"
+            - name: FOUNDRY_AGENT_NAME_RICH
+              value: "inventory-jit-replenishment-rich"
+            - name: FOUNDRY_AUTO_ENSURE_ON_STARTUP
+              value: "true"
+            - name: FOUNDRY_STREAM
+              value: "false"
+            - name: FOUNDRY_STRICT_ENFORCEMENT
+              value: "false"
+            - name: KEY_VAULT_URI
+              value: "https://holidaypeakhub405-dev-kv.vault.azure.net/"
+            - name: MODEL_DEPLOYMENT_NAME_FAST
+              value: "gpt-5-nano"
+            - name: MODEL_DEPLOYMENT_NAME_RICH
+              value: "gpt-5"
+            - name: POSTGRES_AUTH_MODE
+              value: "password"
+            - name: POSTGRES_DATABASE
+              value: "holiday_peak_crud"
+            - name: POSTGRES_HOST
+              value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
+            - name: POSTGRES_PORT
+              value: "5432"
+            - name: POSTGRES_SSL
+              value: "true"
+            - name: POSTGRES_USER
+              value: "crud_workload"
+            - name: PROJECT_ENDPOINT
+              value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
+            - name: PROJECT_NAME
+              value: "aipholidaris"
+            - name: REDIS_HOST
+              value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
+            - name: REDIS_PASSWORD_SECRET_NAME
+              value: "redis-primary-key"
+            - name: REDIS_URL
+              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
+          ports:
+            - containerPort: 8000
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 250m
+              memory: 256Mi
+---
+# Source: holiday-peak-service/templates/agc-routing.yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: inventory-jit-replenishment-inventory-jit-replenishment-agc
+  namespace: holiday-peak
+  labels:
+    app: inventory-jit-replenishment
+spec:
+  parentRefs:
+    - name: "holiday-peak-agc"
+      namespace: "holiday-peak"
+  hostnames:
+    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/inventory-jit-replenishment"
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: "/"
+      backendRefs:
+        - name: inventory-jit-replenishment-inventory-jit-replenishment
+          port: 80

--- a/.kubernetes/rendered/inventory-reservation-validation/all.yaml
+++ b/.kubernetes/rendered/inventory-reservation-validation/all.yaml
@@ -1,0 +1,197 @@
+---
+# Source: holiday-peak-service/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: inventory-reservation-validation
+  namespace: holiday-peak
+  labels:
+    app: inventory-reservation-validation
+  annotations:
+    azure.workload.identity/client-id: "036f4fd2-9093-4948-b0dd-beb5c87aa6dc"
+---
+# Source: holiday-peak-service/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: inventory-reservation-validation-inventory-reservation-validati
+  namespace: holiday-peak
+  labels:
+    app: inventory-reservation-validation
+spec:
+  selector:
+    app: inventory-reservation-validation
+    # When canary is disabled, select all pods
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8000
+  type: ClusterIP
+---
+# Source: holiday-peak-service/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: inventory-reservation-validation-inventory-reservation-validati
+  namespace: holiday-peak
+  labels:
+    app: inventory-reservation-validation
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  selector:
+    matchLabels:
+      app: inventory-reservation-validation
+  template:
+    metadata:
+      labels:
+        app: inventory-reservation-validation
+        canary: "false"
+        azure.workload.identity/use: "true"
+    spec:
+      serviceAccountName: inventory-reservation-validation
+      nodeSelector:
+        agentpool: agents
+      tolerations:
+        - effect: NoSchedule
+          key: workload
+          operator: Equal
+          value: agents
+      containers:
+        - name: inventory-reservation-validation
+          image: "holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/inventory-reservation-validation-dev:azd-deploy-1775347087"
+          env:
+            - name: AI_SEARCH_AUTH_MODE
+              value: "managed_identity"
+            - name: AI_SEARCH_ENDPOINT
+              value: "https://holidaypeakhub405devsearch.search.windows.net"
+            - name: AI_SEARCH_INDEX
+              value: "catalog-products"
+            - name: AI_SEARCH_INDEXER_NAME
+              value: "search-enriched-products-indexer"
+            - name: AI_SEARCH_VECTOR_INDEX
+              value: "product_search_index"
+            - name: APPLICATIONINSIGHTS_CONNECTION_STRING
+              value: "InstrumentationKey=d2fb45bc-e648-4da2-9345-d278636aede5;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=d8eb64c4-956d-46ab-a02e-d481deadaa0b"
+            - name: AZURE_CLIENT_ID
+              value: "036f4fd2-9093-4948-b0dd-beb5c87aa6dc"
+            - name: AZURE_TENANT_ID
+              value: "16b3c013-d300-468d-ac64-7eda0820b6d3"
+            - name: BLOB_ACCOUNT_URL
+              value: "https://holidaypeakhub405devstor.blob.core.windows.net"
+            - name: BLOB_CONTAINER
+              value: "agent-memory"
+            - name: CATALOG_SEARCH_REQUIRE_AI_SEARCH
+              value: "true"
+            - name: COSMOS_ACCOUNT_URI
+              value: "https://holidaypeakhub405-dev-cosmos.documents.azure.com:443/"
+            - name: COSMOS_CONTAINER
+              value: "agent-memory"
+            - name: COSMOS_DATABASE
+              value: "holiday-peak-db"
+            - name: EMBEDDING_DEPLOYMENT_NAME
+              value: "text-embedding-3-large"
+            - name: EVENT_HUB_NAMESPACE
+              value: "holidaypeakhub405-dev-eventhub"
+            - name: FOUNDRY_AGENT_NAME_FAST
+              value: "inventory-reservation-validation-fast"
+            - name: FOUNDRY_AGENT_NAME_RICH
+              value: "inventory-reservation-validation-rich"
+            - name: FOUNDRY_AUTO_ENSURE_ON_STARTUP
+              value: "true"
+            - name: FOUNDRY_STREAM
+              value: "false"
+            - name: FOUNDRY_STRICT_ENFORCEMENT
+              value: "false"
+            - name: KEY_VAULT_URI
+              value: "https://holidaypeakhub405-dev-kv.vault.azure.net/"
+            - name: MODEL_DEPLOYMENT_NAME_FAST
+              value: "gpt-5-nano"
+            - name: MODEL_DEPLOYMENT_NAME_RICH
+              value: "gpt-5"
+            - name: POSTGRES_AUTH_MODE
+              value: "password"
+            - name: POSTGRES_DATABASE
+              value: "holiday_peak_crud"
+            - name: POSTGRES_HOST
+              value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
+            - name: POSTGRES_PORT
+              value: "5432"
+            - name: POSTGRES_SSL
+              value: "true"
+            - name: POSTGRES_USER
+              value: "crud_workload"
+            - name: PROJECT_ENDPOINT
+              value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
+            - name: PROJECT_NAME
+              value: "aipholidaris"
+            - name: REDIS_HOST
+              value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
+            - name: REDIS_PASSWORD_SECRET_NAME
+              value: "redis-primary-key"
+            - name: REDIS_URL
+              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
+          ports:
+            - containerPort: 8000
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 250m
+              memory: 256Mi
+---
+# Source: holiday-peak-service/templates/agc-routing.yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: inventory-reservation-validation-inventory-reservation-validati-agc
+  namespace: holiday-peak
+  labels:
+    app: inventory-reservation-validation
+spec:
+  parentRefs:
+    - name: "holiday-peak-agc"
+      namespace: "holiday-peak"
+  hostnames:
+    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/inventory-reservation-validation"
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: "/"
+      backendRefs:
+        - name: inventory-reservation-validation-inventory-reservation-validati
+          port: 80

--- a/.kubernetes/rendered/logistics-carrier-selection/all.yaml
+++ b/.kubernetes/rendered/logistics-carrier-selection/all.yaml
@@ -1,0 +1,197 @@
+---
+# Source: holiday-peak-service/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: logistics-carrier-selection
+  namespace: holiday-peak
+  labels:
+    app: logistics-carrier-selection
+  annotations:
+    azure.workload.identity/client-id: "036f4fd2-9093-4948-b0dd-beb5c87aa6dc"
+---
+# Source: holiday-peak-service/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: logistics-carrier-selection-logistics-carrier-selection
+  namespace: holiday-peak
+  labels:
+    app: logistics-carrier-selection
+spec:
+  selector:
+    app: logistics-carrier-selection
+    # When canary is disabled, select all pods
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8000
+  type: ClusterIP
+---
+# Source: holiday-peak-service/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: logistics-carrier-selection-logistics-carrier-selection
+  namespace: holiday-peak
+  labels:
+    app: logistics-carrier-selection
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  selector:
+    matchLabels:
+      app: logistics-carrier-selection
+  template:
+    metadata:
+      labels:
+        app: logistics-carrier-selection
+        canary: "false"
+        azure.workload.identity/use: "true"
+    spec:
+      serviceAccountName: logistics-carrier-selection
+      nodeSelector:
+        agentpool: agents
+      tolerations:
+        - effect: NoSchedule
+          key: workload
+          operator: Equal
+          value: agents
+      containers:
+        - name: logistics-carrier-selection
+          image: "holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/logistics-carrier-selection-dev:azd-deploy-1775347321"
+          env:
+            - name: AI_SEARCH_AUTH_MODE
+              value: "managed_identity"
+            - name: AI_SEARCH_ENDPOINT
+              value: "https://holidaypeakhub405devsearch.search.windows.net"
+            - name: AI_SEARCH_INDEX
+              value: "catalog-products"
+            - name: AI_SEARCH_INDEXER_NAME
+              value: "search-enriched-products-indexer"
+            - name: AI_SEARCH_VECTOR_INDEX
+              value: "product_search_index"
+            - name: APPLICATIONINSIGHTS_CONNECTION_STRING
+              value: "InstrumentationKey=d2fb45bc-e648-4da2-9345-d278636aede5;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=d8eb64c4-956d-46ab-a02e-d481deadaa0b"
+            - name: AZURE_CLIENT_ID
+              value: "036f4fd2-9093-4948-b0dd-beb5c87aa6dc"
+            - name: AZURE_TENANT_ID
+              value: "16b3c013-d300-468d-ac64-7eda0820b6d3"
+            - name: BLOB_ACCOUNT_URL
+              value: "https://holidaypeakhub405devstor.blob.core.windows.net"
+            - name: BLOB_CONTAINER
+              value: "agent-memory"
+            - name: CATALOG_SEARCH_REQUIRE_AI_SEARCH
+              value: "true"
+            - name: COSMOS_ACCOUNT_URI
+              value: "https://holidaypeakhub405-dev-cosmos.documents.azure.com:443/"
+            - name: COSMOS_CONTAINER
+              value: "agent-memory"
+            - name: COSMOS_DATABASE
+              value: "holiday-peak-db"
+            - name: EMBEDDING_DEPLOYMENT_NAME
+              value: "text-embedding-3-large"
+            - name: EVENT_HUB_NAMESPACE
+              value: "holidaypeakhub405-dev-eventhub"
+            - name: FOUNDRY_AGENT_NAME_FAST
+              value: "logistics-carrier-selection-fast"
+            - name: FOUNDRY_AGENT_NAME_RICH
+              value: "logistics-carrier-selection-rich"
+            - name: FOUNDRY_AUTO_ENSURE_ON_STARTUP
+              value: "true"
+            - name: FOUNDRY_STREAM
+              value: "false"
+            - name: FOUNDRY_STRICT_ENFORCEMENT
+              value: "false"
+            - name: KEY_VAULT_URI
+              value: "https://holidaypeakhub405-dev-kv.vault.azure.net/"
+            - name: MODEL_DEPLOYMENT_NAME_FAST
+              value: "gpt-5-nano"
+            - name: MODEL_DEPLOYMENT_NAME_RICH
+              value: "gpt-5"
+            - name: POSTGRES_AUTH_MODE
+              value: "password"
+            - name: POSTGRES_DATABASE
+              value: "holiday_peak_crud"
+            - name: POSTGRES_HOST
+              value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
+            - name: POSTGRES_PORT
+              value: "5432"
+            - name: POSTGRES_SSL
+              value: "true"
+            - name: POSTGRES_USER
+              value: "crud_workload"
+            - name: PROJECT_ENDPOINT
+              value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
+            - name: PROJECT_NAME
+              value: "aipholidaris"
+            - name: REDIS_HOST
+              value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
+            - name: REDIS_PASSWORD_SECRET_NAME
+              value: "redis-primary-key"
+            - name: REDIS_URL
+              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
+          ports:
+            - containerPort: 8000
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 250m
+              memory: 256Mi
+---
+# Source: holiday-peak-service/templates/agc-routing.yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: logistics-carrier-selection-logistics-carrier-selection-agc
+  namespace: holiday-peak
+  labels:
+    app: logistics-carrier-selection
+spec:
+  parentRefs:
+    - name: "holiday-peak-agc"
+      namespace: "holiday-peak"
+  hostnames:
+    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/logistics-carrier-selection"
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: "/"
+      backendRefs:
+        - name: logistics-carrier-selection-logistics-carrier-selection
+          port: 80

--- a/.kubernetes/rendered/logistics-eta-computation/all.yaml
+++ b/.kubernetes/rendered/logistics-eta-computation/all.yaml
@@ -1,0 +1,197 @@
+---
+# Source: holiday-peak-service/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: logistics-eta-computation
+  namespace: holiday-peak
+  labels:
+    app: logistics-eta-computation
+  annotations:
+    azure.workload.identity/client-id: "036f4fd2-9093-4948-b0dd-beb5c87aa6dc"
+---
+# Source: holiday-peak-service/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: logistics-eta-computation-logistics-eta-computation
+  namespace: holiday-peak
+  labels:
+    app: logistics-eta-computation
+spec:
+  selector:
+    app: logistics-eta-computation
+    # When canary is disabled, select all pods
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8000
+  type: ClusterIP
+---
+# Source: holiday-peak-service/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: logistics-eta-computation-logistics-eta-computation
+  namespace: holiday-peak
+  labels:
+    app: logistics-eta-computation
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  selector:
+    matchLabels:
+      app: logistics-eta-computation
+  template:
+    metadata:
+      labels:
+        app: logistics-eta-computation
+        canary: "false"
+        azure.workload.identity/use: "true"
+    spec:
+      serviceAccountName: logistics-eta-computation
+      nodeSelector:
+        agentpool: agents
+      tolerations:
+        - effect: NoSchedule
+          key: workload
+          operator: Equal
+          value: agents
+      containers:
+        - name: logistics-eta-computation
+          image: "holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/logistics-eta-computation-dev:azd-deploy-1775347585"
+          env:
+            - name: AI_SEARCH_AUTH_MODE
+              value: "managed_identity"
+            - name: AI_SEARCH_ENDPOINT
+              value: "https://holidaypeakhub405devsearch.search.windows.net"
+            - name: AI_SEARCH_INDEX
+              value: "catalog-products"
+            - name: AI_SEARCH_INDEXER_NAME
+              value: "search-enriched-products-indexer"
+            - name: AI_SEARCH_VECTOR_INDEX
+              value: "product_search_index"
+            - name: APPLICATIONINSIGHTS_CONNECTION_STRING
+              value: "InstrumentationKey=d2fb45bc-e648-4da2-9345-d278636aede5;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=d8eb64c4-956d-46ab-a02e-d481deadaa0b"
+            - name: AZURE_CLIENT_ID
+              value: "036f4fd2-9093-4948-b0dd-beb5c87aa6dc"
+            - name: AZURE_TENANT_ID
+              value: "16b3c013-d300-468d-ac64-7eda0820b6d3"
+            - name: BLOB_ACCOUNT_URL
+              value: "https://holidaypeakhub405devstor.blob.core.windows.net"
+            - name: BLOB_CONTAINER
+              value: "agent-memory"
+            - name: CATALOG_SEARCH_REQUIRE_AI_SEARCH
+              value: "true"
+            - name: COSMOS_ACCOUNT_URI
+              value: "https://holidaypeakhub405-dev-cosmos.documents.azure.com:443/"
+            - name: COSMOS_CONTAINER
+              value: "agent-memory"
+            - name: COSMOS_DATABASE
+              value: "holiday-peak-db"
+            - name: EMBEDDING_DEPLOYMENT_NAME
+              value: "text-embedding-3-large"
+            - name: EVENT_HUB_NAMESPACE
+              value: "holidaypeakhub405-dev-eventhub"
+            - name: FOUNDRY_AGENT_NAME_FAST
+              value: "logistics-eta-computation-fast"
+            - name: FOUNDRY_AGENT_NAME_RICH
+              value: "logistics-eta-computation-rich"
+            - name: FOUNDRY_AUTO_ENSURE_ON_STARTUP
+              value: "true"
+            - name: FOUNDRY_STREAM
+              value: "false"
+            - name: FOUNDRY_STRICT_ENFORCEMENT
+              value: "false"
+            - name: KEY_VAULT_URI
+              value: "https://holidaypeakhub405-dev-kv.vault.azure.net/"
+            - name: MODEL_DEPLOYMENT_NAME_FAST
+              value: "gpt-5-nano"
+            - name: MODEL_DEPLOYMENT_NAME_RICH
+              value: "gpt-5"
+            - name: POSTGRES_AUTH_MODE
+              value: "password"
+            - name: POSTGRES_DATABASE
+              value: "holiday_peak_crud"
+            - name: POSTGRES_HOST
+              value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
+            - name: POSTGRES_PORT
+              value: "5432"
+            - name: POSTGRES_SSL
+              value: "true"
+            - name: POSTGRES_USER
+              value: "crud_workload"
+            - name: PROJECT_ENDPOINT
+              value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
+            - name: PROJECT_NAME
+              value: "aipholidaris"
+            - name: REDIS_HOST
+              value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
+            - name: REDIS_PASSWORD_SECRET_NAME
+              value: "redis-primary-key"
+            - name: REDIS_URL
+              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
+          ports:
+            - containerPort: 8000
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 250m
+              memory: 256Mi
+---
+# Source: holiday-peak-service/templates/agc-routing.yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: logistics-eta-computation-logistics-eta-computation-agc
+  namespace: holiday-peak
+  labels:
+    app: logistics-eta-computation
+spec:
+  parentRefs:
+    - name: "holiday-peak-agc"
+      namespace: "holiday-peak"
+  hostnames:
+    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/logistics-eta-computation"
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: "/"
+      backendRefs:
+        - name: logistics-eta-computation-logistics-eta-computation
+          port: 80

--- a/.kubernetes/rendered/logistics-returns-support/all.yaml
+++ b/.kubernetes/rendered/logistics-returns-support/all.yaml
@@ -1,0 +1,197 @@
+---
+# Source: holiday-peak-service/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: logistics-returns-support
+  namespace: holiday-peak
+  labels:
+    app: logistics-returns-support
+  annotations:
+    azure.workload.identity/client-id: "036f4fd2-9093-4948-b0dd-beb5c87aa6dc"
+---
+# Source: holiday-peak-service/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: logistics-returns-support-logistics-returns-support
+  namespace: holiday-peak
+  labels:
+    app: logistics-returns-support
+spec:
+  selector:
+    app: logistics-returns-support
+    # When canary is disabled, select all pods
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8000
+  type: ClusterIP
+---
+# Source: holiday-peak-service/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: logistics-returns-support-logistics-returns-support
+  namespace: holiday-peak
+  labels:
+    app: logistics-returns-support
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  selector:
+    matchLabels:
+      app: logistics-returns-support
+  template:
+    metadata:
+      labels:
+        app: logistics-returns-support
+        canary: "false"
+        azure.workload.identity/use: "true"
+    spec:
+      serviceAccountName: logistics-returns-support
+      nodeSelector:
+        agentpool: agents
+      tolerations:
+        - effect: NoSchedule
+          key: workload
+          operator: Equal
+          value: agents
+      containers:
+        - name: logistics-returns-support
+          image: "holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/logistics-returns-support-dev:azd-deploy-1775347833"
+          env:
+            - name: AI_SEARCH_AUTH_MODE
+              value: "managed_identity"
+            - name: AI_SEARCH_ENDPOINT
+              value: "https://holidaypeakhub405devsearch.search.windows.net"
+            - name: AI_SEARCH_INDEX
+              value: "catalog-products"
+            - name: AI_SEARCH_INDEXER_NAME
+              value: "search-enriched-products-indexer"
+            - name: AI_SEARCH_VECTOR_INDEX
+              value: "product_search_index"
+            - name: APPLICATIONINSIGHTS_CONNECTION_STRING
+              value: "InstrumentationKey=d2fb45bc-e648-4da2-9345-d278636aede5;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=d8eb64c4-956d-46ab-a02e-d481deadaa0b"
+            - name: AZURE_CLIENT_ID
+              value: "036f4fd2-9093-4948-b0dd-beb5c87aa6dc"
+            - name: AZURE_TENANT_ID
+              value: "16b3c013-d300-468d-ac64-7eda0820b6d3"
+            - name: BLOB_ACCOUNT_URL
+              value: "https://holidaypeakhub405devstor.blob.core.windows.net"
+            - name: BLOB_CONTAINER
+              value: "agent-memory"
+            - name: CATALOG_SEARCH_REQUIRE_AI_SEARCH
+              value: "true"
+            - name: COSMOS_ACCOUNT_URI
+              value: "https://holidaypeakhub405-dev-cosmos.documents.azure.com:443/"
+            - name: COSMOS_CONTAINER
+              value: "agent-memory"
+            - name: COSMOS_DATABASE
+              value: "holiday-peak-db"
+            - name: EMBEDDING_DEPLOYMENT_NAME
+              value: "text-embedding-3-large"
+            - name: EVENT_HUB_NAMESPACE
+              value: "holidaypeakhub405-dev-eventhub"
+            - name: FOUNDRY_AGENT_NAME_FAST
+              value: "logistics-returns-support-fast"
+            - name: FOUNDRY_AGENT_NAME_RICH
+              value: "logistics-returns-support-rich"
+            - name: FOUNDRY_AUTO_ENSURE_ON_STARTUP
+              value: "true"
+            - name: FOUNDRY_STREAM
+              value: "false"
+            - name: FOUNDRY_STRICT_ENFORCEMENT
+              value: "false"
+            - name: KEY_VAULT_URI
+              value: "https://holidaypeakhub405-dev-kv.vault.azure.net/"
+            - name: MODEL_DEPLOYMENT_NAME_FAST
+              value: "gpt-5-nano"
+            - name: MODEL_DEPLOYMENT_NAME_RICH
+              value: "gpt-5"
+            - name: POSTGRES_AUTH_MODE
+              value: "password"
+            - name: POSTGRES_DATABASE
+              value: "holiday_peak_crud"
+            - name: POSTGRES_HOST
+              value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
+            - name: POSTGRES_PORT
+              value: "5432"
+            - name: POSTGRES_SSL
+              value: "true"
+            - name: POSTGRES_USER
+              value: "crud_workload"
+            - name: PROJECT_ENDPOINT
+              value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
+            - name: PROJECT_NAME
+              value: "aipholidaris"
+            - name: REDIS_HOST
+              value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
+            - name: REDIS_PASSWORD_SECRET_NAME
+              value: "redis-primary-key"
+            - name: REDIS_URL
+              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
+          ports:
+            - containerPort: 8000
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 250m
+              memory: 256Mi
+---
+# Source: holiday-peak-service/templates/agc-routing.yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: logistics-returns-support-logistics-returns-support-agc
+  namespace: holiday-peak
+  labels:
+    app: logistics-returns-support
+spec:
+  parentRefs:
+    - name: "holiday-peak-agc"
+      namespace: "holiday-peak"
+  hostnames:
+    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/logistics-returns-support"
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: "/"
+      backendRefs:
+        - name: logistics-returns-support-logistics-returns-support
+          port: 80

--- a/.kubernetes/rendered/logistics-route-issue-detection/all.yaml
+++ b/.kubernetes/rendered/logistics-route-issue-detection/all.yaml
@@ -1,0 +1,197 @@
+---
+# Source: holiday-peak-service/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: logistics-route-issue-detection
+  namespace: holiday-peak
+  labels:
+    app: logistics-route-issue-detection
+  annotations:
+    azure.workload.identity/client-id: "036f4fd2-9093-4948-b0dd-beb5c87aa6dc"
+---
+# Source: holiday-peak-service/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: logistics-route-issue-detection-logistics-route-issue-detection
+  namespace: holiday-peak
+  labels:
+    app: logistics-route-issue-detection
+spec:
+  selector:
+    app: logistics-route-issue-detection
+    # When canary is disabled, select all pods
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8000
+  type: ClusterIP
+---
+# Source: holiday-peak-service/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: logistics-route-issue-detection-logistics-route-issue-detection
+  namespace: holiday-peak
+  labels:
+    app: logistics-route-issue-detection
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  selector:
+    matchLabels:
+      app: logistics-route-issue-detection
+  template:
+    metadata:
+      labels:
+        app: logistics-route-issue-detection
+        canary: "false"
+        azure.workload.identity/use: "true"
+    spec:
+      serviceAccountName: logistics-route-issue-detection
+      nodeSelector:
+        agentpool: agents
+      tolerations:
+        - effect: NoSchedule
+          key: workload
+          operator: Equal
+          value: agents
+      containers:
+        - name: logistics-route-issue-detection
+          image: "holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/logistics-route-issue-detection-dev:azd-deploy-1775348087"
+          env:
+            - name: AI_SEARCH_AUTH_MODE
+              value: "managed_identity"
+            - name: AI_SEARCH_ENDPOINT
+              value: "https://holidaypeakhub405devsearch.search.windows.net"
+            - name: AI_SEARCH_INDEX
+              value: "catalog-products"
+            - name: AI_SEARCH_INDEXER_NAME
+              value: "search-enriched-products-indexer"
+            - name: AI_SEARCH_VECTOR_INDEX
+              value: "product_search_index"
+            - name: APPLICATIONINSIGHTS_CONNECTION_STRING
+              value: "InstrumentationKey=d2fb45bc-e648-4da2-9345-d278636aede5;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=d8eb64c4-956d-46ab-a02e-d481deadaa0b"
+            - name: AZURE_CLIENT_ID
+              value: "036f4fd2-9093-4948-b0dd-beb5c87aa6dc"
+            - name: AZURE_TENANT_ID
+              value: "16b3c013-d300-468d-ac64-7eda0820b6d3"
+            - name: BLOB_ACCOUNT_URL
+              value: "https://holidaypeakhub405devstor.blob.core.windows.net"
+            - name: BLOB_CONTAINER
+              value: "agent-memory"
+            - name: CATALOG_SEARCH_REQUIRE_AI_SEARCH
+              value: "true"
+            - name: COSMOS_ACCOUNT_URI
+              value: "https://holidaypeakhub405-dev-cosmos.documents.azure.com:443/"
+            - name: COSMOS_CONTAINER
+              value: "agent-memory"
+            - name: COSMOS_DATABASE
+              value: "holiday-peak-db"
+            - name: EMBEDDING_DEPLOYMENT_NAME
+              value: "text-embedding-3-large"
+            - name: EVENT_HUB_NAMESPACE
+              value: "holidaypeakhub405-dev-eventhub"
+            - name: FOUNDRY_AGENT_NAME_FAST
+              value: "logistics-route-issue-detection-fast"
+            - name: FOUNDRY_AGENT_NAME_RICH
+              value: "logistics-route-issue-detection-rich"
+            - name: FOUNDRY_AUTO_ENSURE_ON_STARTUP
+              value: "true"
+            - name: FOUNDRY_STREAM
+              value: "false"
+            - name: FOUNDRY_STRICT_ENFORCEMENT
+              value: "false"
+            - name: KEY_VAULT_URI
+              value: "https://holidaypeakhub405-dev-kv.vault.azure.net/"
+            - name: MODEL_DEPLOYMENT_NAME_FAST
+              value: "gpt-5-nano"
+            - name: MODEL_DEPLOYMENT_NAME_RICH
+              value: "gpt-5"
+            - name: POSTGRES_AUTH_MODE
+              value: "password"
+            - name: POSTGRES_DATABASE
+              value: "holiday_peak_crud"
+            - name: POSTGRES_HOST
+              value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
+            - name: POSTGRES_PORT
+              value: "5432"
+            - name: POSTGRES_SSL
+              value: "true"
+            - name: POSTGRES_USER
+              value: "crud_workload"
+            - name: PROJECT_ENDPOINT
+              value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
+            - name: PROJECT_NAME
+              value: "aipholidaris"
+            - name: REDIS_HOST
+              value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
+            - name: REDIS_PASSWORD_SECRET_NAME
+              value: "redis-primary-key"
+            - name: REDIS_URL
+              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
+          ports:
+            - containerPort: 8000
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 250m
+              memory: 256Mi
+---
+# Source: holiday-peak-service/templates/agc-routing.yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: logistics-route-issue-detection-logistics-route-issue-detection-agc
+  namespace: holiday-peak
+  labels:
+    app: logistics-route-issue-detection
+spec:
+  parentRefs:
+    - name: "holiday-peak-agc"
+      namespace: "holiday-peak"
+  hostnames:
+    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/logistics-route-issue-detection"
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: "/"
+      backendRefs:
+        - name: logistics-route-issue-detection-logistics-route-issue-detection
+          port: 80

--- a/.kubernetes/rendered/product-management-acp-transformation/all.yaml
+++ b/.kubernetes/rendered/product-management-acp-transformation/all.yaml
@@ -1,0 +1,197 @@
+---
+# Source: holiday-peak-service/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: product-management-acp-transformation
+  namespace: holiday-peak
+  labels:
+    app: product-management-acp-transformation
+  annotations:
+    azure.workload.identity/client-id: "036f4fd2-9093-4948-b0dd-beb5c87aa6dc"
+---
+# Source: holiday-peak-service/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: product-management-acp-transformation-product-management-acp-tr
+  namespace: holiday-peak
+  labels:
+    app: product-management-acp-transformation
+spec:
+  selector:
+    app: product-management-acp-transformation
+    # When canary is disabled, select all pods
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8000
+  type: ClusterIP
+---
+# Source: holiday-peak-service/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: product-management-acp-transformation-product-management-acp-tr
+  namespace: holiday-peak
+  labels:
+    app: product-management-acp-transformation
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  selector:
+    matchLabels:
+      app: product-management-acp-transformation
+  template:
+    metadata:
+      labels:
+        app: product-management-acp-transformation
+        canary: "false"
+        azure.workload.identity/use: "true"
+    spec:
+      serviceAccountName: product-management-acp-transformation
+      nodeSelector:
+        agentpool: agents
+      tolerations:
+        - effect: NoSchedule
+          key: workload
+          operator: Equal
+          value: agents
+      containers:
+        - name: product-management-acp-transformation
+          image: "holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/product-management-acp-transformation-dev:azd-deploy-1775348336"
+          env:
+            - name: AI_SEARCH_AUTH_MODE
+              value: "managed_identity"
+            - name: AI_SEARCH_ENDPOINT
+              value: "https://holidaypeakhub405devsearch.search.windows.net"
+            - name: AI_SEARCH_INDEX
+              value: "catalog-products"
+            - name: AI_SEARCH_INDEXER_NAME
+              value: "search-enriched-products-indexer"
+            - name: AI_SEARCH_VECTOR_INDEX
+              value: "product_search_index"
+            - name: APPLICATIONINSIGHTS_CONNECTION_STRING
+              value: "InstrumentationKey=d2fb45bc-e648-4da2-9345-d278636aede5;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=d8eb64c4-956d-46ab-a02e-d481deadaa0b"
+            - name: AZURE_CLIENT_ID
+              value: "036f4fd2-9093-4948-b0dd-beb5c87aa6dc"
+            - name: AZURE_TENANT_ID
+              value: "16b3c013-d300-468d-ac64-7eda0820b6d3"
+            - name: BLOB_ACCOUNT_URL
+              value: "https://holidaypeakhub405devstor.blob.core.windows.net"
+            - name: BLOB_CONTAINER
+              value: "agent-memory"
+            - name: CATALOG_SEARCH_REQUIRE_AI_SEARCH
+              value: "true"
+            - name: COSMOS_ACCOUNT_URI
+              value: "https://holidaypeakhub405-dev-cosmos.documents.azure.com:443/"
+            - name: COSMOS_CONTAINER
+              value: "agent-memory"
+            - name: COSMOS_DATABASE
+              value: "holiday-peak-db"
+            - name: EMBEDDING_DEPLOYMENT_NAME
+              value: "text-embedding-3-large"
+            - name: EVENT_HUB_NAMESPACE
+              value: "holidaypeakhub405-dev-eventhub"
+            - name: FOUNDRY_AGENT_NAME_FAST
+              value: "product-management-acp-transformation-fast"
+            - name: FOUNDRY_AGENT_NAME_RICH
+              value: "product-management-acp-transformation-rich"
+            - name: FOUNDRY_AUTO_ENSURE_ON_STARTUP
+              value: "true"
+            - name: FOUNDRY_STREAM
+              value: "false"
+            - name: FOUNDRY_STRICT_ENFORCEMENT
+              value: "false"
+            - name: KEY_VAULT_URI
+              value: "https://holidaypeakhub405-dev-kv.vault.azure.net/"
+            - name: MODEL_DEPLOYMENT_NAME_FAST
+              value: "gpt-5-nano"
+            - name: MODEL_DEPLOYMENT_NAME_RICH
+              value: "gpt-5"
+            - name: POSTGRES_AUTH_MODE
+              value: "password"
+            - name: POSTGRES_DATABASE
+              value: "holiday_peak_crud"
+            - name: POSTGRES_HOST
+              value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
+            - name: POSTGRES_PORT
+              value: "5432"
+            - name: POSTGRES_SSL
+              value: "true"
+            - name: POSTGRES_USER
+              value: "crud_workload"
+            - name: PROJECT_ENDPOINT
+              value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
+            - name: PROJECT_NAME
+              value: "aipholidaris"
+            - name: REDIS_HOST
+              value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
+            - name: REDIS_PASSWORD_SECRET_NAME
+              value: "redis-primary-key"
+            - name: REDIS_URL
+              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
+          ports:
+            - containerPort: 8000
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 250m
+              memory: 256Mi
+---
+# Source: holiday-peak-service/templates/agc-routing.yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: product-management-acp-transformation-product-management-acp-tr-agc
+  namespace: holiday-peak
+  labels:
+    app: product-management-acp-transformation
+spec:
+  parentRefs:
+    - name: "holiday-peak-agc"
+      namespace: "holiday-peak"
+  hostnames:
+    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/product-management-acp-transformation"
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: "/"
+      backendRefs:
+        - name: product-management-acp-transformation-product-management-acp-tr
+          port: 80

--- a/.kubernetes/rendered/product-management-assortment-optimization/all.yaml
+++ b/.kubernetes/rendered/product-management-assortment-optimization/all.yaml
@@ -1,0 +1,197 @@
+---
+# Source: holiday-peak-service/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: product-management-assortment-optimization
+  namespace: holiday-peak
+  labels:
+    app: product-management-assortment-optimization
+  annotations:
+    azure.workload.identity/client-id: "036f4fd2-9093-4948-b0dd-beb5c87aa6dc"
+---
+# Source: holiday-peak-service/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: product-management-assortment-optimization-product-management-a
+  namespace: holiday-peak
+  labels:
+    app: product-management-assortment-optimization
+spec:
+  selector:
+    app: product-management-assortment-optimization
+    # When canary is disabled, select all pods
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8000
+  type: ClusterIP
+---
+# Source: holiday-peak-service/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: product-management-assortment-optimization-product-management-a
+  namespace: holiday-peak
+  labels:
+    app: product-management-assortment-optimization
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  selector:
+    matchLabels:
+      app: product-management-assortment-optimization
+  template:
+    metadata:
+      labels:
+        app: product-management-assortment-optimization
+        canary: "false"
+        azure.workload.identity/use: "true"
+    spec:
+      serviceAccountName: product-management-assortment-optimization
+      nodeSelector:
+        agentpool: agents
+      tolerations:
+        - effect: NoSchedule
+          key: workload
+          operator: Equal
+          value: agents
+      containers:
+        - name: product-management-assortment-optimization
+          image: "holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/product-management-assortment-optimization-dev:azd-deploy-1775348550"
+          env:
+            - name: AI_SEARCH_AUTH_MODE
+              value: "managed_identity"
+            - name: AI_SEARCH_ENDPOINT
+              value: "https://holidaypeakhub405devsearch.search.windows.net"
+            - name: AI_SEARCH_INDEX
+              value: "catalog-products"
+            - name: AI_SEARCH_INDEXER_NAME
+              value: "search-enriched-products-indexer"
+            - name: AI_SEARCH_VECTOR_INDEX
+              value: "product_search_index"
+            - name: APPLICATIONINSIGHTS_CONNECTION_STRING
+              value: "InstrumentationKey=d2fb45bc-e648-4da2-9345-d278636aede5;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=d8eb64c4-956d-46ab-a02e-d481deadaa0b"
+            - name: AZURE_CLIENT_ID
+              value: "036f4fd2-9093-4948-b0dd-beb5c87aa6dc"
+            - name: AZURE_TENANT_ID
+              value: "16b3c013-d300-468d-ac64-7eda0820b6d3"
+            - name: BLOB_ACCOUNT_URL
+              value: "https://holidaypeakhub405devstor.blob.core.windows.net"
+            - name: BLOB_CONTAINER
+              value: "agent-memory"
+            - name: CATALOG_SEARCH_REQUIRE_AI_SEARCH
+              value: "true"
+            - name: COSMOS_ACCOUNT_URI
+              value: "https://holidaypeakhub405-dev-cosmos.documents.azure.com:443/"
+            - name: COSMOS_CONTAINER
+              value: "agent-memory"
+            - name: COSMOS_DATABASE
+              value: "holiday-peak-db"
+            - name: EMBEDDING_DEPLOYMENT_NAME
+              value: "text-embedding-3-large"
+            - name: EVENT_HUB_NAMESPACE
+              value: "holidaypeakhub405-dev-eventhub"
+            - name: FOUNDRY_AGENT_NAME_FAST
+              value: "product-management-assortment-optimization-fast"
+            - name: FOUNDRY_AGENT_NAME_RICH
+              value: "product-management-assortment-optimization-rich"
+            - name: FOUNDRY_AUTO_ENSURE_ON_STARTUP
+              value: "true"
+            - name: FOUNDRY_STREAM
+              value: "false"
+            - name: FOUNDRY_STRICT_ENFORCEMENT
+              value: "false"
+            - name: KEY_VAULT_URI
+              value: "https://holidaypeakhub405-dev-kv.vault.azure.net/"
+            - name: MODEL_DEPLOYMENT_NAME_FAST
+              value: "gpt-5-nano"
+            - name: MODEL_DEPLOYMENT_NAME_RICH
+              value: "gpt-5"
+            - name: POSTGRES_AUTH_MODE
+              value: "password"
+            - name: POSTGRES_DATABASE
+              value: "holiday_peak_crud"
+            - name: POSTGRES_HOST
+              value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
+            - name: POSTGRES_PORT
+              value: "5432"
+            - name: POSTGRES_SSL
+              value: "true"
+            - name: POSTGRES_USER
+              value: "crud_workload"
+            - name: PROJECT_ENDPOINT
+              value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
+            - name: PROJECT_NAME
+              value: "aipholidaris"
+            - name: REDIS_HOST
+              value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
+            - name: REDIS_PASSWORD_SECRET_NAME
+              value: "redis-primary-key"
+            - name: REDIS_URL
+              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
+          ports:
+            - containerPort: 8000
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 250m
+              memory: 256Mi
+---
+# Source: holiday-peak-service/templates/agc-routing.yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: product-management-assortment-optimization-product-management-a-agc
+  namespace: holiday-peak
+  labels:
+    app: product-management-assortment-optimization
+spec:
+  parentRefs:
+    - name: "holiday-peak-agc"
+      namespace: "holiday-peak"
+  hostnames:
+    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/product-management-assortment-optimization"
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: "/"
+      backendRefs:
+        - name: product-management-assortment-optimization-product-management-a
+          port: 80

--- a/.kubernetes/rendered/product-management-consistency-validation/all.yaml
+++ b/.kubernetes/rendered/product-management-consistency-validation/all.yaml
@@ -1,0 +1,197 @@
+---
+# Source: holiday-peak-service/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: product-management-consistency-validation
+  namespace: holiday-peak
+  labels:
+    app: product-management-consistency-validation
+  annotations:
+    azure.workload.identity/client-id: "036f4fd2-9093-4948-b0dd-beb5c87aa6dc"
+---
+# Source: holiday-peak-service/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: product-management-consistency-validation-product-management-co
+  namespace: holiday-peak
+  labels:
+    app: product-management-consistency-validation
+spec:
+  selector:
+    app: product-management-consistency-validation
+    # When canary is disabled, select all pods
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8000
+  type: ClusterIP
+---
+# Source: holiday-peak-service/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: product-management-consistency-validation-product-management-co
+  namespace: holiday-peak
+  labels:
+    app: product-management-consistency-validation
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  selector:
+    matchLabels:
+      app: product-management-consistency-validation
+  template:
+    metadata:
+      labels:
+        app: product-management-consistency-validation
+        canary: "false"
+        azure.workload.identity/use: "true"
+    spec:
+      serviceAccountName: product-management-consistency-validation
+      nodeSelector:
+        agentpool: agents
+      tolerations:
+        - effect: NoSchedule
+          key: workload
+          operator: Equal
+          value: agents
+      containers:
+        - name: product-management-consistency-validation
+          image: "holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/product-management-consistency-validation-dev:azd-deploy-1775348779"
+          env:
+            - name: AI_SEARCH_AUTH_MODE
+              value: "managed_identity"
+            - name: AI_SEARCH_ENDPOINT
+              value: "https://holidaypeakhub405devsearch.search.windows.net"
+            - name: AI_SEARCH_INDEX
+              value: "catalog-products"
+            - name: AI_SEARCH_INDEXER_NAME
+              value: "search-enriched-products-indexer"
+            - name: AI_SEARCH_VECTOR_INDEX
+              value: "product_search_index"
+            - name: APPLICATIONINSIGHTS_CONNECTION_STRING
+              value: "InstrumentationKey=d2fb45bc-e648-4da2-9345-d278636aede5;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=d8eb64c4-956d-46ab-a02e-d481deadaa0b"
+            - name: AZURE_CLIENT_ID
+              value: "036f4fd2-9093-4948-b0dd-beb5c87aa6dc"
+            - name: AZURE_TENANT_ID
+              value: "16b3c013-d300-468d-ac64-7eda0820b6d3"
+            - name: BLOB_ACCOUNT_URL
+              value: "https://holidaypeakhub405devstor.blob.core.windows.net"
+            - name: BLOB_CONTAINER
+              value: "agent-memory"
+            - name: CATALOG_SEARCH_REQUIRE_AI_SEARCH
+              value: "true"
+            - name: COSMOS_ACCOUNT_URI
+              value: "https://holidaypeakhub405-dev-cosmos.documents.azure.com:443/"
+            - name: COSMOS_CONTAINER
+              value: "agent-memory"
+            - name: COSMOS_DATABASE
+              value: "holiday-peak-db"
+            - name: EMBEDDING_DEPLOYMENT_NAME
+              value: "text-embedding-3-large"
+            - name: FOUNDRY_AGENT_NAME_FAST
+              value: "product-management-consistency-validation-fast"
+            - name: FOUNDRY_AGENT_NAME_RICH
+              value: "product-management-consistency-validation-rich"
+            - name: FOUNDRY_AUTO_ENSURE_ON_STARTUP
+              value: "true"
+            - name: FOUNDRY_STREAM
+              value: "false"
+            - name: FOUNDRY_STRICT_ENFORCEMENT
+              value: "false"
+            - name: KEY_VAULT_URI
+              value: "https://holidaypeakhub405-dev-kv.vault.azure.net/"
+            - name: MODEL_DEPLOYMENT_NAME_FAST
+              value: "gpt-5-nano"
+            - name: MODEL_DEPLOYMENT_NAME_RICH
+              value: "gpt-5"
+            - name: PLATFORM_JOBS_EVENT_HUB_NAMESPACE
+              value: "holidaypeakhub405-dev-jobs-eh"
+            - name: POSTGRES_AUTH_MODE
+              value: "password"
+            - name: POSTGRES_DATABASE
+              value: "holiday_peak_crud"
+            - name: POSTGRES_HOST
+              value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
+            - name: POSTGRES_PORT
+              value: "5432"
+            - name: POSTGRES_SSL
+              value: "true"
+            - name: POSTGRES_USER
+              value: "crud_workload"
+            - name: PROJECT_ENDPOINT
+              value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
+            - name: PROJECT_NAME
+              value: "aipholidaris"
+            - name: REDIS_HOST
+              value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
+            - name: REDIS_PASSWORD_SECRET_NAME
+              value: "redis-primary-key"
+            - name: REDIS_URL
+              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
+          ports:
+            - containerPort: 8000
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 250m
+              memory: 256Mi
+---
+# Source: holiday-peak-service/templates/agc-routing.yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: product-management-consistency-validation-product-management-co-agc
+  namespace: holiday-peak
+  labels:
+    app: product-management-consistency-validation
+spec:
+  parentRefs:
+    - name: "holiday-peak-agc"
+      namespace: "holiday-peak"
+  hostnames:
+    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/product-management-consistency-validation"
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: "/"
+      backendRefs:
+        - name: product-management-consistency-validation-product-management-co
+          port: 80

--- a/.kubernetes/rendered/product-management-normalization-classification/all.yaml
+++ b/.kubernetes/rendered/product-management-normalization-classification/all.yaml
@@ -1,0 +1,197 @@
+---
+# Source: holiday-peak-service/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: product-management-normalization-classification
+  namespace: holiday-peak
+  labels:
+    app: product-management-normalization-classification
+  annotations:
+    azure.workload.identity/client-id: "e9c11fac-45b3-4057-8477-1d96703eaae4"
+---
+# Source: holiday-peak-service/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: product-management-normalization-classification-product-managem
+  namespace: holiday-peak
+  labels:
+    app: product-management-normalization-classification
+spec:
+  selector:
+    app: product-management-normalization-classification
+    # When canary is disabled, select all pods
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8000
+  type: ClusterIP
+---
+# Source: holiday-peak-service/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: product-management-normalization-classification-product-managem
+  namespace: holiday-peak
+  labels:
+    app: product-management-normalization-classification
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  selector:
+    matchLabels:
+      app: product-management-normalization-classification
+  template:
+    metadata:
+      labels:
+        app: product-management-normalization-classification
+        canary: "false"
+        azure.workload.identity/use: "true"
+    spec:
+      serviceAccountName: product-management-normalization-classification
+      nodeSelector:
+        agentpool: agents
+      tolerations:
+        - effect: NoSchedule
+          key: workload
+          operator: Equal
+          value: agents
+      containers:
+        - name: product-management-normalization-classification
+          image: "holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/product-management-normalization-classification-dev:azd-deploy-1775349002"
+          env:
+            - name: AI_SEARCH_AUTH_MODE
+              value: "managed_identity"
+            - name: AI_SEARCH_ENDPOINT
+              value: "https://holidaypeakhub405devsearch.search.windows.net"
+            - name: AI_SEARCH_INDEX
+              value: "catalog-products"
+            - name: AI_SEARCH_INDEXER_NAME
+              value: "search-enriched-products-indexer"
+            - name: AI_SEARCH_VECTOR_INDEX
+              value: "product_search_index"
+            - name: APPLICATIONINSIGHTS_CONNECTION_STRING
+              value: "InstrumentationKey=d2fb45bc-e648-4da2-9345-d278636aede5;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=d8eb64c4-956d-46ab-a02e-d481deadaa0b"
+            - name: AZURE_CLIENT_ID
+              value: "e9c11fac-45b3-4057-8477-1d96703eaae4"
+            - name: AZURE_TENANT_ID
+              value: "16b3c013-d300-468d-ac64-7eda0820b6d3"
+            - name: BLOB_ACCOUNT_URL
+              value: "https://holidaypeakhub405devstor.blob.core.windows.net"
+            - name: BLOB_CONTAINER
+              value: "agent-memory"
+            - name: CATALOG_SEARCH_REQUIRE_AI_SEARCH
+              value: "true"
+            - name: COSMOS_ACCOUNT_URI
+              value: "https://holidaypeakhub405-dev-cosmos.documents.azure.com:443/"
+            - name: COSMOS_CONTAINER
+              value: "agent-memory"
+            - name: COSMOS_DATABASE
+              value: "holiday-peak-db"
+            - name: EMBEDDING_DEPLOYMENT_NAME
+              value: "text-embedding-3-large"
+            - name: EVENT_HUB_NAMESPACE
+              value: "holidaypeakhub405-dev-eventhub"
+            - name: FOUNDRY_AGENT_NAME_FAST
+              value: "product-management-normalization-classification-fast"
+            - name: FOUNDRY_AGENT_NAME_RICH
+              value: "product-management-normalization-classification-rich"
+            - name: FOUNDRY_AUTO_ENSURE_ON_STARTUP
+              value: "true"
+            - name: FOUNDRY_STREAM
+              value: "false"
+            - name: FOUNDRY_STRICT_ENFORCEMENT
+              value: "false"
+            - name: KEY_VAULT_URI
+              value: "https://holidaypeakhub405-dev-kv.vault.azure.net/"
+            - name: MODEL_DEPLOYMENT_NAME_FAST
+              value: "gpt-5-nano"
+            - name: MODEL_DEPLOYMENT_NAME_RICH
+              value: "gpt-5"
+            - name: POSTGRES_AUTH_MODE
+              value: "password"
+            - name: POSTGRES_DATABASE
+              value: "holiday_peak_crud"
+            - name: POSTGRES_HOST
+              value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
+            - name: POSTGRES_PORT
+              value: "5432"
+            - name: POSTGRES_SSL
+              value: "true"
+            - name: POSTGRES_USER
+              value: "crud_workload"
+            - name: PROJECT_ENDPOINT
+              value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
+            - name: PROJECT_NAME
+              value: "aipholidaris"
+            - name: REDIS_HOST
+              value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
+            - name: REDIS_PASSWORD_SECRET_NAME
+              value: "redis-primary-key"
+            - name: REDIS_URL
+              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
+          ports:
+            - containerPort: 8000
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 250m
+              memory: 256Mi
+---
+# Source: holiday-peak-service/templates/agc-routing.yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: product-management-normalization-classification-product-managem-agc
+  namespace: holiday-peak
+  labels:
+    app: product-management-normalization-classification
+spec:
+  parentRefs:
+    - name: "holiday-peak-agc"
+      namespace: "holiday-peak"
+  hostnames:
+    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/product-management-normalization-classification"
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: "/"
+      backendRefs:
+        - name: product-management-normalization-classification-product-managem
+          port: 80

--- a/.kubernetes/rendered/search-enrichment-agent/all.yaml
+++ b/.kubernetes/rendered/search-enrichment-agent/all.yaml
@@ -1,0 +1,201 @@
+---
+# Source: holiday-peak-service/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: search-enrichment-agent
+  namespace: holiday-peak
+  labels:
+    app: search-enrichment-agent
+  annotations:
+    azure.workload.identity/client-id: "e9c11fac-45b3-4057-8477-1d96703eaae4"
+---
+# Source: holiday-peak-service/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: search-enrichment-agent-search-enrichment-agent
+  namespace: holiday-peak
+  labels:
+    app: search-enrichment-agent
+spec:
+  selector:
+    app: search-enrichment-agent
+    # When canary is disabled, select all pods
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8000
+  type: ClusterIP
+---
+# Source: holiday-peak-service/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: search-enrichment-agent-search-enrichment-agent
+  namespace: holiday-peak
+  labels:
+    app: search-enrichment-agent
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  selector:
+    matchLabels:
+      app: search-enrichment-agent
+  template:
+    metadata:
+      labels:
+        app: search-enrichment-agent
+        canary: "false"
+        azure.workload.identity/use: "true"
+    spec:
+      serviceAccountName: search-enrichment-agent
+      nodeSelector:
+        agentpool: agents
+      tolerations:
+        - effect: NoSchedule
+          key: workload
+          operator: Equal
+          value: agents
+      containers:
+        - name: search-enrichment-agent
+          image: "holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/search-enrichment-agent-dev:azd-deploy-1775349482"
+          env:
+            - name: AI_SEARCH_AUTH_MODE
+              value: "managed_identity"
+            - name: AI_SEARCH_ENDPOINT
+              value: "https://holidaypeakhub405devsearch.search.windows.net"
+            - name: AI_SEARCH_INDEX
+              value: "catalog-products"
+            - name: AI_SEARCH_INDEXER_NAME
+              value: "search-enriched-products-indexer"
+            - name: AI_SEARCH_VECTOR_INDEX
+              value: "product_search_index"
+            - name: APPLICATIONINSIGHTS_CONNECTION_STRING
+              value: "InstrumentationKey=d2fb45bc-e648-4da2-9345-d278636aede5;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=d8eb64c4-956d-46ab-a02e-d481deadaa0b"
+            - name: AZURE_CLIENT_ID
+              value: "e9c11fac-45b3-4057-8477-1d96703eaae4"
+            - name: AZURE_TENANT_ID
+              value: "16b3c013-d300-468d-ac64-7eda0820b6d3"
+            - name: BLOB_ACCOUNT_URL
+              value: "https://holidaypeakhub405devstor.blob.core.windows.net"
+            - name: BLOB_CONTAINER
+              value: "agent-memory"
+            - name: CATALOG_SEARCH_REQUIRE_AI_SEARCH
+              value: "true"
+            - name: COSMOS_ACCOUNT_URI
+              value: "https://holidaypeakhub405-dev-cosmos.documents.azure.com:443/"
+            - name: COSMOS_CONTAINER
+              value: "agent-memory"
+            - name: COSMOS_DATABASE
+              value: "holiday-peak-db"
+            - name: EMBEDDING_DEPLOYMENT_NAME
+              value: "text-embedding-3-large"
+            - name: FOUNDRY_AGENT_NAME_FAST
+              value: "search-enrichment-agent-fast"
+            - name: FOUNDRY_AGENT_NAME_RICH
+              value: "search-enrichment-agent-rich"
+            - name: FOUNDRY_AUTO_ENSURE_ON_STARTUP
+              value: "true"
+            - name: FOUNDRY_STREAM
+              value: "false"
+            - name: FOUNDRY_STRICT_ENFORCEMENT
+              value: "false"
+            - name: KEY_VAULT_URI
+              value: "https://holidaypeakhub405-dev-kv.vault.azure.net/"
+            - name: MODEL_DEPLOYMENT_NAME_FAST
+              value: "gpt-5-nano"
+            - name: MODEL_DEPLOYMENT_NAME_RICH
+              value: "gpt-5"
+            - name: PLATFORM_JOBS_EVENT_HUB_NAMESPACE
+              value: "holidaypeakhub405-dev-jobs-eh"
+            - name: POSTGRES_AUTH_MODE
+              value: "password"
+            - name: POSTGRES_DATABASE
+              value: "holiday_peak_crud"
+            - name: POSTGRES_HOST
+              value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
+            - name: POSTGRES_PORT
+              value: "5432"
+            - name: POSTGRES_SSL
+              value: "true"
+            - name: POSTGRES_USER
+              value: "crud_workload"
+            - name: PROJECT_ENDPOINT
+              value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
+            - name: PROJECT_NAME
+              value: "aipholidaris"
+            - name: REDIS_HOST
+              value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
+            - name: REDIS_PASSWORD_SECRET_NAME
+              value: "redis-primary-key"
+            - name: REDIS_URL
+              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
+            - name: SEARCH_ENRICHMENT_EVENT_HUB_CONSUMER_GROUP
+              value: "search-enrichment-consumer"
+            - name: SEARCH_ENRICHMENT_EVENT_HUB_NAME
+              value: "search-enrichment-jobs"
+          ports:
+            - containerPort: 8000
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 250m
+              memory: 256Mi
+---
+# Source: holiday-peak-service/templates/agc-routing.yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: search-enrichment-agent-search-enrichment-agent-agc
+  namespace: holiday-peak
+  labels:
+    app: search-enrichment-agent
+spec:
+  parentRefs:
+    - name: "holiday-peak-agc"
+      namespace: "holiday-peak"
+  hostnames:
+    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/search-enrichment-agent"
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: "/"
+      backendRefs:
+        - name: search-enrichment-agent-search-enrichment-agent
+          port: 80

--- a/.kubernetes/rendered/truth-enrichment/all.yaml
+++ b/.kubernetes/rendered/truth-enrichment/all.yaml
@@ -1,0 +1,201 @@
+---
+# Source: holiday-peak-service/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: truth-enrichment
+  namespace: holiday-peak
+  labels:
+    app: truth-enrichment
+  annotations:
+    azure.workload.identity/client-id: "e9c11fac-45b3-4057-8477-1d96703eaae4"
+---
+# Source: holiday-peak-service/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: truth-enrichment-truth-enrichment
+  namespace: holiday-peak
+  labels:
+    app: truth-enrichment
+spec:
+  selector:
+    app: truth-enrichment
+    # When canary is disabled, select all pods
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8000
+  type: ClusterIP
+---
+# Source: holiday-peak-service/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: truth-enrichment-truth-enrichment
+  namespace: holiday-peak
+  labels:
+    app: truth-enrichment
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  selector:
+    matchLabels:
+      app: truth-enrichment
+  template:
+    metadata:
+      labels:
+        app: truth-enrichment
+        canary: "false"
+        azure.workload.identity/use: "true"
+    spec:
+      serviceAccountName: truth-enrichment
+      nodeSelector:
+        agentpool: agents
+      tolerations:
+        - effect: NoSchedule
+          key: workload
+          operator: Equal
+          value: agents
+      containers:
+        - name: truth-enrichment
+          image: "holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/truth-enrichment-dev:azd-deploy-1775350057"
+          env:
+            - name: AI_SEARCH_AUTH_MODE
+              value: "managed_identity"
+            - name: AI_SEARCH_ENDPOINT
+              value: "https://holidaypeakhub405devsearch.search.windows.net"
+            - name: AI_SEARCH_INDEX
+              value: "catalog-products"
+            - name: AI_SEARCH_INDEXER_NAME
+              value: "search-enriched-products-indexer"
+            - name: AI_SEARCH_VECTOR_INDEX
+              value: "product_search_index"
+            - name: APPLICATIONINSIGHTS_CONNECTION_STRING
+              value: "InstrumentationKey=d2fb45bc-e648-4da2-9345-d278636aede5;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=d8eb64c4-956d-46ab-a02e-d481deadaa0b"
+            - name: AZURE_CLIENT_ID
+              value: "e9c11fac-45b3-4057-8477-1d96703eaae4"
+            - name: AZURE_TENANT_ID
+              value: "16b3c013-d300-468d-ac64-7eda0820b6d3"
+            - name: BLOB_ACCOUNT_URL
+              value: "https://holidaypeakhub405devstor.blob.core.windows.net"
+            - name: BLOB_CONTAINER
+              value: "agent-memory"
+            - name: CATALOG_SEARCH_REQUIRE_AI_SEARCH
+              value: "true"
+            - name: COSMOS_ACCOUNT_URI
+              value: "https://holidaypeakhub405-dev-cosmos.documents.azure.com:443/"
+            - name: COSMOS_CONTAINER
+              value: "agent-memory"
+            - name: COSMOS_DATABASE
+              value: "holiday-peak-db"
+            - name: EMBEDDING_DEPLOYMENT_NAME
+              value: "text-embedding-3-large"
+            - name: FOUNDRY_AGENT_NAME_FAST
+              value: "truth-enrichment-fast"
+            - name: FOUNDRY_AGENT_NAME_RICH
+              value: "truth-enrichment-rich"
+            - name: FOUNDRY_AUTO_ENSURE_ON_STARTUP
+              value: "true"
+            - name: FOUNDRY_STREAM
+              value: "false"
+            - name: FOUNDRY_STRICT_ENFORCEMENT
+              value: "false"
+            - name: KEY_VAULT_URI
+              value: "https://holidaypeakhub405-dev-kv.vault.azure.net/"
+            - name: MODEL_DEPLOYMENT_NAME_FAST
+              value: "gpt-5-nano"
+            - name: MODEL_DEPLOYMENT_NAME_RICH
+              value: "gpt-5"
+            - name: PLATFORM_JOBS_EVENT_HUB_NAMESPACE
+              value: "holidaypeakhub405-dev-jobs-eh"
+            - name: POSTGRES_AUTH_MODE
+              value: "password"
+            - name: POSTGRES_DATABASE
+              value: "holiday_peak_crud"
+            - name: POSTGRES_HOST
+              value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
+            - name: POSTGRES_PORT
+              value: "5432"
+            - name: POSTGRES_SSL
+              value: "true"
+            - name: POSTGRES_USER
+              value: "crud_workload"
+            - name: PROJECT_ENDPOINT
+              value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
+            - name: PROJECT_NAME
+              value: "aipholidaris"
+            - name: REDIS_HOST
+              value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
+            - name: REDIS_PASSWORD_SECRET_NAME
+              value: "redis-primary-key"
+            - name: REDIS_URL
+              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
+            - name: TRUTH_EVENT_HUB_CONSUMER_GROUP
+              value: "enrichment-engine"
+            - name: TRUTH_EVENT_HUB_NAME
+              value: "enrichment-jobs"
+          ports:
+            - containerPort: 8000
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 250m
+              memory: 256Mi
+---
+# Source: holiday-peak-service/templates/agc-routing.yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: truth-enrichment-truth-enrichment-agc
+  namespace: holiday-peak
+  labels:
+    app: truth-enrichment
+spec:
+  parentRefs:
+    - name: "holiday-peak-agc"
+      namespace: "holiday-peak"
+  hostnames:
+    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/truth-enrichment"
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: "/"
+      backendRefs:
+        - name: truth-enrichment-truth-enrichment
+          port: 80

--- a/.kubernetes/rendered/truth-export/all.yaml
+++ b/.kubernetes/rendered/truth-export/all.yaml
@@ -1,0 +1,209 @@
+---
+# Source: holiday-peak-service/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: truth-export
+  namespace: holiday-peak
+  labels:
+    app: truth-export
+  annotations:
+    azure.workload.identity/client-id: "e9c11fac-45b3-4057-8477-1d96703eaae4"
+---
+# Source: holiday-peak-service/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: truth-export-truth-export
+  namespace: holiday-peak
+  labels:
+    app: truth-export
+spec:
+  selector:
+    app: truth-export
+    # When canary is disabled, select all pods
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8000
+  type: ClusterIP
+---
+# Source: holiday-peak-service/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: truth-export-truth-export
+  namespace: holiday-peak
+  labels:
+    app: truth-export
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  selector:
+    matchLabels:
+      app: truth-export
+  template:
+    metadata:
+      labels:
+        app: truth-export
+        canary: "false"
+        azure.workload.identity/use: "true"
+    spec:
+      serviceAccountName: truth-export
+      nodeSelector:
+        agentpool: agents
+      tolerations:
+        - effect: NoSchedule
+          key: workload
+          operator: Equal
+          value: agents
+      containers:
+        - name: truth-export
+          image: "holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/truth-export-dev:azd-deploy-1775350303"
+          command:
+            - uvicorn
+          args:
+            - truth_export.main:app
+            - --host
+            - 0.0.0.0
+            - --port
+            - "8000"
+          env:
+            - name: AI_SEARCH_AUTH_MODE
+              value: "managed_identity"
+            - name: AI_SEARCH_ENDPOINT
+              value: "https://holidaypeakhub405devsearch.search.windows.net"
+            - name: AI_SEARCH_INDEX
+              value: "catalog-products"
+            - name: AI_SEARCH_INDEXER_NAME
+              value: "search-enriched-products-indexer"
+            - name: AI_SEARCH_VECTOR_INDEX
+              value: "product_search_index"
+            - name: APPLICATIONINSIGHTS_CONNECTION_STRING
+              value: "InstrumentationKey=d2fb45bc-e648-4da2-9345-d278636aede5;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=d8eb64c4-956d-46ab-a02e-d481deadaa0b"
+            - name: AZURE_CLIENT_ID
+              value: "e9c11fac-45b3-4057-8477-1d96703eaae4"
+            - name: AZURE_TENANT_ID
+              value: "16b3c013-d300-468d-ac64-7eda0820b6d3"
+            - name: BLOB_ACCOUNT_URL
+              value: "https://holidaypeakhub405devstor.blob.core.windows.net"
+            - name: BLOB_CONTAINER
+              value: "agent-memory"
+            - name: CATALOG_SEARCH_REQUIRE_AI_SEARCH
+              value: "true"
+            - name: COSMOS_ACCOUNT_URI
+              value: "https://holidaypeakhub405-dev-cosmos.documents.azure.com:443/"
+            - name: COSMOS_CONTAINER
+              value: "agent-memory"
+            - name: COSMOS_DATABASE
+              value: "holiday-peak-db"
+            - name: EMBEDDING_DEPLOYMENT_NAME
+              value: "text-embedding-3-large"
+            - name: FOUNDRY_AGENT_NAME_FAST
+              value: "truth-export-fast"
+            - name: FOUNDRY_AGENT_NAME_RICH
+              value: "truth-export-rich"
+            - name: FOUNDRY_AUTO_ENSURE_ON_STARTUP
+              value: "true"
+            - name: FOUNDRY_STREAM
+              value: "false"
+            - name: FOUNDRY_STRICT_ENFORCEMENT
+              value: "false"
+            - name: KEY_VAULT_URI
+              value: "https://holidaypeakhub405-dev-kv.vault.azure.net/"
+            - name: MODEL_DEPLOYMENT_NAME_FAST
+              value: "gpt-5-nano"
+            - name: MODEL_DEPLOYMENT_NAME_RICH
+              value: "gpt-5"
+            - name: PLATFORM_JOBS_EVENT_HUB_NAMESPACE
+              value: "holidaypeakhub405-dev-jobs-eh"
+            - name: POSTGRES_AUTH_MODE
+              value: "password"
+            - name: POSTGRES_DATABASE
+              value: "holiday_peak_crud"
+            - name: POSTGRES_HOST
+              value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
+            - name: POSTGRES_PORT
+              value: "5432"
+            - name: POSTGRES_SSL
+              value: "true"
+            - name: POSTGRES_USER
+              value: "crud_workload"
+            - name: PROJECT_ENDPOINT
+              value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
+            - name: PROJECT_NAME
+              value: "aipholidaris"
+            - name: REDIS_HOST
+              value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
+            - name: REDIS_PASSWORD_SECRET_NAME
+              value: "redis-primary-key"
+            - name: REDIS_URL
+              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
+            - name: TRUTH_EVENT_HUB_CONSUMER_GROUP
+              value: "export-engine"
+            - name: TRUTH_EVENT_HUB_NAME
+              value: "export-jobs"
+          ports:
+            - containerPort: 8000
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 250m
+              memory: 256Mi
+---
+# Source: holiday-peak-service/templates/agc-routing.yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: truth-export-truth-export-agc
+  namespace: holiday-peak
+  labels:
+    app: truth-export
+spec:
+  parentRefs:
+    - name: "holiday-peak-agc"
+      namespace: "holiday-peak"
+  hostnames:
+    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/truth-export"
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: "/"
+      backendRefs:
+        - name: truth-export-truth-export
+          port: 80

--- a/.kubernetes/rendered/truth-hitl/all.yaml
+++ b/.kubernetes/rendered/truth-hitl/all.yaml
@@ -1,0 +1,201 @@
+---
+# Source: holiday-peak-service/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: truth-hitl
+  namespace: holiday-peak
+  labels:
+    app: truth-hitl
+  annotations:
+    azure.workload.identity/client-id: "e9c11fac-45b3-4057-8477-1d96703eaae4"
+---
+# Source: holiday-peak-service/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: truth-hitl-truth-hitl
+  namespace: holiday-peak
+  labels:
+    app: truth-hitl
+spec:
+  selector:
+    app: truth-hitl
+    # When canary is disabled, select all pods
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8000
+  type: ClusterIP
+---
+# Source: holiday-peak-service/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: truth-hitl-truth-hitl
+  namespace: holiday-peak
+  labels:
+    app: truth-hitl
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  selector:
+    matchLabels:
+      app: truth-hitl
+  template:
+    metadata:
+      labels:
+        app: truth-hitl
+        canary: "false"
+        azure.workload.identity/use: "true"
+    spec:
+      serviceAccountName: truth-hitl
+      nodeSelector:
+        agentpool: agents
+      tolerations:
+        - effect: NoSchedule
+          key: workload
+          operator: Equal
+          value: agents
+      containers:
+        - name: truth-hitl
+          image: "holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/truth-hitl-dev:azd-deploy-1775350566"
+          env:
+            - name: AI_SEARCH_AUTH_MODE
+              value: "managed_identity"
+            - name: AI_SEARCH_ENDPOINT
+              value: "https://holidaypeakhub405devsearch.search.windows.net"
+            - name: AI_SEARCH_INDEX
+              value: "catalog-products"
+            - name: AI_SEARCH_INDEXER_NAME
+              value: "search-enriched-products-indexer"
+            - name: AI_SEARCH_VECTOR_INDEX
+              value: "product_search_index"
+            - name: APPLICATIONINSIGHTS_CONNECTION_STRING
+              value: "InstrumentationKey=d2fb45bc-e648-4da2-9345-d278636aede5;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=d8eb64c4-956d-46ab-a02e-d481deadaa0b"
+            - name: AZURE_CLIENT_ID
+              value: "e9c11fac-45b3-4057-8477-1d96703eaae4"
+            - name: AZURE_TENANT_ID
+              value: "16b3c013-d300-468d-ac64-7eda0820b6d3"
+            - name: BLOB_ACCOUNT_URL
+              value: "https://holidaypeakhub405devstor.blob.core.windows.net"
+            - name: BLOB_CONTAINER
+              value: "agent-memory"
+            - name: CATALOG_SEARCH_REQUIRE_AI_SEARCH
+              value: "true"
+            - name: COSMOS_ACCOUNT_URI
+              value: "https://holidaypeakhub405-dev-cosmos.documents.azure.com:443/"
+            - name: COSMOS_CONTAINER
+              value: "agent-memory"
+            - name: COSMOS_DATABASE
+              value: "holiday-peak-db"
+            - name: EMBEDDING_DEPLOYMENT_NAME
+              value: "text-embedding-3-large"
+            - name: FOUNDRY_AGENT_NAME_FAST
+              value: "truth-hitl-fast"
+            - name: FOUNDRY_AGENT_NAME_RICH
+              value: "truth-hitl-rich"
+            - name: FOUNDRY_AUTO_ENSURE_ON_STARTUP
+              value: "true"
+            - name: FOUNDRY_STREAM
+              value: "false"
+            - name: FOUNDRY_STRICT_ENFORCEMENT
+              value: "false"
+            - name: KEY_VAULT_URI
+              value: "https://holidaypeakhub405-dev-kv.vault.azure.net/"
+            - name: MODEL_DEPLOYMENT_NAME_FAST
+              value: "gpt-5-nano"
+            - name: MODEL_DEPLOYMENT_NAME_RICH
+              value: "gpt-5"
+            - name: PLATFORM_JOBS_EVENT_HUB_NAMESPACE
+              value: "holidaypeakhub405-dev-jobs-eh"
+            - name: POSTGRES_AUTH_MODE
+              value: "password"
+            - name: POSTGRES_DATABASE
+              value: "holiday_peak_crud"
+            - name: POSTGRES_HOST
+              value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
+            - name: POSTGRES_PORT
+              value: "5432"
+            - name: POSTGRES_SSL
+              value: "true"
+            - name: POSTGRES_USER
+              value: "crud_workload"
+            - name: PROJECT_ENDPOINT
+              value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
+            - name: PROJECT_NAME
+              value: "aipholidaris"
+            - name: REDIS_HOST
+              value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
+            - name: REDIS_PASSWORD_SECRET_NAME
+              value: "redis-primary-key"
+            - name: REDIS_URL
+              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
+            - name: TRUTH_EVENT_HUB_CONSUMER_GROUP
+              value: "hitl-service"
+            - name: TRUTH_EVENT_HUB_NAME
+              value: "hitl-jobs"
+          ports:
+            - containerPort: 8000
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 250m
+              memory: 256Mi
+---
+# Source: holiday-peak-service/templates/agc-routing.yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: truth-hitl-truth-hitl-agc
+  namespace: holiday-peak
+  labels:
+    app: truth-hitl
+spec:
+  parentRefs:
+    - name: "holiday-peak-agc"
+      namespace: "holiday-peak"
+  hostnames:
+    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/truth-hitl"
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: "/"
+      backendRefs:
+        - name: truth-hitl-truth-hitl
+          port: 80

--- a/.kubernetes/rendered/truth-ingestion/all.yaml
+++ b/.kubernetes/rendered/truth-ingestion/all.yaml
@@ -1,0 +1,204 @@
+---
+# Source: holiday-peak-service/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: truth-ingestion
+  namespace: holiday-peak
+  labels:
+    app: truth-ingestion
+  annotations:
+    azure.workload.identity/client-id: "e9c11fac-45b3-4057-8477-1d96703eaae4"
+---
+# Source: holiday-peak-service/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: truth-ingestion-truth-ingestion
+  namespace: holiday-peak
+  labels:
+    app: truth-ingestion
+spec:
+  selector:
+    app: truth-ingestion
+    # When canary is disabled, select all pods
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8000
+  type: ClusterIP
+---
+# Source: holiday-peak-service/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: truth-ingestion-truth-ingestion
+  namespace: holiday-peak
+  labels:
+    app: truth-ingestion
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  selector:
+    matchLabels:
+      app: truth-ingestion
+      canary: "false"
+  template:
+    metadata:
+      labels:
+        app: truth-ingestion
+        canary: "false"
+        azure.workload.identity/use: "true"
+    spec:
+      serviceAccountName: truth-ingestion
+      nodeSelector:
+        agentpool: agents
+      tolerations:
+        - effect: NoSchedule
+          key: workload
+          operator: Equal
+          value: agents
+      containers:
+        - name: truth-ingestion
+          image: "holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/truth-ingestion-dev:azd-deploy-1775349769"
+          env:
+            - name: AI_SEARCH_AUTH_MODE
+              value: "managed_identity"
+            - name: AI_SEARCH_ENDPOINT
+              value: "https://holidaypeakhub405devsearch.search.windows.net"
+            - name: AI_SEARCH_INDEX
+              value: "catalog-products"
+            - name: AI_SEARCH_INDEXER_NAME
+              value: "search-enriched-products-indexer"
+            - name: AI_SEARCH_VECTOR_INDEX
+              value: "product_search_index"
+            - name: APPLICATIONINSIGHTS_CONNECTION_STRING
+              value: "InstrumentationKey=d2fb45bc-e648-4da2-9345-d278636aede5;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=d8eb64c4-956d-46ab-a02e-d481deadaa0b"
+            - name: AZURE_CLIENT_ID
+              value: "e9c11fac-45b3-4057-8477-1d96703eaae4"
+            - name: AZURE_TENANT_ID
+              value: "16b3c013-d300-468d-ac64-7eda0820b6d3"
+            - name: BLOB_ACCOUNT_URL
+              value: "https://holidaypeakhub405devstor.blob.core.windows.net"
+            - name: BLOB_CONTAINER
+              value: "agent-memory"
+            - name: CATALOG_SEARCH_REQUIRE_AI_SEARCH
+              value: "true"
+            - name: COSMOS_ACCOUNT_URI
+              value: "https://holidaypeakhub405-dev-cosmos.documents.azure.com:443/"
+            - name: COSMOS_AUDIT_CONTAINER
+              value: "audit"
+            - name: COSMOS_CONTAINER
+              value: "products"
+            - name: COSMOS_DATABASE
+              value: "holiday-peak-db"
+            - name: EMBEDDING_DEPLOYMENT_NAME
+              value: "text-embedding-3-large"
+            - name: FOUNDRY_AGENT_NAME_FAST
+              value: "truth-ingestion-fast"
+            - name: FOUNDRY_AGENT_NAME_RICH
+              value: "truth-ingestion-rich"
+            - name: FOUNDRY_AUTO_ENSURE_ON_STARTUP
+              value: "true"
+            - name: FOUNDRY_STREAM
+              value: "false"
+            - name: FOUNDRY_STRICT_ENFORCEMENT
+              value: "false"
+            - name: KEY_VAULT_URI
+              value: "https://holidaypeakhub405-dev-kv.vault.azure.net/"
+            - name: MODEL_DEPLOYMENT_NAME_FAST
+              value: "gpt-5-nano"
+            - name: MODEL_DEPLOYMENT_NAME_RICH
+              value: "gpt-5"
+            - name: PLATFORM_JOBS_EVENT_HUB_NAMESPACE
+              value: "holidaypeakhub405-dev-jobs-eh"
+            - name: POSTGRES_AUTH_MODE
+              value: "password"
+            - name: POSTGRES_DATABASE
+              value: "holiday_peak_crud"
+            - name: POSTGRES_HOST
+              value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
+            - name: POSTGRES_PORT
+              value: "5432"
+            - name: POSTGRES_SSL
+              value: "true"
+            - name: POSTGRES_USER
+              value: "crud_workload"
+            - name: PROJECT_ENDPOINT
+              value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
+            - name: PROJECT_NAME
+              value: "aipholidaris"
+            - name: REDIS_HOST
+              value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
+            - name: REDIS_PASSWORD_SECRET_NAME
+              value: "redis-primary-key"
+            - name: REDIS_URL
+              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
+            - name: TRUTH_EVENT_HUB_CONSUMER_GROUP
+              value: "ingestion-group"
+            - name: TRUTH_EVENT_HUB_NAME
+              value: "ingest-jobs"
+          ports:
+            - containerPort: 8000
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 250m
+              memory: 256Mi
+---
+# Source: holiday-peak-service/templates/agc-routing.yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: truth-ingestion-truth-ingestion-agc
+  namespace: holiday-peak
+  labels:
+    app: truth-ingestion
+spec:
+  parentRefs:
+    - name: "holiday-peak-agc"
+      namespace: "holiday-peak"
+  hostnames:
+    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/truth-ingestion"
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: "/"
+      backendRefs:
+        - name: truth-ingestion-truth-ingestion
+          port: 80


### PR DESCRIPTION
## Summary

Seeds the initial rendered Kubernetes manifests for all 27 services so Flux CD can begin reconciliation immediately.

## Context

PR #785 added the Flux CD GitOps configuration and \.kubernetes/rendered/kustomization.yaml\. However, the individual service \ll.yaml\ files were not committed — they would normally be generated by the \commit-rendered-manifests\ CI job during the next deploy.

This PR provides the initial seed so Flux can validate its configuration against the current cluster state without waiting for a full deploy cycle.

## Changes

27 rendered Kubernetes manifest files (\ll.yaml\) generated by \ender-helm.sh\.

## Related Issues
Part of #782 (Flux CD migration)