### PR TITLE
feat: namespace isolation — split CRUD and agents into separate namespaces (ADR-034)

### DIFF
--- a/.github/workflows/deploy-azd.yml
+++ b/.github/workflows/deploy-azd.yml
@@ -411,6 +411,8 @@ jobs:
           azd env set IMAGE_PREFIX "ghcr.io/${{ github.repository_owner }}" -e "${{ inputs.environment }}"
           azd env set IMAGE_TAG "${{ inputs.imageTag }}" -e "${{ inputs.environment }}"
           azd env set K8S_NAMESPACE holiday-peak -e "${{ inputs.environment }}"
+          azd env set K8S_CRUD_NAMESPACE holiday-peak-crud -e "${{ inputs.environment }}"
+          azd env set K8S_AGENTS_NAMESPACE holiday-peak-agents -e "${{ inputs.environment }}"
           azd env set KEDA_ENABLED true -e "${{ inputs.environment }}"
           if [ "${{ inputs.environment }}" = "dev" ]; then
             azd env set POSTGRES_AUTH_MODE entra -e "${{ inputs.environment }}"
@@ -1415,6 +1417,18 @@ jobs:
           nslookup "$AKS_FQDN" || true
           exit 1
 
+      - name: Ensure target namespaces exist
+        shell: bash
+        run: |
+          set -euo pipefail
+          for ns in holiday-peak-crud holiday-peak-agents; do
+            if ! kubectl get namespace "$ns" >/dev/null 2>&1; then
+              kubectl create namespace "$ns"
+              echo "Created namespace $ns"
+            fi
+            kubectl label namespace "$ns" holiday-peak/ingress-allowed=true --overwrite
+          done
+
       - name: Resolve AKS managed identity client ID
         run: |
           AKS_MI_CLIENT_ID=$(az aks show \
@@ -1510,16 +1524,16 @@ jobs:
           deploy_crud() {
             export SERVICE_CRUD_SERVICE_IMAGE_NAME="$CRUD_IMAGE_REF"
             bash .infra/azd/hooks/render-helm.sh crud-service
-            kubectl apply --dry-run=server -f .kubernetes/rendered/crud-service/all.yaml -n holiday-peak >/dev/null
-            kubectl apply -f .kubernetes/rendered/crud-service/all.yaml -n holiday-peak >/dev/null
+            kubectl apply --dry-run=server -f .kubernetes/rendered/crud-service/all.yaml -n holiday-peak-crud >/dev/null
+            kubectl apply -f .kubernetes/rendered/crud-service/all.yaml -n holiday-peak-crud >/dev/null
 
-            DEPLOYMENT_NAME=$(kubectl get deployment -n holiday-peak -l 'app=crud-service,canary=false' -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+            DEPLOYMENT_NAME=$(kubectl get deployment -n holiday-peak-crud -l 'app=crud-service,canary=false' -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
             if [ -z "$DEPLOYMENT_NAME" ]; then
               echo "Failed to resolve CRUD deployment name after manifest apply." >&2
               return 1
             fi
 
-            kubectl rollout status "deployment/${DEPLOYMENT_NAME}" -n holiday-peak --timeout=300s
+            kubectl rollout status "deployment/${DEPLOYMENT_NAME}" -n holiday-peak-crud --timeout=300s
           }
 
           if deploy_crud; then
@@ -1543,21 +1557,21 @@ jobs:
           } > "$TRIAGE_DIR/run-metadata.txt"
 
           kubectl get ingressclass -o wide > "$TRIAGE_DIR/kubectl-ingressclass.txt" 2>&1 || true
-          kubectl get ingress -n holiday-peak -o wide > "$TRIAGE_DIR/kubectl-ingress.txt" 2>&1 || true
+          kubectl get ingress -n holiday-peak-crud -o wide > "$TRIAGE_DIR/kubectl-ingress.txt" 2>&1 || true
           kubectl get pods -n app-routing-system -o wide > "$TRIAGE_DIR/kubectl-app-routing-pods.txt" 2>&1 || true
           kubectl get pods -n ingress-nginx -o wide > "$TRIAGE_DIR/kubectl-ingress-nginx-pods.txt" 2>&1 || true
-          kubectl -n holiday-peak get deployment -l app=crud-service,canary=false -o wide > "$TRIAGE_DIR/kubectl-crud-deployment.txt" 2>&1 || true
-          kubectl -n holiday-peak describe deployment $(kubectl get deployment -n holiday-peak -l app=crud-service,canary=false -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo crud-service-crud-service) > "$TRIAGE_DIR/kubectl-crud-deployment-describe.txt" 2>&1 || true
-          kubectl -n holiday-peak get rs -l app=crud-service -o wide > "$TRIAGE_DIR/kubectl-crud-rs.txt" 2>&1 || true
-          kubectl -n holiday-peak get pods -l app=crud-service -o wide > "$TRIAGE_DIR/kubectl-crud-pods.txt" 2>&1 || true
-          kubectl -n holiday-peak get events --sort-by='.lastTimestamp' | tail -n 200 > "$TRIAGE_DIR/kubectl-events-tail.txt" 2>&1 || true
+          kubectl -n holiday-peak-crud get deployment -l app=crud-service,canary=false -o wide > "$TRIAGE_DIR/kubectl-crud-deployment.txt" 2>&1 || true
+          kubectl -n holiday-peak-crud describe deployment $(kubectl get deployment -n holiday-peak-crud -l app=crud-service,canary=false -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo crud-service-crud-service) > "$TRIAGE_DIR/kubectl-crud-deployment-describe.txt" 2>&1 || true
+          kubectl -n holiday-peak-crud get rs -l app=crud-service -o wide > "$TRIAGE_DIR/kubectl-crud-rs.txt" 2>&1 || true
+          kubectl -n holiday-peak-crud get pods -l app=crud-service -o wide > "$TRIAGE_DIR/kubectl-crud-pods.txt" 2>&1 || true
+          kubectl -n holiday-peak-crud get events --sort-by='.lastTimestamp' | tail -n 200 > "$TRIAGE_DIR/kubectl-events-tail.txt" 2>&1 || true
           cp .kubernetes/rendered/crud-service/all.yaml "$TRIAGE_DIR/rendered-crud-all.yaml" 2>/dev/null || true
 
-          NEW_POD=$(kubectl -n holiday-peak get pods -l app=crud-service --sort-by=.metadata.creationTimestamp -o jsonpath='{.items[-1:].metadata.name}' 2>/dev/null || true)
+          NEW_POD=$(kubectl -n holiday-peak-crud get pods -l app=crud-service --sort-by=.metadata.creationTimestamp -o jsonpath='{.items[-1:].metadata.name}' 2>/dev/null || true)
           if [ -n "$NEW_POD" ]; then
-            kubectl -n holiday-peak describe pod "$NEW_POD" > "$TRIAGE_DIR/kubectl-new-pod-describe.txt" 2>&1 || true
-            kubectl -n holiday-peak logs "$NEW_POD" --tail=300 > "$TRIAGE_DIR/kubectl-new-pod-logs.txt" 2>&1 || true
-            kubectl -n holiday-peak logs "$NEW_POD" --previous --tail=300 > "$TRIAGE_DIR/kubectl-new-pod-logs-previous.txt" 2>&1 || true
+            kubectl -n holiday-peak-crud describe pod "$NEW_POD" > "$TRIAGE_DIR/kubectl-new-pod-describe.txt" 2>&1 || true
+            kubectl -n holiday-peak-crud logs "$NEW_POD" --tail=300 > "$TRIAGE_DIR/kubectl-new-pod-logs.txt" 2>&1 || true
+            kubectl -n holiday-peak-crud logs "$NEW_POD" --previous --tail=300 > "$TRIAGE_DIR/kubectl-new-pod-logs-previous.txt" 2>&1 || true
           fi
 
           echo "CRUD deploy failed on first attempt. Review first-failure protocol in run summary before rerun." >&2
@@ -1677,7 +1691,7 @@ jobs:
             echo "APIM gateway URL not provided by provision outputs; skipping APIM /api/ready check."
           fi
 
-          kubectl port-forward svc/crud-service 18080:8000 -n holiday-peak >/tmp/crud-port-forward.log 2>&1 &
+          kubectl port-forward svc/crud-service 18080:8000 -n holiday-peak-crud >/tmp/crud-port-forward.log 2>&1 &
           PF_PID=$!
           trap 'kill "$PF_PID" >/dev/null 2>&1 || true' EXIT
           sleep 3
@@ -2186,6 +2200,16 @@ jobs:
           nslookup "$AKS_FQDN" || true
           exit 1
 
+      - name: Ensure agents namespace exists
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! kubectl get namespace holiday-peak-agents >/dev/null 2>&1; then
+            kubectl create namespace holiday-peak-agents
+            echo "Created namespace holiday-peak-agents"
+          fi
+          kubectl label namespace holiday-peak-agents holiday-peak/ingress-allowed=true --overwrite
+
       - name: Resolve AKS managed identity client ID
         run: |
           AKS_MI_CLIENT_ID=$(az aks show \
@@ -2223,16 +2247,16 @@ jobs:
           export "${SERVICE_IMAGE_VAR_NAME}=${IMAGE_REF}"
 
           bash .infra/azd/hooks/render-helm.sh "$SERVICE_NAME"
-          kubectl apply --dry-run=server -f ".kubernetes/rendered/${SERVICE_NAME}/all.yaml" -n holiday-peak >/dev/null
-          kubectl apply -f ".kubernetes/rendered/${SERVICE_NAME}/all.yaml" -n holiday-peak >/dev/null
+          kubectl apply --dry-run=server -f ".kubernetes/rendered/${SERVICE_NAME}/all.yaml" -n holiday-peak-agents >/dev/null
+          kubectl apply -f ".kubernetes/rendered/${SERVICE_NAME}/all.yaml" -n holiday-peak-agents >/dev/null
 
-          DEPLOYMENT_NAME=$(kubectl get deployment -n holiday-peak -l "app=${SERVICE_NAME},canary=false" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+          DEPLOYMENT_NAME=$(kubectl get deployment -n holiday-peak-agents -l "app=${SERVICE_NAME},canary=false" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
           if [ -z "$DEPLOYMENT_NAME" ]; then
             echo "Failed to resolve deployment name for ${SERVICE_NAME} after manifest apply." >&2
             exit 1
           fi
 
-          kubectl rollout status "deployment/${DEPLOYMENT_NAME}" -n holiday-peak --timeout=300s
+          kubectl rollout status "deployment/${DEPLOYMENT_NAME}" -n holiday-peak-agents --timeout=300s
         env:
           DEPLOY_ENV: ${{ inputs.environment }}
           AZURE_TENANT_ID: ${{ env.AZURE_TENANT_ID }}
@@ -2538,7 +2562,7 @@ jobs:
           RG_NAME="${{ inputs.projectName }}-${{ inputs.environment }}-rg"
           APIM_NAME="${{ inputs.projectName }}-${{ inputs.environment }}-apim"
           AKS_NAME="${{ inputs.projectName }}-${{ inputs.environment }}-aks"
-          K8S_NAMESPACE="holiday-peak"
+          K8S_NAMESPACE="holiday-peak-crud"
 
           fetch_crud_endpoint_ips() {
             local logs
@@ -2805,7 +2829,7 @@ jobs:
       - name: Render changed agent manifests for Foundry contract validation
         shell: bash
         env:
-          K8S_NAMESPACE: holiday-peak
+          K8S_NAMESPACE: holiday-peak-agents
         run: |
           set -euo pipefail
 
@@ -2888,7 +2912,7 @@ jobs:
           export FOUNDRY_AUTO_ENSURE_ON_STARTUP="${FOUNDRY_RUNTIME_AUTO_ENSURE_ON_STARTUP}"
           bash .infra/azd/hooks/ensure-foundry-agents.sh --port-forward --fail-on-error
         env:
-          K8S_NAMESPACE: holiday-peak
+          K8S_NAMESPACE: holiday-peak-agents
           VALIDATE_RENDERED_FOUNDRY_CONTRACT: "true"
           VALIDATE_READY_AFTER_ENSURE: "true"
 

--- a/.infra/README.md
+++ b/.infra/README.md
@@ -331,6 +331,8 @@ Optional env overrides (stored in `.azure/<env>/.env`):
 
 ```bash
 azd env set K8S_NAMESPACE holiday-peak -e <environment>
+azd env set K8S_CRUD_NAMESPACE holiday-peak-crud -e <environment>
+azd env set K8S_AGENTS_NAMESPACE holiday-peak-agents -e <environment>
 azd env set IMAGE_PREFIX ghcr.io/azure-samples -e <environment>
 azd env set IMAGE_TAG latest -e <environment>
 azd env set KEDA_ENABLED false -e <environment>

--- a/.infra/azd/hooks/ensure-foundry-agents.ps1
+++ b/.infra/azd/hooks/ensure-foundry-agents.ps1
@@ -12,7 +12,7 @@
     The script is idempotent — it creates agents only if they don't already exist.
 
 .PARAMETER Namespace
-    Kubernetes namespace. Defaults to K8S_NAMESPACE or 'holiday-peak'.
+    Kubernetes namespace. Defaults to K8S_AGENTS_NAMESPACE or K8S_NAMESPACE or 'holiday-peak-agents'.
 
 .PARAMETER UsePortForward
     If set, uses kubectl port-forward to reach services. Otherwise expects
@@ -29,7 +29,7 @@
     Number of retries per service if the ensure call fails. Default 3.
 #>
 param(
-    [string]$Namespace = $(if ($env:K8S_NAMESPACE) { $env:K8S_NAMESPACE } else { 'holiday-peak' }),
+    [string]$Namespace = $(if ($env:K8S_AGENTS_NAMESPACE) { $env:K8S_AGENTS_NAMESPACE } elseif ($env:K8S_NAMESPACE) { $env:K8S_NAMESPACE } else { 'holiday-peak-agents' }),
     [switch]$UsePortForward,
     [string]$BaseUrl,
     [string]$AzureYamlPath,

--- a/.infra/azd/hooks/render-helm.ps1
+++ b/.infra/azd/hooks/render-helm.ps1
@@ -392,6 +392,15 @@ $envMappings = @{
   APPLICATIONINSIGHTS_CONNECTION_STRING = $env:APPLICATIONINSIGHTS_CONNECTION_STRING
 }
 
+# Cross-namespace CRUD service URL for agent->CRUD communication (ADR-034)
+if ($ServiceName -ne "crud-service") {
+  $crudNs = if ($env:K8S_CRUD_NAMESPACE) { $env:K8S_CRUD_NAMESPACE }
+            elseif ($env:K8S_NAMESPACE) { $env:K8S_NAMESPACE }
+            else { "holiday-peak-crud" }
+  $defaultCrudUrl = "http://crud-service-crud-service.${crudNs}.svc.cluster.local:8000"
+  $envMappings["CRUD_SERVICE_URL"] = if ($env:CRUD_SERVICE_URL) { $env:CRUD_SERVICE_URL } else { $defaultCrudUrl }
+}
+
 $truthServiceEventHubMappings = @{
   "truth-ingestion" = @{ TRUTH_EVENT_HUB_NAME = "ingest-jobs"; TRUTH_EVENT_HUB_CONSUMER_GROUP = "ingestion-group" }
   "truth-enrichment" = @{ TRUTH_EVENT_HUB_NAME = "enrichment-jobs"; TRUTH_EVENT_HUB_CONSUMER_GROUP = "enrichment-engine" }

--- a/.infra/azd/hooks/render-helm.ps1
+++ b/.infra/azd/hooks/render-helm.ps1
@@ -3,7 +3,15 @@ param(
     [string]$ServiceName
 )
 
-$namespace = if ($env:K8S_NAMESPACE) { $env:K8S_NAMESPACE } else { "holiday-peak" }
+$namespace = if ($ServiceName -eq "crud-service") {
+    if ($env:K8S_CRUD_NAMESPACE) { $env:K8S_CRUD_NAMESPACE }
+    elseif ($env:K8S_NAMESPACE) { $env:K8S_NAMESPACE }
+    else { "holiday-peak-crud" }
+} else {
+    if ($env:K8S_AGENTS_NAMESPACE) { $env:K8S_AGENTS_NAMESPACE }
+    elseif ($env:K8S_NAMESPACE) { $env:K8S_NAMESPACE }
+    else { "holiday-peak-agents" }
+}
 $imagePrefix = if ($env:IMAGE_PREFIX) { $env:IMAGE_PREFIX } else { "ghcr.io/azure-samples" }
 $imageTag = if ($env:IMAGE_TAG) { $env:IMAGE_TAG } else { "latest" }
 $imageDigest = if ($env:IMAGE_DIGEST) { $env:IMAGE_DIGEST } else { "" }

--- a/.infra/azd/hooks/render-helm.sh
+++ b/.infra/azd/hooks/render-helm.sh
@@ -416,6 +416,12 @@ add_env_arg "BLOB_CONTAINER" "${BLOB_CONTAINER:-}"
 # Observability
 add_env_arg "APPLICATIONINSIGHTS_CONNECTION_STRING" "${APPLICATIONINSIGHTS_CONNECTION_STRING:-}"
 
+# Cross-namespace CRUD service URL for agent→CRUD communication (ADR-034)
+if is_agent_service; then
+  CRUD_NS="${K8S_CRUD_NAMESPACE:-${K8S_NAMESPACE:-holiday-peak-crud}}"
+  add_env_arg "CRUD_SERVICE_URL" "${CRUD_SERVICE_URL:-http://crud-service-crud-service.${CRUD_NS}.svc.cluster.local:8000}"
+fi
+
 if [ "$SERVICE_NAME" = "ecommerce-catalog-search" ]; then
   add_env_arg "SEARCH_ENRICHMENT_EVENT_HUB_NAME" "${SEARCH_ENRICHMENT_EVENT_HUB_NAME:-search-enrichment-jobs}"
   add_env_arg "SEARCH_ENRICHMENT_EVENT_HUB_CONSUMER_GROUP" "${SEARCH_ENRICHMENT_EVENT_HUB_CONSUMER_GROUP:-search-enrichment-consumer}"

--- a/.infra/azd/hooks/render-helm.sh
+++ b/.infra/azd/hooks/render-helm.sh
@@ -3,7 +3,13 @@ set -eu
 
 SERVICE_NAME="$1"
 
-NAMESPACE="${K8S_NAMESPACE:-holiday-peak}"
+# Namespace routing: CRUD goes to holiday-peak-crud, agents to holiday-peak-agents.
+# ADR-034: Namespace Isolation Strategy
+if [ "$SERVICE_NAME" = "crud-service" ]; then
+  NAMESPACE="${K8S_CRUD_NAMESPACE:-${K8S_NAMESPACE:-holiday-peak-crud}}"
+else
+  NAMESPACE="${K8S_AGENTS_NAMESPACE:-${K8S_NAMESPACE:-holiday-peak-agents}}"
+fi
 IMAGE_PREFIX="${IMAGE_PREFIX:-ghcr.io/azure-samples}"
 IMAGE_TAG="${IMAGE_TAG:-latest}"
 IMAGE_DIGEST="${IMAGE_DIGEST:-}"

--- a/.infra/azd/hooks/seed-crud-demo-data.ps1
+++ b/.infra/azd/hooks/seed-crud-demo-data.ps1
@@ -1,6 +1,6 @@
 #!/usr/bin/env pwsh
 param(
-    [string]$Namespace = $(if ($env:K8S_NAMESPACE) { $env:K8S_NAMESPACE } else { 'holiday-peak' }),
+    [string]$Namespace = $(if ($env:K8S_CRUD_NAMESPACE) { $env:K8S_CRUD_NAMESPACE } elseif ($env:K8S_NAMESPACE) { $env:K8S_NAMESPACE } else { 'holiday-peak-crud' }),
     [string]$EnvironmentName = $(if ($env:AZURE_ENV_NAME) { $env:AZURE_ENV_NAME } else { 'dev' }),
     [int]$WaitTimeoutSeconds = 600,
     [bool]$EnableSeed = $(if ($env:DEMO_SEED_ENABLED) { $env:DEMO_SEED_ENABLED -eq 'true' } else { $true }),

--- a/.infra/azd/hooks/sync-apim-agents.ps1
+++ b/.infra/azd/hooks/sync-apim-agents.ps1
@@ -2,7 +2,7 @@ param(
     [string]$ResourceGroup = $env:AZURE_RESOURCE_GROUP,
     [string]$ApimName = $env:APIM_NAME,
     [string]$ApimCorsAllowedOrigins = $(if ($env:APIM_CORS_ALLOWED_ORIGINS) { $env:APIM_CORS_ALLOWED_ORIGINS } else { 'http://localhost:3000' }),
-    [string]$Namespace = $(if ($env:K8S_NAMESPACE) { $env:K8S_NAMESPACE } else { 'holiday-peak' }),
+    [string]$Namespace = $(if ($env:K8S_NAMESPACE) { $env:K8S_NAMESPACE } else { 'holiday-peak-agents' }),
     [string]$AzureYamlPath,
     [string]$ChangedServices = $env:CHANGED_SERVICES,
     [string]$ApiPathPrefix = 'agents',

--- a/.infra/modules/shared-infrastructure/shared-infrastructure.bicep
+++ b/.infra/modules/shared-infrastructure/shared-infrastructure.bicep
@@ -84,7 +84,9 @@ var agcControllerIdentityName = '${projectName}${envSuffix}-agc-controller'
 var agcControllerNamespace = 'azure-alb-system'
 var agcControllerServiceAccount = 'alb-controller-sa'
 var agcGatewayClassName = 'azure-alb-external'
-var workloadNamespace = 'holiday-peak'
+// ADR-034: Namespace isolation — CRUD and agents in separate namespaces.
+var crudNamespace = 'holiday-peak-crud'
+var agentsNamespace = 'holiday-peak-agents'
 var agentsIdentityName = '${projectName}${envSuffix}-agents-identity'
 var agentsIdentity2Name = '${projectName}${envSuffix}-agents-identity-2'
 var crudIdentityName = '${projectName}${envSuffix}-crud-identity'
@@ -1183,13 +1185,23 @@ resource fluxConfig 'Microsoft.KubernetesConfiguration/fluxConfigurations@2024-0
       timeoutInSeconds: 600
     }
     kustomizations: {
-      'holiday-peak-services': {
-        path: '.kubernetes/rendered'
+      'holiday-peak-crud': {
+        path: '.kubernetes/rendered/crud'
         syncIntervalInSeconds: 300
         timeoutInSeconds: 600
         prune: true
         force: false
         dependsOn: []
+      }
+      'holiday-peak-agents': {
+        path: '.kubernetes/rendered/agents'
+        syncIntervalInSeconds: 300
+        timeoutInSeconds: 600
+        prune: true
+        force: false
+        dependsOn: [
+          'holiday-peak-crud'
+        ]
       }
     }
   }
@@ -1279,7 +1291,7 @@ resource agentsFederatedCredentials 'Microsoft.ManagedIdentity/userAssignedIdent
       'api://AzureADTokenExchange'
     ]
     issuer: aks.outputs.?oidcIssuerUrl ?? ''
-    subject: 'system:serviceaccount:${workloadNamespace}:${svc}'
+    subject: 'system:serviceaccount:${agentsNamespace}:${svc}'
   }
 }]
 
@@ -1292,7 +1304,7 @@ resource agentsFederatedCredentials2 'Microsoft.ManagedIdentity/userAssignedIden
       'api://AzureADTokenExchange'
     ]
     issuer: aks.outputs.?oidcIssuerUrl ?? ''
-    subject: 'system:serviceaccount:${workloadNamespace}:${svc}'
+    subject: 'system:serviceaccount:${agentsNamespace}:${svc}'
   }
 }]
 
@@ -1304,7 +1316,7 @@ resource crudFederatedCredential 'Microsoft.ManagedIdentity/userAssignedIdentiti
       'api://AzureADTokenExchange'
     ]
     issuer: aks.outputs.?oidcIssuerUrl ?? ''
-    subject: 'system:serviceaccount:${workloadNamespace}:crud-service'
+    subject: 'system:serviceaccount:${crudNamespace}:crud-service'
   }
 }
 

--- a/.kubernetes/rendered/agents/kustomization.yaml
+++ b/.kubernetes/rendered/agents/kustomization.yaml
@@ -1,0 +1,30 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../crm-campaign-intelligence/all.yaml
+  - ../crm-profile-aggregation/all.yaml
+  - ../crm-segmentation-personalization/all.yaml
+  - ../crm-support-assistance/all.yaml
+  - ../ecommerce-cart-intelligence/all.yaml
+  - ../ecommerce-catalog-search/all.yaml
+  - ../ecommerce-checkout-support/all.yaml
+  - ../ecommerce-order-status/all.yaml
+  - ../ecommerce-product-detail-enrichment/all.yaml
+  - ../inventory-alerts-triggers/all.yaml
+  - ../inventory-health-check/all.yaml
+  - ../inventory-jit-replenishment/all.yaml
+  - ../inventory-reservation-validation/all.yaml
+  - ../logistics-carrier-selection/all.yaml
+  - ../logistics-eta-computation/all.yaml
+  - ../logistics-returns-support/all.yaml
+  - ../logistics-route-issue-detection/all.yaml
+  - ../product-management-acp-transformation/all.yaml
+  - ../product-management-assortment-optimization/all.yaml
+  - ../product-management-consistency-validation/all.yaml
+  - ../product-management-normalization-classification/all.yaml
+  - ../search-enrichment-agent/all.yaml
+  - ../truth-enrichment/all.yaml
+  - ../truth-export/all.yaml
+  - ../truth-hitl/all.yaml
+  - ../truth-ingestion/all.yaml

--- a/.kubernetes/rendered/crm-campaign-intelligence/all.yaml
+++ b/.kubernetes/rendered/crm-campaign-intelligence/all.yaml
@@ -93,6 +93,8 @@ spec:
               value: "agent-memory"
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
+            - name: CRUD_SERVICE_URL
+              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: EVENT_HUB_NAMESPACE

--- a/.kubernetes/rendered/crm-campaign-intelligence/all.yaml
+++ b/.kubernetes/rendered/crm-campaign-intelligence/all.yaml
@@ -1,10 +1,10 @@
----
+﻿---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: crm-campaign-intelligence
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: crm-campaign-intelligence
   annotations:
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: crm-campaign-intelligence-crm-campaign-intelligence
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: crm-campaign-intelligence
 spec:
@@ -33,7 +33,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: crm-campaign-intelligence-crm-campaign-intelligence
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: crm-campaign-intelligence
 spec:
@@ -114,17 +114,15 @@ spec:
             - name: MODEL_DEPLOYMENT_NAME_RICH
               value: "gpt-5"
             - name: POSTGRES_AUTH_MODE
-              value: "password"
+              value: "entra"
             - name: POSTGRES_DATABASE
               value: "holiday_peak_crud"
             - name: POSTGRES_HOST
               value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
-            - name: POSTGRES_PORT
-              value: "5432"
             - name: POSTGRES_SSL
               value: "true"
             - name: POSTGRES_USER
-              value: "crud_workload"
+              value: "holidaypeakhub405-dev-crud-identity"
             - name: PROJECT_ENDPOINT
               value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
             - name: PROJECT_NAME
@@ -133,8 +131,6 @@ spec:
               value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
             - name: REDIS_PASSWORD_SECRET_NAME
               value: "redis-primary-key"
-            - name: REDIS_URL
-              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
           ports:
             - containerPort: 8000
           startupProbe:
@@ -166,32 +162,3 @@ spec:
             requests:
               cpu: 250m
               memory: 256Mi
----
-# Source: holiday-peak-service/templates/agc-routing.yaml
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: crm-campaign-intelligence-crm-campaign-intelligence-agc
-  namespace: holiday-peak
-  labels:
-    app: crm-campaign-intelligence
-spec:
-  parentRefs:
-    - name: "holiday-peak-agc"
-      namespace: "holiday-peak"
-  hostnames:
-    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
-  rules:
-    - matches:
-        - path:
-            type: PathPrefix
-            value: "/crm-campaign-intelligence"
-      filters:
-        - type: URLRewrite
-          urlRewrite:
-            path:
-              type: ReplacePrefixMatch
-              replacePrefixMatch: "/"
-      backendRefs:
-        - name: crm-campaign-intelligence-crm-campaign-intelligence
-          port: 80

--- a/.kubernetes/rendered/crm-profile-aggregation/all.yaml
+++ b/.kubernetes/rendered/crm-profile-aggregation/all.yaml
@@ -1,10 +1,10 @@
----
+﻿---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: crm-profile-aggregation
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: crm-profile-aggregation
   annotations:
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: crm-profile-aggregation-crm-profile-aggregation
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: crm-profile-aggregation
 spec:
@@ -33,7 +33,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: crm-profile-aggregation-crm-profile-aggregation
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: crm-profile-aggregation
 spec:
@@ -114,17 +114,15 @@ spec:
             - name: MODEL_DEPLOYMENT_NAME_RICH
               value: "gpt-5"
             - name: POSTGRES_AUTH_MODE
-              value: "password"
+              value: "entra"
             - name: POSTGRES_DATABASE
               value: "holiday_peak_crud"
             - name: POSTGRES_HOST
               value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
-            - name: POSTGRES_PORT
-              value: "5432"
             - name: POSTGRES_SSL
               value: "true"
             - name: POSTGRES_USER
-              value: "crud_workload"
+              value: "holidaypeakhub405-dev-crud-identity"
             - name: PROJECT_ENDPOINT
               value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
             - name: PROJECT_NAME
@@ -133,8 +131,6 @@ spec:
               value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
             - name: REDIS_PASSWORD_SECRET_NAME
               value: "redis-primary-key"
-            - name: REDIS_URL
-              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
           ports:
             - containerPort: 8000
           startupProbe:
@@ -166,32 +162,3 @@ spec:
             requests:
               cpu: 250m
               memory: 256Mi
----
-# Source: holiday-peak-service/templates/agc-routing.yaml
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: crm-profile-aggregation-crm-profile-aggregation-agc
-  namespace: holiday-peak
-  labels:
-    app: crm-profile-aggregation
-spec:
-  parentRefs:
-    - name: "holiday-peak-agc"
-      namespace: "holiday-peak"
-  hostnames:
-    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
-  rules:
-    - matches:
-        - path:
-            type: PathPrefix
-            value: "/crm-profile-aggregation"
-      filters:
-        - type: URLRewrite
-          urlRewrite:
-            path:
-              type: ReplacePrefixMatch
-              replacePrefixMatch: "/"
-      backendRefs:
-        - name: crm-profile-aggregation-crm-profile-aggregation
-          port: 80

--- a/.kubernetes/rendered/crm-profile-aggregation/all.yaml
+++ b/.kubernetes/rendered/crm-profile-aggregation/all.yaml
@@ -93,6 +93,8 @@ spec:
               value: "agent-memory"
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
+            - name: CRUD_SERVICE_URL
+              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: EVENT_HUB_NAMESPACE

--- a/.kubernetes/rendered/crm-segmentation-personalization/all.yaml
+++ b/.kubernetes/rendered/crm-segmentation-personalization/all.yaml
@@ -1,10 +1,10 @@
----
+﻿---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: crm-segmentation-personalization
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: crm-segmentation-personalization
   annotations:
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: crm-segmentation-personalization-crm-segmentation-personalizati
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: crm-segmentation-personalization
 spec:
@@ -33,7 +33,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: crm-segmentation-personalization-crm-segmentation-personalizati
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: crm-segmentation-personalization
 spec:
@@ -114,17 +114,15 @@ spec:
             - name: MODEL_DEPLOYMENT_NAME_RICH
               value: "gpt-5"
             - name: POSTGRES_AUTH_MODE
-              value: "password"
+              value: "entra"
             - name: POSTGRES_DATABASE
               value: "holiday_peak_crud"
             - name: POSTGRES_HOST
               value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
-            - name: POSTGRES_PORT
-              value: "5432"
             - name: POSTGRES_SSL
               value: "true"
             - name: POSTGRES_USER
-              value: "crud_workload"
+              value: "holidaypeakhub405-dev-crud-identity"
             - name: PROJECT_ENDPOINT
               value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
             - name: PROJECT_NAME
@@ -133,8 +131,6 @@ spec:
               value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
             - name: REDIS_PASSWORD_SECRET_NAME
               value: "redis-primary-key"
-            - name: REDIS_URL
-              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
           ports:
             - containerPort: 8000
           startupProbe:
@@ -166,32 +162,3 @@ spec:
             requests:
               cpu: 250m
               memory: 256Mi
----
-# Source: holiday-peak-service/templates/agc-routing.yaml
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: crm-segmentation-personalization-crm-segmentation-personalizati-agc
-  namespace: holiday-peak
-  labels:
-    app: crm-segmentation-personalization
-spec:
-  parentRefs:
-    - name: "holiday-peak-agc"
-      namespace: "holiday-peak"
-  hostnames:
-    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
-  rules:
-    - matches:
-        - path:
-            type: PathPrefix
-            value: "/crm-segmentation-personalization"
-      filters:
-        - type: URLRewrite
-          urlRewrite:
-            path:
-              type: ReplacePrefixMatch
-              replacePrefixMatch: "/"
-      backendRefs:
-        - name: crm-segmentation-personalization-crm-segmentation-personalizati
-          port: 80

--- a/.kubernetes/rendered/crm-segmentation-personalization/all.yaml
+++ b/.kubernetes/rendered/crm-segmentation-personalization/all.yaml
@@ -93,6 +93,8 @@ spec:
               value: "agent-memory"
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
+            - name: CRUD_SERVICE_URL
+              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: EVENT_HUB_NAMESPACE

--- a/.kubernetes/rendered/crm-support-assistance/all.yaml
+++ b/.kubernetes/rendered/crm-support-assistance/all.yaml
@@ -1,10 +1,10 @@
----
+﻿---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: crm-support-assistance
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: crm-support-assistance
   annotations:
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: crm-support-assistance-crm-support-assistance
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: crm-support-assistance
 spec:
@@ -33,7 +33,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: crm-support-assistance-crm-support-assistance
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: crm-support-assistance
 spec:
@@ -114,17 +114,15 @@ spec:
             - name: MODEL_DEPLOYMENT_NAME_RICH
               value: "gpt-5"
             - name: POSTGRES_AUTH_MODE
-              value: "password"
+              value: "entra"
             - name: POSTGRES_DATABASE
               value: "holiday_peak_crud"
             - name: POSTGRES_HOST
               value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
-            - name: POSTGRES_PORT
-              value: "5432"
             - name: POSTGRES_SSL
               value: "true"
             - name: POSTGRES_USER
-              value: "crud_workload"
+              value: "holidaypeakhub405-dev-crud-identity"
             - name: PROJECT_ENDPOINT
               value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
             - name: PROJECT_NAME
@@ -133,8 +131,6 @@ spec:
               value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
             - name: REDIS_PASSWORD_SECRET_NAME
               value: "redis-primary-key"
-            - name: REDIS_URL
-              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
           ports:
             - containerPort: 8000
           startupProbe:
@@ -166,32 +162,3 @@ spec:
             requests:
               cpu: 250m
               memory: 256Mi
----
-# Source: holiday-peak-service/templates/agc-routing.yaml
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: crm-support-assistance-crm-support-assistance-agc
-  namespace: holiday-peak
-  labels:
-    app: crm-support-assistance
-spec:
-  parentRefs:
-    - name: "holiday-peak-agc"
-      namespace: "holiday-peak"
-  hostnames:
-    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
-  rules:
-    - matches:
-        - path:
-            type: PathPrefix
-            value: "/crm-support-assistance"
-      filters:
-        - type: URLRewrite
-          urlRewrite:
-            path:
-              type: ReplacePrefixMatch
-              replacePrefixMatch: "/"
-      backendRefs:
-        - name: crm-support-assistance-crm-support-assistance
-          port: 80

--- a/.kubernetes/rendered/crm-support-assistance/all.yaml
+++ b/.kubernetes/rendered/crm-support-assistance/all.yaml
@@ -93,6 +93,8 @@ spec:
               value: "agent-memory"
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
+            - name: CRUD_SERVICE_URL
+              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: EVENT_HUB_NAMESPACE

--- a/.kubernetes/rendered/crud-service/all.yaml
+++ b/.kubernetes/rendered/crud-service/all.yaml
@@ -1,10 +1,10 @@
----
+﻿---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: crud-service
-  namespace: holiday-peak
+  namespace: holiday-peak-crud
   labels:
     app: crud-service
   annotations:
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: crud-service-crud-service
-  namespace: holiday-peak
+  namespace: holiday-peak-crud
   labels:
     app: crud-service
 spec:
@@ -33,7 +33,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: crud-service-crud-service
-  namespace: holiday-peak
+  namespace: holiday-peak-crud
   labels:
     app: crud-service
 spec:
@@ -115,8 +115,6 @@ spec:
               value: "holiday_peak_crud"
             - name: POSTGRES_HOST
               value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
-            - name: POSTGRES_PORT
-              value: "5432"
             - name: POSTGRES_SSL
               value: "true"
             - name: POSTGRES_USER
@@ -160,64 +158,3 @@ spec:
             requests:
               cpu: 250m
               memory: 256Mi
----
-# Source: holiday-peak-service/templates/agc-routing.yaml
-apiVersion: alb.networking.azure.io/v1
-kind: ApplicationLoadBalancer
-metadata:
-  name: holiday-peak-agc
-  namespace: holiday-peak
-  labels:
-    app: crud-service
-spec:
-  associations:
-    - "/subscriptions/150e82e8-25db-4f1a-8e04-a2f6a77d26c4/resourceGroups/holidaypeakhub405-dev-rg/providers/Microsoft.Network/virtualNetworks/holidaypeakhub405-dev-vnet/subnets/agc"
----
-# Source: holiday-peak-service/templates/agc-routing.yaml
-apiVersion: gateway.networking.k8s.io/v1
-kind: Gateway
-metadata:
-  name: holiday-peak-agc
-  namespace: holiday-peak
-  labels:
-    app: crud-service
-spec:
-  gatewayClassName: "azure-alb-external"
-  listeners:
-    - name: "http"
-      protocol: "HTTP"
-      port: 80
-      hostname: "e3g0avgfauc3e4cp.fz87.alb.azure.com"
-      allowedRoutes:
-        namespaces:
-          from: Same
----
-# Source: holiday-peak-service/templates/agc-routing.yaml
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: crud-service-crud-service-agc
-  namespace: holiday-peak
-  labels:
-    app: crud-service
-spec:
-  parentRefs:
-    - name: "holiday-peak-agc"
-      namespace: "holiday-peak"
-  hostnames:
-    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
-  rules:
-    - matches:
-        - path:
-            type: PathPrefix
-            value: "/health"
-      backendRefs:
-        - name: crud-service-crud-service
-          port: 80
-    - matches:
-        - path:
-            type: PathPrefix
-            value: "/api"
-      backendRefs:
-        - name: crud-service-crud-service
-          port: 80

--- a/.kubernetes/rendered/crud/kustomization.yaml
+++ b/.kubernetes/rendered/crud/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../crud-service/all.yaml

--- a/.kubernetes/rendered/ecommerce-cart-intelligence/all.yaml
+++ b/.kubernetes/rendered/ecommerce-cart-intelligence/all.yaml
@@ -1,10 +1,10 @@
----
+﻿---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: ecommerce-cart-intelligence
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: ecommerce-cart-intelligence
   annotations:
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ecommerce-cart-intelligence-ecommerce-cart-intelligence
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: ecommerce-cart-intelligence
 spec:
@@ -33,7 +33,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ecommerce-cart-intelligence-ecommerce-cart-intelligence
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: ecommerce-cart-intelligence
 spec:
@@ -114,17 +114,15 @@ spec:
             - name: MODEL_DEPLOYMENT_NAME_RICH
               value: "gpt-5"
             - name: POSTGRES_AUTH_MODE
-              value: "password"
+              value: "entra"
             - name: POSTGRES_DATABASE
               value: "holiday_peak_crud"
             - name: POSTGRES_HOST
               value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
-            - name: POSTGRES_PORT
-              value: "5432"
             - name: POSTGRES_SSL
               value: "true"
             - name: POSTGRES_USER
-              value: "crud_workload"
+              value: "holidaypeakhub405-dev-crud-identity"
             - name: PROJECT_ENDPOINT
               value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
             - name: PROJECT_NAME
@@ -133,8 +131,6 @@ spec:
               value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
             - name: REDIS_PASSWORD_SECRET_NAME
               value: "redis-primary-key"
-            - name: REDIS_URL
-              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
           ports:
             - containerPort: 8000
           startupProbe:
@@ -166,32 +162,3 @@ spec:
             requests:
               cpu: 250m
               memory: 256Mi
----
-# Source: holiday-peak-service/templates/agc-routing.yaml
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: ecommerce-cart-intelligence-ecommerce-cart-intelligence-agc
-  namespace: holiday-peak
-  labels:
-    app: ecommerce-cart-intelligence
-spec:
-  parentRefs:
-    - name: "holiday-peak-agc"
-      namespace: "holiday-peak"
-  hostnames:
-    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
-  rules:
-    - matches:
-        - path:
-            type: PathPrefix
-            value: "/ecommerce-cart-intelligence"
-      filters:
-        - type: URLRewrite
-          urlRewrite:
-            path:
-              type: ReplacePrefixMatch
-              replacePrefixMatch: "/"
-      backendRefs:
-        - name: ecommerce-cart-intelligence-ecommerce-cart-intelligence
-          port: 80

--- a/.kubernetes/rendered/ecommerce-cart-intelligence/all.yaml
+++ b/.kubernetes/rendered/ecommerce-cart-intelligence/all.yaml
@@ -93,6 +93,8 @@ spec:
               value: "agent-memory"
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
+            - name: CRUD_SERVICE_URL
+              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: EVENT_HUB_NAMESPACE

--- a/.kubernetes/rendered/ecommerce-catalog-search/all.yaml
+++ b/.kubernetes/rendered/ecommerce-catalog-search/all.yaml
@@ -1,10 +1,10 @@
----
+﻿---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: ecommerce-catalog-search
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: ecommerce-catalog-search
   annotations:
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ecommerce-catalog-search-ecommerce-catalog-search
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: ecommerce-catalog-search
 spec:
@@ -33,7 +33,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ecommerce-catalog-search-ecommerce-catalog-search
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: ecommerce-catalog-search
 spec:
@@ -114,17 +114,15 @@ spec:
             - name: MODEL_DEPLOYMENT_NAME_RICH
               value: "gpt-5"
             - name: POSTGRES_AUTH_MODE
-              value: "password"
+              value: "entra"
             - name: POSTGRES_DATABASE
               value: "holiday_peak_crud"
             - name: POSTGRES_HOST
               value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
-            - name: POSTGRES_PORT
-              value: "5432"
             - name: POSTGRES_SSL
               value: "true"
             - name: POSTGRES_USER
-              value: "crud_workload"
+              value: "holidaypeakhub405-dev-crud-identity"
             - name: PROJECT_ENDPOINT
               value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
             - name: PROJECT_NAME
@@ -133,8 +131,6 @@ spec:
               value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
             - name: REDIS_PASSWORD_SECRET_NAME
               value: "redis-primary-key"
-            - name: REDIS_URL
-              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
             - name: SEARCH_ENRICHMENT_EVENT_HUB_CONSUMER_GROUP
               value: "search-enrichment-consumer"
             - name: SEARCH_ENRICHMENT_EVENT_HUB_NAME
@@ -170,32 +166,3 @@ spec:
             requests:
               cpu: 250m
               memory: 256Mi
----
-# Source: holiday-peak-service/templates/agc-routing.yaml
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: ecommerce-catalog-search-ecommerce-catalog-search-agc
-  namespace: holiday-peak
-  labels:
-    app: ecommerce-catalog-search
-spec:
-  parentRefs:
-    - name: "holiday-peak-agc"
-      namespace: "holiday-peak"
-  hostnames:
-    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
-  rules:
-    - matches:
-        - path:
-            type: PathPrefix
-            value: "/ecommerce-catalog-search"
-      filters:
-        - type: URLRewrite
-          urlRewrite:
-            path:
-              type: ReplacePrefixMatch
-              replacePrefixMatch: "/"
-      backendRefs:
-        - name: ecommerce-catalog-search-ecommerce-catalog-search
-          port: 80

--- a/.kubernetes/rendered/ecommerce-catalog-search/all.yaml
+++ b/.kubernetes/rendered/ecommerce-catalog-search/all.yaml
@@ -93,6 +93,8 @@ spec:
               value: "agent-memory"
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
+            - name: CRUD_SERVICE_URL
+              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: EVENT_HUB_NAMESPACE

--- a/.kubernetes/rendered/ecommerce-checkout-support/all.yaml
+++ b/.kubernetes/rendered/ecommerce-checkout-support/all.yaml
@@ -93,6 +93,8 @@ spec:
               value: "agent-memory"
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
+            - name: CRUD_SERVICE_URL
+              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: EVENT_HUB_NAMESPACE

--- a/.kubernetes/rendered/ecommerce-checkout-support/all.yaml
+++ b/.kubernetes/rendered/ecommerce-checkout-support/all.yaml
@@ -1,10 +1,10 @@
----
+﻿---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: ecommerce-checkout-support
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: ecommerce-checkout-support
   annotations:
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ecommerce-checkout-support-ecommerce-checkout-support
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: ecommerce-checkout-support
 spec:
@@ -33,7 +33,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ecommerce-checkout-support-ecommerce-checkout-support
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: ecommerce-checkout-support
 spec:
@@ -114,17 +114,15 @@ spec:
             - name: MODEL_DEPLOYMENT_NAME_RICH
               value: "gpt-5"
             - name: POSTGRES_AUTH_MODE
-              value: "password"
+              value: "entra"
             - name: POSTGRES_DATABASE
               value: "holiday_peak_crud"
             - name: POSTGRES_HOST
               value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
-            - name: POSTGRES_PORT
-              value: "5432"
             - name: POSTGRES_SSL
               value: "true"
             - name: POSTGRES_USER
-              value: "crud_workload"
+              value: "holidaypeakhub405-dev-crud-identity"
             - name: PROJECT_ENDPOINT
               value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
             - name: PROJECT_NAME
@@ -133,8 +131,6 @@ spec:
               value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
             - name: REDIS_PASSWORD_SECRET_NAME
               value: "redis-primary-key"
-            - name: REDIS_URL
-              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
           ports:
             - containerPort: 8000
           startupProbe:
@@ -166,32 +162,3 @@ spec:
             requests:
               cpu: 250m
               memory: 256Mi
----
-# Source: holiday-peak-service/templates/agc-routing.yaml
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: ecommerce-checkout-support-ecommerce-checkout-support-agc
-  namespace: holiday-peak
-  labels:
-    app: ecommerce-checkout-support
-spec:
-  parentRefs:
-    - name: "holiday-peak-agc"
-      namespace: "holiday-peak"
-  hostnames:
-    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
-  rules:
-    - matches:
-        - path:
-            type: PathPrefix
-            value: "/ecommerce-checkout-support"
-      filters:
-        - type: URLRewrite
-          urlRewrite:
-            path:
-              type: ReplacePrefixMatch
-              replacePrefixMatch: "/"
-      backendRefs:
-        - name: ecommerce-checkout-support-ecommerce-checkout-support
-          port: 80

--- a/.kubernetes/rendered/ecommerce-order-status/all.yaml
+++ b/.kubernetes/rendered/ecommerce-order-status/all.yaml
@@ -1,10 +1,10 @@
----
+﻿---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: ecommerce-order-status
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: ecommerce-order-status
   annotations:
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ecommerce-order-status-ecommerce-order-status
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: ecommerce-order-status
 spec:
@@ -33,7 +33,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ecommerce-order-status-ecommerce-order-status
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: ecommerce-order-status
 spec:
@@ -114,17 +114,15 @@ spec:
             - name: MODEL_DEPLOYMENT_NAME_RICH
               value: "gpt-5"
             - name: POSTGRES_AUTH_MODE
-              value: "password"
+              value: "entra"
             - name: POSTGRES_DATABASE
               value: "holiday_peak_crud"
             - name: POSTGRES_HOST
               value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
-            - name: POSTGRES_PORT
-              value: "5432"
             - name: POSTGRES_SSL
               value: "true"
             - name: POSTGRES_USER
-              value: "crud_workload"
+              value: "holidaypeakhub405-dev-crud-identity"
             - name: PROJECT_ENDPOINT
               value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
             - name: PROJECT_NAME
@@ -133,8 +131,6 @@ spec:
               value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
             - name: REDIS_PASSWORD_SECRET_NAME
               value: "redis-primary-key"
-            - name: REDIS_URL
-              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
           ports:
             - containerPort: 8000
           startupProbe:
@@ -166,32 +162,3 @@ spec:
             requests:
               cpu: 250m
               memory: 256Mi
----
-# Source: holiday-peak-service/templates/agc-routing.yaml
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: ecommerce-order-status-ecommerce-order-status-agc
-  namespace: holiday-peak
-  labels:
-    app: ecommerce-order-status
-spec:
-  parentRefs:
-    - name: "holiday-peak-agc"
-      namespace: "holiday-peak"
-  hostnames:
-    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
-  rules:
-    - matches:
-        - path:
-            type: PathPrefix
-            value: "/ecommerce-order-status"
-      filters:
-        - type: URLRewrite
-          urlRewrite:
-            path:
-              type: ReplacePrefixMatch
-              replacePrefixMatch: "/"
-      backendRefs:
-        - name: ecommerce-order-status-ecommerce-order-status
-          port: 80

--- a/.kubernetes/rendered/ecommerce-order-status/all.yaml
+++ b/.kubernetes/rendered/ecommerce-order-status/all.yaml
@@ -93,6 +93,8 @@ spec:
               value: "agent-memory"
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
+            - name: CRUD_SERVICE_URL
+              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: EVENT_HUB_NAMESPACE

--- a/.kubernetes/rendered/ecommerce-product-detail-enrichment/all.yaml
+++ b/.kubernetes/rendered/ecommerce-product-detail-enrichment/all.yaml
@@ -1,10 +1,10 @@
----
+﻿---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: ecommerce-product-detail-enrichment
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: ecommerce-product-detail-enrichment
   annotations:
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ecommerce-product-detail-enrichment-ecommerce-product-detail-en
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: ecommerce-product-detail-enrichment
 spec:
@@ -33,7 +33,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ecommerce-product-detail-enrichment-ecommerce-product-detail-en
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: ecommerce-product-detail-enrichment
 spec:
@@ -114,17 +114,15 @@ spec:
             - name: MODEL_DEPLOYMENT_NAME_RICH
               value: "gpt-5"
             - name: POSTGRES_AUTH_MODE
-              value: "password"
+              value: "entra"
             - name: POSTGRES_DATABASE
               value: "holiday_peak_crud"
             - name: POSTGRES_HOST
               value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
-            - name: POSTGRES_PORT
-              value: "5432"
             - name: POSTGRES_SSL
               value: "true"
             - name: POSTGRES_USER
-              value: "crud_workload"
+              value: "holidaypeakhub405-dev-crud-identity"
             - name: PROJECT_ENDPOINT
               value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
             - name: PROJECT_NAME
@@ -133,8 +131,6 @@ spec:
               value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
             - name: REDIS_PASSWORD_SECRET_NAME
               value: "redis-primary-key"
-            - name: REDIS_URL
-              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
           ports:
             - containerPort: 8000
           startupProbe:
@@ -166,32 +162,3 @@ spec:
             requests:
               cpu: 250m
               memory: 256Mi
----
-# Source: holiday-peak-service/templates/agc-routing.yaml
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: ecommerce-product-detail-enrichment-ecommerce-product-detail-en-agc
-  namespace: holiday-peak
-  labels:
-    app: ecommerce-product-detail-enrichment
-spec:
-  parentRefs:
-    - name: "holiday-peak-agc"
-      namespace: "holiday-peak"
-  hostnames:
-    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
-  rules:
-    - matches:
-        - path:
-            type: PathPrefix
-            value: "/ecommerce-product-detail-enrichment"
-      filters:
-        - type: URLRewrite
-          urlRewrite:
-            path:
-              type: ReplacePrefixMatch
-              replacePrefixMatch: "/"
-      backendRefs:
-        - name: ecommerce-product-detail-enrichment-ecommerce-product-detail-en
-          port: 80

--- a/.kubernetes/rendered/ecommerce-product-detail-enrichment/all.yaml
+++ b/.kubernetes/rendered/ecommerce-product-detail-enrichment/all.yaml
@@ -93,6 +93,8 @@ spec:
               value: "agent-memory"
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
+            - name: CRUD_SERVICE_URL
+              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: EVENT_HUB_NAMESPACE

--- a/.kubernetes/rendered/inventory-alerts-triggers/all.yaml
+++ b/.kubernetes/rendered/inventory-alerts-triggers/all.yaml
@@ -1,10 +1,10 @@
----
+﻿---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: inventory-alerts-triggers
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: inventory-alerts-triggers
   annotations:
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: inventory-alerts-triggers-inventory-alerts-triggers
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: inventory-alerts-triggers
 spec:
@@ -33,7 +33,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: inventory-alerts-triggers-inventory-alerts-triggers
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: inventory-alerts-triggers
 spec:
@@ -114,17 +114,15 @@ spec:
             - name: MODEL_DEPLOYMENT_NAME_RICH
               value: "gpt-5"
             - name: POSTGRES_AUTH_MODE
-              value: "password"
+              value: "entra"
             - name: POSTGRES_DATABASE
               value: "holiday_peak_crud"
             - name: POSTGRES_HOST
               value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
-            - name: POSTGRES_PORT
-              value: "5432"
             - name: POSTGRES_SSL
               value: "true"
             - name: POSTGRES_USER
-              value: "crud_workload"
+              value: "holidaypeakhub405-dev-crud-identity"
             - name: PROJECT_ENDPOINT
               value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
             - name: PROJECT_NAME
@@ -133,8 +131,6 @@ spec:
               value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
             - name: REDIS_PASSWORD_SECRET_NAME
               value: "redis-primary-key"
-            - name: REDIS_URL
-              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
           ports:
             - containerPort: 8000
           startupProbe:
@@ -166,32 +162,3 @@ spec:
             requests:
               cpu: 250m
               memory: 256Mi
----
-# Source: holiday-peak-service/templates/agc-routing.yaml
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: inventory-alerts-triggers-inventory-alerts-triggers-agc
-  namespace: holiday-peak
-  labels:
-    app: inventory-alerts-triggers
-spec:
-  parentRefs:
-    - name: "holiday-peak-agc"
-      namespace: "holiday-peak"
-  hostnames:
-    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
-  rules:
-    - matches:
-        - path:
-            type: PathPrefix
-            value: "/inventory-alerts-triggers"
-      filters:
-        - type: URLRewrite
-          urlRewrite:
-            path:
-              type: ReplacePrefixMatch
-              replacePrefixMatch: "/"
-      backendRefs:
-        - name: inventory-alerts-triggers-inventory-alerts-triggers
-          port: 80

--- a/.kubernetes/rendered/inventory-alerts-triggers/all.yaml
+++ b/.kubernetes/rendered/inventory-alerts-triggers/all.yaml
@@ -93,6 +93,8 @@ spec:
               value: "agent-memory"
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
+            - name: CRUD_SERVICE_URL
+              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: EVENT_HUB_NAMESPACE

--- a/.kubernetes/rendered/inventory-health-check/all.yaml
+++ b/.kubernetes/rendered/inventory-health-check/all.yaml
@@ -1,10 +1,10 @@
----
+﻿---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: inventory-health-check
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: inventory-health-check
   annotations:
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: inventory-health-check-inventory-health-check
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: inventory-health-check
 spec:
@@ -33,7 +33,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: inventory-health-check-inventory-health-check
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: inventory-health-check
 spec:
@@ -114,17 +114,15 @@ spec:
             - name: MODEL_DEPLOYMENT_NAME_RICH
               value: "gpt-5"
             - name: POSTGRES_AUTH_MODE
-              value: "password"
+              value: "entra"
             - name: POSTGRES_DATABASE
               value: "holiday_peak_crud"
             - name: POSTGRES_HOST
               value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
-            - name: POSTGRES_PORT
-              value: "5432"
             - name: POSTGRES_SSL
               value: "true"
             - name: POSTGRES_USER
-              value: "crud_workload"
+              value: "holidaypeakhub405-dev-crud-identity"
             - name: PROJECT_ENDPOINT
               value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
             - name: PROJECT_NAME
@@ -133,8 +131,6 @@ spec:
               value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
             - name: REDIS_PASSWORD_SECRET_NAME
               value: "redis-primary-key"
-            - name: REDIS_URL
-              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
           ports:
             - containerPort: 8000
           startupProbe:
@@ -166,32 +162,3 @@ spec:
             requests:
               cpu: 250m
               memory: 256Mi
----
-# Source: holiday-peak-service/templates/agc-routing.yaml
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: inventory-health-check-inventory-health-check-agc
-  namespace: holiday-peak
-  labels:
-    app: inventory-health-check
-spec:
-  parentRefs:
-    - name: "holiday-peak-agc"
-      namespace: "holiday-peak"
-  hostnames:
-    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
-  rules:
-    - matches:
-        - path:
-            type: PathPrefix
-            value: "/inventory-health-check"
-      filters:
-        - type: URLRewrite
-          urlRewrite:
-            path:
-              type: ReplacePrefixMatch
-              replacePrefixMatch: "/"
-      backendRefs:
-        - name: inventory-health-check-inventory-health-check
-          port: 80

--- a/.kubernetes/rendered/inventory-health-check/all.yaml
+++ b/.kubernetes/rendered/inventory-health-check/all.yaml
@@ -93,6 +93,8 @@ spec:
               value: "agent-memory"
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
+            - name: CRUD_SERVICE_URL
+              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: EVENT_HUB_NAMESPACE

--- a/.kubernetes/rendered/inventory-jit-replenishment/all.yaml
+++ b/.kubernetes/rendered/inventory-jit-replenishment/all.yaml
@@ -1,10 +1,10 @@
----
+﻿---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: inventory-jit-replenishment
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: inventory-jit-replenishment
   annotations:
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: inventory-jit-replenishment-inventory-jit-replenishment
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: inventory-jit-replenishment
 spec:
@@ -33,7 +33,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: inventory-jit-replenishment-inventory-jit-replenishment
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: inventory-jit-replenishment
 spec:
@@ -114,17 +114,15 @@ spec:
             - name: MODEL_DEPLOYMENT_NAME_RICH
               value: "gpt-5"
             - name: POSTGRES_AUTH_MODE
-              value: "password"
+              value: "entra"
             - name: POSTGRES_DATABASE
               value: "holiday_peak_crud"
             - name: POSTGRES_HOST
               value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
-            - name: POSTGRES_PORT
-              value: "5432"
             - name: POSTGRES_SSL
               value: "true"
             - name: POSTGRES_USER
-              value: "crud_workload"
+              value: "holidaypeakhub405-dev-crud-identity"
             - name: PROJECT_ENDPOINT
               value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
             - name: PROJECT_NAME
@@ -133,8 +131,6 @@ spec:
               value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
             - name: REDIS_PASSWORD_SECRET_NAME
               value: "redis-primary-key"
-            - name: REDIS_URL
-              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
           ports:
             - containerPort: 8000
           startupProbe:
@@ -166,32 +162,3 @@ spec:
             requests:
               cpu: 250m
               memory: 256Mi
----
-# Source: holiday-peak-service/templates/agc-routing.yaml
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: inventory-jit-replenishment-inventory-jit-replenishment-agc
-  namespace: holiday-peak
-  labels:
-    app: inventory-jit-replenishment
-spec:
-  parentRefs:
-    - name: "holiday-peak-agc"
-      namespace: "holiday-peak"
-  hostnames:
-    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
-  rules:
-    - matches:
-        - path:
-            type: PathPrefix
-            value: "/inventory-jit-replenishment"
-      filters:
-        - type: URLRewrite
-          urlRewrite:
-            path:
-              type: ReplacePrefixMatch
-              replacePrefixMatch: "/"
-      backendRefs:
-        - name: inventory-jit-replenishment-inventory-jit-replenishment
-          port: 80

--- a/.kubernetes/rendered/inventory-jit-replenishment/all.yaml
+++ b/.kubernetes/rendered/inventory-jit-replenishment/all.yaml
@@ -93,6 +93,8 @@ spec:
               value: "agent-memory"
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
+            - name: CRUD_SERVICE_URL
+              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: EVENT_HUB_NAMESPACE

--- a/.kubernetes/rendered/inventory-reservation-validation/all.yaml
+++ b/.kubernetes/rendered/inventory-reservation-validation/all.yaml
@@ -93,6 +93,8 @@ spec:
               value: "agent-memory"
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
+            - name: CRUD_SERVICE_URL
+              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: EVENT_HUB_NAMESPACE

--- a/.kubernetes/rendered/inventory-reservation-validation/all.yaml
+++ b/.kubernetes/rendered/inventory-reservation-validation/all.yaml
@@ -1,10 +1,10 @@
----
+﻿---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: inventory-reservation-validation
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: inventory-reservation-validation
   annotations:
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: inventory-reservation-validation-inventory-reservation-validati
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: inventory-reservation-validation
 spec:
@@ -33,7 +33,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: inventory-reservation-validation-inventory-reservation-validati
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: inventory-reservation-validation
 spec:
@@ -114,17 +114,15 @@ spec:
             - name: MODEL_DEPLOYMENT_NAME_RICH
               value: "gpt-5"
             - name: POSTGRES_AUTH_MODE
-              value: "password"
+              value: "entra"
             - name: POSTGRES_DATABASE
               value: "holiday_peak_crud"
             - name: POSTGRES_HOST
               value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
-            - name: POSTGRES_PORT
-              value: "5432"
             - name: POSTGRES_SSL
               value: "true"
             - name: POSTGRES_USER
-              value: "crud_workload"
+              value: "holidaypeakhub405-dev-crud-identity"
             - name: PROJECT_ENDPOINT
               value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
             - name: PROJECT_NAME
@@ -133,8 +131,6 @@ spec:
               value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
             - name: REDIS_PASSWORD_SECRET_NAME
               value: "redis-primary-key"
-            - name: REDIS_URL
-              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
           ports:
             - containerPort: 8000
           startupProbe:
@@ -166,32 +162,3 @@ spec:
             requests:
               cpu: 250m
               memory: 256Mi
----
-# Source: holiday-peak-service/templates/agc-routing.yaml
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: inventory-reservation-validation-inventory-reservation-validati-agc
-  namespace: holiday-peak
-  labels:
-    app: inventory-reservation-validation
-spec:
-  parentRefs:
-    - name: "holiday-peak-agc"
-      namespace: "holiday-peak"
-  hostnames:
-    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
-  rules:
-    - matches:
-        - path:
-            type: PathPrefix
-            value: "/inventory-reservation-validation"
-      filters:
-        - type: URLRewrite
-          urlRewrite:
-            path:
-              type: ReplacePrefixMatch
-              replacePrefixMatch: "/"
-      backendRefs:
-        - name: inventory-reservation-validation-inventory-reservation-validati
-          port: 80

--- a/.kubernetes/rendered/logistics-carrier-selection/all.yaml
+++ b/.kubernetes/rendered/logistics-carrier-selection/all.yaml
@@ -1,10 +1,10 @@
----
+﻿---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: logistics-carrier-selection
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: logistics-carrier-selection
   annotations:
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: logistics-carrier-selection-logistics-carrier-selection
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: logistics-carrier-selection
 spec:
@@ -33,7 +33,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: logistics-carrier-selection-logistics-carrier-selection
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: logistics-carrier-selection
 spec:
@@ -114,17 +114,15 @@ spec:
             - name: MODEL_DEPLOYMENT_NAME_RICH
               value: "gpt-5"
             - name: POSTGRES_AUTH_MODE
-              value: "password"
+              value: "entra"
             - name: POSTGRES_DATABASE
               value: "holiday_peak_crud"
             - name: POSTGRES_HOST
               value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
-            - name: POSTGRES_PORT
-              value: "5432"
             - name: POSTGRES_SSL
               value: "true"
             - name: POSTGRES_USER
-              value: "crud_workload"
+              value: "holidaypeakhub405-dev-crud-identity"
             - name: PROJECT_ENDPOINT
               value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
             - name: PROJECT_NAME
@@ -133,8 +131,6 @@ spec:
               value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
             - name: REDIS_PASSWORD_SECRET_NAME
               value: "redis-primary-key"
-            - name: REDIS_URL
-              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
           ports:
             - containerPort: 8000
           startupProbe:
@@ -166,32 +162,3 @@ spec:
             requests:
               cpu: 250m
               memory: 256Mi
----
-# Source: holiday-peak-service/templates/agc-routing.yaml
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: logistics-carrier-selection-logistics-carrier-selection-agc
-  namespace: holiday-peak
-  labels:
-    app: logistics-carrier-selection
-spec:
-  parentRefs:
-    - name: "holiday-peak-agc"
-      namespace: "holiday-peak"
-  hostnames:
-    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
-  rules:
-    - matches:
-        - path:
-            type: PathPrefix
-            value: "/logistics-carrier-selection"
-      filters:
-        - type: URLRewrite
-          urlRewrite:
-            path:
-              type: ReplacePrefixMatch
-              replacePrefixMatch: "/"
-      backendRefs:
-        - name: logistics-carrier-selection-logistics-carrier-selection
-          port: 80

--- a/.kubernetes/rendered/logistics-carrier-selection/all.yaml
+++ b/.kubernetes/rendered/logistics-carrier-selection/all.yaml
@@ -93,6 +93,8 @@ spec:
               value: "agent-memory"
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
+            - name: CRUD_SERVICE_URL
+              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: EVENT_HUB_NAMESPACE

--- a/.kubernetes/rendered/logistics-eta-computation/all.yaml
+++ b/.kubernetes/rendered/logistics-eta-computation/all.yaml
@@ -93,6 +93,8 @@ spec:
               value: "agent-memory"
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
+            - name: CRUD_SERVICE_URL
+              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: EVENT_HUB_NAMESPACE

--- a/.kubernetes/rendered/logistics-eta-computation/all.yaml
+++ b/.kubernetes/rendered/logistics-eta-computation/all.yaml
@@ -1,10 +1,10 @@
----
+﻿---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: logistics-eta-computation
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: logistics-eta-computation
   annotations:
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: logistics-eta-computation-logistics-eta-computation
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: logistics-eta-computation
 spec:
@@ -33,7 +33,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: logistics-eta-computation-logistics-eta-computation
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: logistics-eta-computation
 spec:
@@ -114,17 +114,15 @@ spec:
             - name: MODEL_DEPLOYMENT_NAME_RICH
               value: "gpt-5"
             - name: POSTGRES_AUTH_MODE
-              value: "password"
+              value: "entra"
             - name: POSTGRES_DATABASE
               value: "holiday_peak_crud"
             - name: POSTGRES_HOST
               value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
-            - name: POSTGRES_PORT
-              value: "5432"
             - name: POSTGRES_SSL
               value: "true"
             - name: POSTGRES_USER
-              value: "crud_workload"
+              value: "holidaypeakhub405-dev-crud-identity"
             - name: PROJECT_ENDPOINT
               value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
             - name: PROJECT_NAME
@@ -133,8 +131,6 @@ spec:
               value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
             - name: REDIS_PASSWORD_SECRET_NAME
               value: "redis-primary-key"
-            - name: REDIS_URL
-              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
           ports:
             - containerPort: 8000
           startupProbe:
@@ -166,32 +162,3 @@ spec:
             requests:
               cpu: 250m
               memory: 256Mi
----
-# Source: holiday-peak-service/templates/agc-routing.yaml
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: logistics-eta-computation-logistics-eta-computation-agc
-  namespace: holiday-peak
-  labels:
-    app: logistics-eta-computation
-spec:
-  parentRefs:
-    - name: "holiday-peak-agc"
-      namespace: "holiday-peak"
-  hostnames:
-    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
-  rules:
-    - matches:
-        - path:
-            type: PathPrefix
-            value: "/logistics-eta-computation"
-      filters:
-        - type: URLRewrite
-          urlRewrite:
-            path:
-              type: ReplacePrefixMatch
-              replacePrefixMatch: "/"
-      backendRefs:
-        - name: logistics-eta-computation-logistics-eta-computation
-          port: 80

--- a/.kubernetes/rendered/logistics-returns-support/all.yaml
+++ b/.kubernetes/rendered/logistics-returns-support/all.yaml
@@ -1,10 +1,10 @@
----
+﻿---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: logistics-returns-support
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: logistics-returns-support
   annotations:
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: logistics-returns-support-logistics-returns-support
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: logistics-returns-support
 spec:
@@ -33,7 +33,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: logistics-returns-support-logistics-returns-support
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: logistics-returns-support
 spec:
@@ -114,17 +114,15 @@ spec:
             - name: MODEL_DEPLOYMENT_NAME_RICH
               value: "gpt-5"
             - name: POSTGRES_AUTH_MODE
-              value: "password"
+              value: "entra"
             - name: POSTGRES_DATABASE
               value: "holiday_peak_crud"
             - name: POSTGRES_HOST
               value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
-            - name: POSTGRES_PORT
-              value: "5432"
             - name: POSTGRES_SSL
               value: "true"
             - name: POSTGRES_USER
-              value: "crud_workload"
+              value: "holidaypeakhub405-dev-crud-identity"
             - name: PROJECT_ENDPOINT
               value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
             - name: PROJECT_NAME
@@ -133,8 +131,6 @@ spec:
               value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
             - name: REDIS_PASSWORD_SECRET_NAME
               value: "redis-primary-key"
-            - name: REDIS_URL
-              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
           ports:
             - containerPort: 8000
           startupProbe:
@@ -166,32 +162,3 @@ spec:
             requests:
               cpu: 250m
               memory: 256Mi
----
-# Source: holiday-peak-service/templates/agc-routing.yaml
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: logistics-returns-support-logistics-returns-support-agc
-  namespace: holiday-peak
-  labels:
-    app: logistics-returns-support
-spec:
-  parentRefs:
-    - name: "holiday-peak-agc"
-      namespace: "holiday-peak"
-  hostnames:
-    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
-  rules:
-    - matches:
-        - path:
-            type: PathPrefix
-            value: "/logistics-returns-support"
-      filters:
-        - type: URLRewrite
-          urlRewrite:
-            path:
-              type: ReplacePrefixMatch
-              replacePrefixMatch: "/"
-      backendRefs:
-        - name: logistics-returns-support-logistics-returns-support
-          port: 80

--- a/.kubernetes/rendered/logistics-returns-support/all.yaml
+++ b/.kubernetes/rendered/logistics-returns-support/all.yaml
@@ -93,6 +93,8 @@ spec:
               value: "agent-memory"
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
+            - name: CRUD_SERVICE_URL
+              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: EVENT_HUB_NAMESPACE

--- a/.kubernetes/rendered/logistics-route-issue-detection/all.yaml
+++ b/.kubernetes/rendered/logistics-route-issue-detection/all.yaml
@@ -1,10 +1,10 @@
----
+﻿---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: logistics-route-issue-detection
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: logistics-route-issue-detection
   annotations:
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: logistics-route-issue-detection-logistics-route-issue-detection
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: logistics-route-issue-detection
 spec:
@@ -33,7 +33,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: logistics-route-issue-detection-logistics-route-issue-detection
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: logistics-route-issue-detection
 spec:
@@ -114,17 +114,15 @@ spec:
             - name: MODEL_DEPLOYMENT_NAME_RICH
               value: "gpt-5"
             - name: POSTGRES_AUTH_MODE
-              value: "password"
+              value: "entra"
             - name: POSTGRES_DATABASE
               value: "holiday_peak_crud"
             - name: POSTGRES_HOST
               value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
-            - name: POSTGRES_PORT
-              value: "5432"
             - name: POSTGRES_SSL
               value: "true"
             - name: POSTGRES_USER
-              value: "crud_workload"
+              value: "holidaypeakhub405-dev-crud-identity"
             - name: PROJECT_ENDPOINT
               value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
             - name: PROJECT_NAME
@@ -133,8 +131,6 @@ spec:
               value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
             - name: REDIS_PASSWORD_SECRET_NAME
               value: "redis-primary-key"
-            - name: REDIS_URL
-              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
           ports:
             - containerPort: 8000
           startupProbe:
@@ -166,32 +162,3 @@ spec:
             requests:
               cpu: 250m
               memory: 256Mi
----
-# Source: holiday-peak-service/templates/agc-routing.yaml
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: logistics-route-issue-detection-logistics-route-issue-detection-agc
-  namespace: holiday-peak
-  labels:
-    app: logistics-route-issue-detection
-spec:
-  parentRefs:
-    - name: "holiday-peak-agc"
-      namespace: "holiday-peak"
-  hostnames:
-    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
-  rules:
-    - matches:
-        - path:
-            type: PathPrefix
-            value: "/logistics-route-issue-detection"
-      filters:
-        - type: URLRewrite
-          urlRewrite:
-            path:
-              type: ReplacePrefixMatch
-              replacePrefixMatch: "/"
-      backendRefs:
-        - name: logistics-route-issue-detection-logistics-route-issue-detection
-          port: 80

--- a/.kubernetes/rendered/logistics-route-issue-detection/all.yaml
+++ b/.kubernetes/rendered/logistics-route-issue-detection/all.yaml
@@ -93,6 +93,8 @@ spec:
               value: "agent-memory"
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
+            - name: CRUD_SERVICE_URL
+              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: EVENT_HUB_NAMESPACE

--- a/.kubernetes/rendered/product-management-acp-transformation/all.yaml
+++ b/.kubernetes/rendered/product-management-acp-transformation/all.yaml
@@ -1,10 +1,10 @@
----
+﻿---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: product-management-acp-transformation
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: product-management-acp-transformation
   annotations:
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: product-management-acp-transformation-product-management-acp-tr
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: product-management-acp-transformation
 spec:
@@ -33,7 +33,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: product-management-acp-transformation-product-management-acp-tr
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: product-management-acp-transformation
 spec:
@@ -114,17 +114,15 @@ spec:
             - name: MODEL_DEPLOYMENT_NAME_RICH
               value: "gpt-5"
             - name: POSTGRES_AUTH_MODE
-              value: "password"
+              value: "entra"
             - name: POSTGRES_DATABASE
               value: "holiday_peak_crud"
             - name: POSTGRES_HOST
               value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
-            - name: POSTGRES_PORT
-              value: "5432"
             - name: POSTGRES_SSL
               value: "true"
             - name: POSTGRES_USER
-              value: "crud_workload"
+              value: "holidaypeakhub405-dev-crud-identity"
             - name: PROJECT_ENDPOINT
               value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
             - name: PROJECT_NAME
@@ -133,8 +131,6 @@ spec:
               value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
             - name: REDIS_PASSWORD_SECRET_NAME
               value: "redis-primary-key"
-            - name: REDIS_URL
-              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
           ports:
             - containerPort: 8000
           startupProbe:
@@ -166,32 +162,3 @@ spec:
             requests:
               cpu: 250m
               memory: 256Mi
----
-# Source: holiday-peak-service/templates/agc-routing.yaml
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: product-management-acp-transformation-product-management-acp-tr-agc
-  namespace: holiday-peak
-  labels:
-    app: product-management-acp-transformation
-spec:
-  parentRefs:
-    - name: "holiday-peak-agc"
-      namespace: "holiday-peak"
-  hostnames:
-    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
-  rules:
-    - matches:
-        - path:
-            type: PathPrefix
-            value: "/product-management-acp-transformation"
-      filters:
-        - type: URLRewrite
-          urlRewrite:
-            path:
-              type: ReplacePrefixMatch
-              replacePrefixMatch: "/"
-      backendRefs:
-        - name: product-management-acp-transformation-product-management-acp-tr
-          port: 80

--- a/.kubernetes/rendered/product-management-acp-transformation/all.yaml
+++ b/.kubernetes/rendered/product-management-acp-transformation/all.yaml
@@ -93,6 +93,8 @@ spec:
               value: "agent-memory"
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
+            - name: CRUD_SERVICE_URL
+              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: EVENT_HUB_NAMESPACE

--- a/.kubernetes/rendered/product-management-assortment-optimization/all.yaml
+++ b/.kubernetes/rendered/product-management-assortment-optimization/all.yaml
@@ -93,6 +93,8 @@ spec:
               value: "agent-memory"
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
+            - name: CRUD_SERVICE_URL
+              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: EVENT_HUB_NAMESPACE

--- a/.kubernetes/rendered/product-management-assortment-optimization/all.yaml
+++ b/.kubernetes/rendered/product-management-assortment-optimization/all.yaml
@@ -1,10 +1,10 @@
----
+﻿---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: product-management-assortment-optimization
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: product-management-assortment-optimization
   annotations:
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: product-management-assortment-optimization-product-management-a
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: product-management-assortment-optimization
 spec:
@@ -33,7 +33,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: product-management-assortment-optimization-product-management-a
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: product-management-assortment-optimization
 spec:
@@ -114,17 +114,15 @@ spec:
             - name: MODEL_DEPLOYMENT_NAME_RICH
               value: "gpt-5"
             - name: POSTGRES_AUTH_MODE
-              value: "password"
+              value: "entra"
             - name: POSTGRES_DATABASE
               value: "holiday_peak_crud"
             - name: POSTGRES_HOST
               value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
-            - name: POSTGRES_PORT
-              value: "5432"
             - name: POSTGRES_SSL
               value: "true"
             - name: POSTGRES_USER
-              value: "crud_workload"
+              value: "holidaypeakhub405-dev-crud-identity"
             - name: PROJECT_ENDPOINT
               value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
             - name: PROJECT_NAME
@@ -133,8 +131,6 @@ spec:
               value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
             - name: REDIS_PASSWORD_SECRET_NAME
               value: "redis-primary-key"
-            - name: REDIS_URL
-              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
           ports:
             - containerPort: 8000
           startupProbe:
@@ -166,32 +162,3 @@ spec:
             requests:
               cpu: 250m
               memory: 256Mi
----
-# Source: holiday-peak-service/templates/agc-routing.yaml
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: product-management-assortment-optimization-product-management-a-agc
-  namespace: holiday-peak
-  labels:
-    app: product-management-assortment-optimization
-spec:
-  parentRefs:
-    - name: "holiday-peak-agc"
-      namespace: "holiday-peak"
-  hostnames:
-    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
-  rules:
-    - matches:
-        - path:
-            type: PathPrefix
-            value: "/product-management-assortment-optimization"
-      filters:
-        - type: URLRewrite
-          urlRewrite:
-            path:
-              type: ReplacePrefixMatch
-              replacePrefixMatch: "/"
-      backendRefs:
-        - name: product-management-assortment-optimization-product-management-a
-          port: 80

--- a/.kubernetes/rendered/product-management-consistency-validation/all.yaml
+++ b/.kubernetes/rendered/product-management-consistency-validation/all.yaml
@@ -93,6 +93,8 @@ spec:
               value: "agent-memory"
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
+            - name: CRUD_SERVICE_URL
+              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: FOUNDRY_AGENT_NAME_FAST

--- a/.kubernetes/rendered/product-management-consistency-validation/all.yaml
+++ b/.kubernetes/rendered/product-management-consistency-validation/all.yaml
@@ -1,10 +1,10 @@
----
+﻿---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: product-management-consistency-validation
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: product-management-consistency-validation
   annotations:
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: product-management-consistency-validation-product-management-co
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: product-management-consistency-validation
 spec:
@@ -33,7 +33,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: product-management-consistency-validation-product-management-co
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: product-management-consistency-validation
 spec:
@@ -114,17 +114,15 @@ spec:
             - name: PLATFORM_JOBS_EVENT_HUB_NAMESPACE
               value: "holidaypeakhub405-dev-jobs-eh"
             - name: POSTGRES_AUTH_MODE
-              value: "password"
+              value: "entra"
             - name: POSTGRES_DATABASE
               value: "holiday_peak_crud"
             - name: POSTGRES_HOST
               value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
-            - name: POSTGRES_PORT
-              value: "5432"
             - name: POSTGRES_SSL
               value: "true"
             - name: POSTGRES_USER
-              value: "crud_workload"
+              value: "holidaypeakhub405-dev-crud-identity"
             - name: PROJECT_ENDPOINT
               value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
             - name: PROJECT_NAME
@@ -133,8 +131,6 @@ spec:
               value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
             - name: REDIS_PASSWORD_SECRET_NAME
               value: "redis-primary-key"
-            - name: REDIS_URL
-              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
           ports:
             - containerPort: 8000
           startupProbe:
@@ -166,32 +162,3 @@ spec:
             requests:
               cpu: 250m
               memory: 256Mi
----
-# Source: holiday-peak-service/templates/agc-routing.yaml
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: product-management-consistency-validation-product-management-co-agc
-  namespace: holiday-peak
-  labels:
-    app: product-management-consistency-validation
-spec:
-  parentRefs:
-    - name: "holiday-peak-agc"
-      namespace: "holiday-peak"
-  hostnames:
-    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
-  rules:
-    - matches:
-        - path:
-            type: PathPrefix
-            value: "/product-management-consistency-validation"
-      filters:
-        - type: URLRewrite
-          urlRewrite:
-            path:
-              type: ReplacePrefixMatch
-              replacePrefixMatch: "/"
-      backendRefs:
-        - name: product-management-consistency-validation-product-management-co
-          port: 80

--- a/.kubernetes/rendered/product-management-normalization-classification/all.yaml
+++ b/.kubernetes/rendered/product-management-normalization-classification/all.yaml
@@ -93,6 +93,8 @@ spec:
               value: "agent-memory"
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
+            - name: CRUD_SERVICE_URL
+              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: EVENT_HUB_NAMESPACE

--- a/.kubernetes/rendered/product-management-normalization-classification/all.yaml
+++ b/.kubernetes/rendered/product-management-normalization-classification/all.yaml
@@ -1,10 +1,10 @@
----
+﻿---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: product-management-normalization-classification
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: product-management-normalization-classification
   annotations:
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: product-management-normalization-classification-product-managem
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: product-management-normalization-classification
 spec:
@@ -33,7 +33,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: product-management-normalization-classification-product-managem
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: product-management-normalization-classification
 spec:
@@ -114,17 +114,15 @@ spec:
             - name: MODEL_DEPLOYMENT_NAME_RICH
               value: "gpt-5"
             - name: POSTGRES_AUTH_MODE
-              value: "password"
+              value: "entra"
             - name: POSTGRES_DATABASE
               value: "holiday_peak_crud"
             - name: POSTGRES_HOST
               value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
-            - name: POSTGRES_PORT
-              value: "5432"
             - name: POSTGRES_SSL
               value: "true"
             - name: POSTGRES_USER
-              value: "crud_workload"
+              value: "holidaypeakhub405-dev-crud-identity"
             - name: PROJECT_ENDPOINT
               value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
             - name: PROJECT_NAME
@@ -133,8 +131,6 @@ spec:
               value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
             - name: REDIS_PASSWORD_SECRET_NAME
               value: "redis-primary-key"
-            - name: REDIS_URL
-              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
           ports:
             - containerPort: 8000
           startupProbe:
@@ -166,32 +162,3 @@ spec:
             requests:
               cpu: 250m
               memory: 256Mi
----
-# Source: holiday-peak-service/templates/agc-routing.yaml
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: product-management-normalization-classification-product-managem-agc
-  namespace: holiday-peak
-  labels:
-    app: product-management-normalization-classification
-spec:
-  parentRefs:
-    - name: "holiday-peak-agc"
-      namespace: "holiday-peak"
-  hostnames:
-    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
-  rules:
-    - matches:
-        - path:
-            type: PathPrefix
-            value: "/product-management-normalization-classification"
-      filters:
-        - type: URLRewrite
-          urlRewrite:
-            path:
-              type: ReplacePrefixMatch
-              replacePrefixMatch: "/"
-      backendRefs:
-        - name: product-management-normalization-classification-product-managem
-          port: 80

--- a/.kubernetes/rendered/search-enrichment-agent/all.yaml
+++ b/.kubernetes/rendered/search-enrichment-agent/all.yaml
@@ -93,6 +93,8 @@ spec:
               value: "agent-memory"
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
+            - name: CRUD_SERVICE_URL
+              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: FOUNDRY_AGENT_NAME_FAST

--- a/.kubernetes/rendered/search-enrichment-agent/all.yaml
+++ b/.kubernetes/rendered/search-enrichment-agent/all.yaml
@@ -1,10 +1,10 @@
----
+﻿---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: search-enrichment-agent
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: search-enrichment-agent
   annotations:
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: search-enrichment-agent-search-enrichment-agent
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: search-enrichment-agent
 spec:
@@ -33,7 +33,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: search-enrichment-agent-search-enrichment-agent
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: search-enrichment-agent
 spec:
@@ -114,17 +114,15 @@ spec:
             - name: PLATFORM_JOBS_EVENT_HUB_NAMESPACE
               value: "holidaypeakhub405-dev-jobs-eh"
             - name: POSTGRES_AUTH_MODE
-              value: "password"
+              value: "entra"
             - name: POSTGRES_DATABASE
               value: "holiday_peak_crud"
             - name: POSTGRES_HOST
               value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
-            - name: POSTGRES_PORT
-              value: "5432"
             - name: POSTGRES_SSL
               value: "true"
             - name: POSTGRES_USER
-              value: "crud_workload"
+              value: "holidaypeakhub405-dev-crud-identity"
             - name: PROJECT_ENDPOINT
               value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
             - name: PROJECT_NAME
@@ -133,8 +131,6 @@ spec:
               value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
             - name: REDIS_PASSWORD_SECRET_NAME
               value: "redis-primary-key"
-            - name: REDIS_URL
-              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
             - name: SEARCH_ENRICHMENT_EVENT_HUB_CONSUMER_GROUP
               value: "search-enrichment-consumer"
             - name: SEARCH_ENRICHMENT_EVENT_HUB_NAME
@@ -170,32 +166,3 @@ spec:
             requests:
               cpu: 250m
               memory: 256Mi
----
-# Source: holiday-peak-service/templates/agc-routing.yaml
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: search-enrichment-agent-search-enrichment-agent-agc
-  namespace: holiday-peak
-  labels:
-    app: search-enrichment-agent
-spec:
-  parentRefs:
-    - name: "holiday-peak-agc"
-      namespace: "holiday-peak"
-  hostnames:
-    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
-  rules:
-    - matches:
-        - path:
-            type: PathPrefix
-            value: "/search-enrichment-agent"
-      filters:
-        - type: URLRewrite
-          urlRewrite:
-            path:
-              type: ReplacePrefixMatch
-              replacePrefixMatch: "/"
-      backendRefs:
-        - name: search-enrichment-agent-search-enrichment-agent
-          port: 80

--- a/.kubernetes/rendered/truth-enrichment/all.yaml
+++ b/.kubernetes/rendered/truth-enrichment/all.yaml
@@ -93,6 +93,8 @@ spec:
               value: "agent-memory"
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
+            - name: CRUD_SERVICE_URL
+              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: FOUNDRY_AGENT_NAME_FAST

--- a/.kubernetes/rendered/truth-enrichment/all.yaml
+++ b/.kubernetes/rendered/truth-enrichment/all.yaml
@@ -1,10 +1,10 @@
----
+﻿---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: truth-enrichment
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: truth-enrichment
   annotations:
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: truth-enrichment-truth-enrichment
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: truth-enrichment
 spec:
@@ -33,7 +33,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: truth-enrichment-truth-enrichment
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: truth-enrichment
 spec:
@@ -114,17 +114,15 @@ spec:
             - name: PLATFORM_JOBS_EVENT_HUB_NAMESPACE
               value: "holidaypeakhub405-dev-jobs-eh"
             - name: POSTGRES_AUTH_MODE
-              value: "password"
+              value: "entra"
             - name: POSTGRES_DATABASE
               value: "holiday_peak_crud"
             - name: POSTGRES_HOST
               value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
-            - name: POSTGRES_PORT
-              value: "5432"
             - name: POSTGRES_SSL
               value: "true"
             - name: POSTGRES_USER
-              value: "crud_workload"
+              value: "holidaypeakhub405-dev-crud-identity"
             - name: PROJECT_ENDPOINT
               value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
             - name: PROJECT_NAME
@@ -133,8 +131,6 @@ spec:
               value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
             - name: REDIS_PASSWORD_SECRET_NAME
               value: "redis-primary-key"
-            - name: REDIS_URL
-              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
             - name: TRUTH_EVENT_HUB_CONSUMER_GROUP
               value: "enrichment-engine"
             - name: TRUTH_EVENT_HUB_NAME
@@ -170,32 +166,3 @@ spec:
             requests:
               cpu: 250m
               memory: 256Mi
----
-# Source: holiday-peak-service/templates/agc-routing.yaml
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: truth-enrichment-truth-enrichment-agc
-  namespace: holiday-peak
-  labels:
-    app: truth-enrichment
-spec:
-  parentRefs:
-    - name: "holiday-peak-agc"
-      namespace: "holiday-peak"
-  hostnames:
-    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
-  rules:
-    - matches:
-        - path:
-            type: PathPrefix
-            value: "/truth-enrichment"
-      filters:
-        - type: URLRewrite
-          urlRewrite:
-            path:
-              type: ReplacePrefixMatch
-              replacePrefixMatch: "/"
-      backendRefs:
-        - name: truth-enrichment-truth-enrichment
-          port: 80

--- a/.kubernetes/rendered/truth-export/all.yaml
+++ b/.kubernetes/rendered/truth-export/all.yaml
@@ -101,6 +101,8 @@ spec:
               value: "agent-memory"
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
+            - name: CRUD_SERVICE_URL
+              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: FOUNDRY_AGENT_NAME_FAST

--- a/.kubernetes/rendered/truth-export/all.yaml
+++ b/.kubernetes/rendered/truth-export/all.yaml
@@ -1,10 +1,10 @@
----
+﻿---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: truth-export
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: truth-export
   annotations:
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: truth-export-truth-export
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: truth-export
 spec:
@@ -33,7 +33,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: truth-export-truth-export
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: truth-export
 spec:
@@ -122,17 +122,15 @@ spec:
             - name: PLATFORM_JOBS_EVENT_HUB_NAMESPACE
               value: "holidaypeakhub405-dev-jobs-eh"
             - name: POSTGRES_AUTH_MODE
-              value: "password"
+              value: "entra"
             - name: POSTGRES_DATABASE
               value: "holiday_peak_crud"
             - name: POSTGRES_HOST
               value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
-            - name: POSTGRES_PORT
-              value: "5432"
             - name: POSTGRES_SSL
               value: "true"
             - name: POSTGRES_USER
-              value: "crud_workload"
+              value: "holidaypeakhub405-dev-crud-identity"
             - name: PROJECT_ENDPOINT
               value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
             - name: PROJECT_NAME
@@ -141,8 +139,6 @@ spec:
               value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
             - name: REDIS_PASSWORD_SECRET_NAME
               value: "redis-primary-key"
-            - name: REDIS_URL
-              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
             - name: TRUTH_EVENT_HUB_CONSUMER_GROUP
               value: "export-engine"
             - name: TRUTH_EVENT_HUB_NAME
@@ -178,32 +174,3 @@ spec:
             requests:
               cpu: 250m
               memory: 256Mi
----
-# Source: holiday-peak-service/templates/agc-routing.yaml
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: truth-export-truth-export-agc
-  namespace: holiday-peak
-  labels:
-    app: truth-export
-spec:
-  parentRefs:
-    - name: "holiday-peak-agc"
-      namespace: "holiday-peak"
-  hostnames:
-    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
-  rules:
-    - matches:
-        - path:
-            type: PathPrefix
-            value: "/truth-export"
-      filters:
-        - type: URLRewrite
-          urlRewrite:
-            path:
-              type: ReplacePrefixMatch
-              replacePrefixMatch: "/"
-      backendRefs:
-        - name: truth-export-truth-export
-          port: 80

--- a/.kubernetes/rendered/truth-hitl/all.yaml
+++ b/.kubernetes/rendered/truth-hitl/all.yaml
@@ -1,10 +1,10 @@
----
+﻿---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: truth-hitl
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: truth-hitl
   annotations:
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: truth-hitl-truth-hitl
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: truth-hitl
 spec:
@@ -33,7 +33,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: truth-hitl-truth-hitl
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: truth-hitl
 spec:
@@ -114,17 +114,15 @@ spec:
             - name: PLATFORM_JOBS_EVENT_HUB_NAMESPACE
               value: "holidaypeakhub405-dev-jobs-eh"
             - name: POSTGRES_AUTH_MODE
-              value: "password"
+              value: "entra"
             - name: POSTGRES_DATABASE
               value: "holiday_peak_crud"
             - name: POSTGRES_HOST
               value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
-            - name: POSTGRES_PORT
-              value: "5432"
             - name: POSTGRES_SSL
               value: "true"
             - name: POSTGRES_USER
-              value: "crud_workload"
+              value: "holidaypeakhub405-dev-crud-identity"
             - name: PROJECT_ENDPOINT
               value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
             - name: PROJECT_NAME
@@ -133,8 +131,6 @@ spec:
               value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
             - name: REDIS_PASSWORD_SECRET_NAME
               value: "redis-primary-key"
-            - name: REDIS_URL
-              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
             - name: TRUTH_EVENT_HUB_CONSUMER_GROUP
               value: "hitl-service"
             - name: TRUTH_EVENT_HUB_NAME
@@ -170,32 +166,3 @@ spec:
             requests:
               cpu: 250m
               memory: 256Mi
----
-# Source: holiday-peak-service/templates/agc-routing.yaml
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: truth-hitl-truth-hitl-agc
-  namespace: holiday-peak
-  labels:
-    app: truth-hitl
-spec:
-  parentRefs:
-    - name: "holiday-peak-agc"
-      namespace: "holiday-peak"
-  hostnames:
-    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
-  rules:
-    - matches:
-        - path:
-            type: PathPrefix
-            value: "/truth-hitl"
-      filters:
-        - type: URLRewrite
-          urlRewrite:
-            path:
-              type: ReplacePrefixMatch
-              replacePrefixMatch: "/"
-      backendRefs:
-        - name: truth-hitl-truth-hitl
-          port: 80

--- a/.kubernetes/rendered/truth-hitl/all.yaml
+++ b/.kubernetes/rendered/truth-hitl/all.yaml
@@ -93,6 +93,8 @@ spec:
               value: "agent-memory"
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
+            - name: CRUD_SERVICE_URL
+              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: FOUNDRY_AGENT_NAME_FAST

--- a/.kubernetes/rendered/truth-ingestion/all.yaml
+++ b/.kubernetes/rendered/truth-ingestion/all.yaml
@@ -1,10 +1,10 @@
----
+﻿---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: truth-ingestion
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: truth-ingestion
   annotations:
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: truth-ingestion-truth-ingestion
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: truth-ingestion
 spec:
@@ -33,7 +33,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: truth-ingestion-truth-ingestion
-  namespace: holiday-peak
+  namespace: holiday-peak-agents
   labels:
     app: truth-ingestion
 spec:
@@ -117,17 +117,15 @@ spec:
             - name: PLATFORM_JOBS_EVENT_HUB_NAMESPACE
               value: "holidaypeakhub405-dev-jobs-eh"
             - name: POSTGRES_AUTH_MODE
-              value: "password"
+              value: "entra"
             - name: POSTGRES_DATABASE
               value: "holiday_peak_crud"
             - name: POSTGRES_HOST
               value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
-            - name: POSTGRES_PORT
-              value: "5432"
             - name: POSTGRES_SSL
               value: "true"
             - name: POSTGRES_USER
-              value: "crud_workload"
+              value: "holidaypeakhub405-dev-crud-identity"
             - name: PROJECT_ENDPOINT
               value: "https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris"
             - name: PROJECT_NAME
@@ -136,8 +134,6 @@ spec:
               value: "holidaypeakhub405-dev-redis.redis.cache.windows.net"
             - name: REDIS_PASSWORD_SECRET_NAME
               value: "redis-primary-key"
-            - name: REDIS_URL
-              value: "rediss://holidaypeakhub405-dev-redis.redis.cache.windows.net:6380/0"
             - name: TRUTH_EVENT_HUB_CONSUMER_GROUP
               value: "ingestion-group"
             - name: TRUTH_EVENT_HUB_NAME
@@ -173,32 +169,3 @@ spec:
             requests:
               cpu: 250m
               memory: 256Mi
----
-# Source: holiday-peak-service/templates/agc-routing.yaml
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: truth-ingestion-truth-ingestion-agc
-  namespace: holiday-peak
-  labels:
-    app: truth-ingestion
-spec:
-  parentRefs:
-    - name: "holiday-peak-agc"
-      namespace: "holiday-peak"
-  hostnames:
-    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
-  rules:
-    - matches:
-        - path:
-            type: PathPrefix
-            value: "/truth-ingestion"
-      filters:
-        - type: URLRewrite
-          urlRewrite:
-            path:
-              type: ReplacePrefixMatch
-              replacePrefixMatch: "/"
-      backendRefs:
-        - name: truth-ingestion-truth-ingestion
-          port: 80

--- a/.kubernetes/rendered/truth-ingestion/all.yaml
+++ b/.kubernetes/rendered/truth-ingestion/all.yaml
@@ -96,6 +96,8 @@ spec:
               value: "products"
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
+            - name: CRUD_SERVICE_URL
+              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: FOUNDRY_AGENT_NAME_FAST

--- a/azure.yaml
+++ b/azure.yaml
@@ -28,7 +28,7 @@ services:
       context: ../../..
       remoteBuild: true
     k8s:
-      namespace: holiday-peak
+      namespace: holiday-peak-crud
       deploymentPath: ../../../.kubernetes/rendered/crud-service
     hooks:
       predeploy:
@@ -46,7 +46,7 @@ services:
     language: python
     host: aks
     k8s:
-      namespace: holiday-peak
+      namespace: holiday-peak-agents
       deploymentPath: ../../../.kubernetes/rendered/crm-campaign-intelligence
     hooks:
       predeploy:
@@ -64,7 +64,7 @@ services:
     language: python
     host: aks
     k8s:
-      namespace: holiday-peak
+      namespace: holiday-peak-agents
       deploymentPath: ../../../.kubernetes/rendered/crm-profile-aggregation
     hooks:
       predeploy:
@@ -82,7 +82,7 @@ services:
     language: python
     host: aks
     k8s:
-      namespace: holiday-peak
+      namespace: holiday-peak-agents
       deploymentPath: ../../../.kubernetes/rendered/crm-segmentation-personalization
     hooks:
       predeploy:
@@ -100,7 +100,7 @@ services:
     language: python
     host: aks
     k8s:
-      namespace: holiday-peak
+      namespace: holiday-peak-agents
       deploymentPath: ../../../.kubernetes/rendered/crm-support-assistance
     hooks:
       predeploy:
@@ -118,7 +118,7 @@ services:
     language: python
     host: aks
     k8s:
-      namespace: holiday-peak
+      namespace: holiday-peak-agents
       deploymentPath: ../../../.kubernetes/rendered/ecommerce-cart-intelligence
     hooks:
       predeploy:
@@ -136,7 +136,7 @@ services:
     language: python
     host: aks
     k8s:
-      namespace: holiday-peak
+      namespace: holiday-peak-agents
       deploymentPath: ../../../.kubernetes/rendered/ecommerce-catalog-search
     hooks:
       predeploy:
@@ -154,7 +154,7 @@ services:
     language: python
     host: aks
     k8s:
-      namespace: holiday-peak
+      namespace: holiday-peak-agents
       deploymentPath: ../../../.kubernetes/rendered/ecommerce-checkout-support
     hooks:
       predeploy:
@@ -172,7 +172,7 @@ services:
     language: python
     host: aks
     k8s:
-      namespace: holiday-peak
+      namespace: holiday-peak-agents
       deploymentPath: ../../../.kubernetes/rendered/ecommerce-order-status
     hooks:
       predeploy:
@@ -190,7 +190,7 @@ services:
     language: python
     host: aks
     k8s:
-      namespace: holiday-peak
+      namespace: holiday-peak-agents
       deploymentPath: ../../../.kubernetes/rendered/ecommerce-product-detail-enrichment
     hooks:
       predeploy:
@@ -208,7 +208,7 @@ services:
     language: python
     host: aks
     k8s:
-      namespace: holiday-peak
+      namespace: holiday-peak-agents
       deploymentPath: ../../../.kubernetes/rendered/inventory-alerts-triggers
     hooks:
       predeploy:
@@ -226,7 +226,7 @@ services:
     language: python
     host: aks
     k8s:
-      namespace: holiday-peak
+      namespace: holiday-peak-agents
       deploymentPath: ../../../.kubernetes/rendered/inventory-health-check
     hooks:
       predeploy:
@@ -244,7 +244,7 @@ services:
     language: python
     host: aks
     k8s:
-      namespace: holiday-peak
+      namespace: holiday-peak-agents
       deploymentPath: ../../../.kubernetes/rendered/inventory-jit-replenishment
     hooks:
       predeploy:
@@ -262,7 +262,7 @@ services:
     language: python
     host: aks
     k8s:
-      namespace: holiday-peak
+      namespace: holiday-peak-agents
       deploymentPath: ../../../.kubernetes/rendered/inventory-reservation-validation
     hooks:
       predeploy:
@@ -280,7 +280,7 @@ services:
     language: python
     host: aks
     k8s:
-      namespace: holiday-peak
+      namespace: holiday-peak-agents
       deploymentPath: ../../../.kubernetes/rendered/logistics-carrier-selection
     hooks:
       predeploy:
@@ -298,7 +298,7 @@ services:
     language: python
     host: aks
     k8s:
-      namespace: holiday-peak
+      namespace: holiday-peak-agents
       deploymentPath: ../../../.kubernetes/rendered/logistics-eta-computation
     hooks:
       predeploy:
@@ -316,7 +316,7 @@ services:
     language: python
     host: aks
     k8s:
-      namespace: holiday-peak
+      namespace: holiday-peak-agents
       deploymentPath: ../../../.kubernetes/rendered/logistics-returns-support
     hooks:
       predeploy:
@@ -334,7 +334,7 @@ services:
     language: python
     host: aks
     k8s:
-      namespace: holiday-peak
+      namespace: holiday-peak-agents
       deploymentPath: ../../../.kubernetes/rendered/logistics-route-issue-detection
     hooks:
       predeploy:
@@ -352,7 +352,7 @@ services:
     language: python
     host: aks
     k8s:
-      namespace: holiday-peak
+      namespace: holiday-peak-agents
       deploymentPath: ../../../.kubernetes/rendered/product-management-acp-transformation
     hooks:
       predeploy:
@@ -370,7 +370,7 @@ services:
     language: python
     host: aks
     k8s:
-      namespace: holiday-peak
+      namespace: holiday-peak-agents
       deploymentPath: ../../../.kubernetes/rendered/product-management-assortment-optimization
     hooks:
       predeploy:
@@ -388,7 +388,7 @@ services:
     language: python
     host: aks
     k8s:
-      namespace: holiday-peak
+      namespace: holiday-peak-agents
       deploymentPath: ../../../.kubernetes/rendered/product-management-consistency-validation
     hooks:
       predeploy:
@@ -406,7 +406,7 @@ services:
     language: python
     host: aks
     k8s:
-      namespace: holiday-peak
+      namespace: holiday-peak-agents
       deploymentPath: ../../../.kubernetes/rendered/product-management-normalization-classification
     hooks:
       predeploy:
@@ -424,7 +424,7 @@ services:
     language: python
     host: aks
     k8s:
-      namespace: holiday-peak
+      namespace: holiday-peak-agents
       deploymentPath: ../../../.kubernetes/rendered/search-enrichment-agent
     hooks:
       predeploy:
@@ -442,7 +442,7 @@ services:
     language: python
     host: aks
     k8s:
-      namespace: holiday-peak
+      namespace: holiday-peak-agents
       deploymentPath: ../../../.kubernetes/rendered/truth-ingestion
     hooks:
       predeploy:
@@ -460,7 +460,7 @@ services:
     language: python
     host: aks
     k8s:
-      namespace: holiday-peak
+      namespace: holiday-peak-agents
       deploymentPath: ../../../.kubernetes/rendered/truth-enrichment
     hooks:
       predeploy:
@@ -479,7 +479,7 @@ services:
     language: python
     host: aks
     k8s:
-      namespace: holiday-peak
+      namespace: holiday-peak-agents
       deploymentPath: ../../../.kubernetes/rendered/truth-export
     hooks:
       predeploy:
@@ -498,7 +498,7 @@ services:
     language: python
     host: aks
     k8s:
-      namespace: holiday-peak
+      namespace: holiday-peak-agents
       deploymentPath: ../../../.kubernetes/rendered/truth-hitl
     hooks:
       predeploy:

--- a/docs/architecture/adrs/adr-034-namespace-isolation-strategy.md
+++ b/docs/architecture/adrs/adr-034-namespace-isolation-strategy.md
@@ -1,0 +1,515 @@
+# ADR-034: Namespace Isolation Strategy
+
+**Status**: Proposed
+**Date**: 2026-04-11
+**Deciders**: Architecture Team, Ricardo Cataldi
+**Tags**: infrastructure, kubernetes, aks, namespace, security, istio, flux, network-policy
+**References**: [ADR-031](adr-031-mcp-internal-communication-policy.md), [ADR-033](adr-033-helm-deployment-strategy.md), [ADR-009](adr-009-aks-deployment.md), [ADR-027](adr-027-apim-agc-edge.md), [ADR-028](adr-028-memory-namespace-isolation-contract.md)
+
+## Context
+
+The holiday-peak-hub platform deploys 27 production services to AKS: 1 CRUD service (transactional system of record) and 26 agent services (including 4 truth-layer services). All services currently run in a single `holiday-peak` Kubernetes namespace, despite node-level isolation already being enforced via dedicated node pools (`aks-crud`, `aks-agents`, `aks-system`) with taints (ADR-009).
+
+A single shared namespace presents the following problems:
+
+1. **Blast radius** — A misconfigured RBAC binding, resource quota, or network policy in one workload class affects all 27 services. A runaway agent pod can consume the namespace's resource quota, starving the CRUD service (the transactional system of record).
+2. **Observability noise** — Logs, metrics, and traces for 27 services share label selectors, making per-concern dashboards noisy and alert routing less precise.
+3. **Security posture** — Kubernetes RBAC permissions, Secrets, ConfigMaps, and ServiceAccount tokens are namespace-scoped. A single namespace means every service's ServiceAccount can enumerate every other service's Secrets by default.
+4. **Deployment independence** — With Flux CD (ADR-033), a single Kustomization reconciling all 27 services means a rendering error in one agent blocks deployment of the CRUD service and vice versa.
+5. **Istio policy granularity** — Istio `AuthorizationPolicy` and `PeerAuthentication` resources are namespace-scoped. A single namespace makes it impossible to enforce distinct mTLS modes or access policies for the two workload classes without per-service policy explosion.
+
+Architecture frameworks applied:
+
+- **TOGAF (Architecture Building Blocks)**: Namespace boundaries are governed infrastructure building blocks whose scope affects security, deployment, and observability.
+- **Domain-Driven Design (Bounded Contexts)**: CRUD (transactional) and Agent (intelligence) are fundamentally different bounded contexts with different scaling, availability, and security characteristics.
+- **Azure Well-Architected Framework (Security / Operational Excellence)**: Least privilege, defense in depth, and independent deployment units.
+- **microservices.io (Database per Service, Bulkhead)**: Namespace isolation is the Kubernetes-native bulkhead mechanism.
+
+## Decision
+
+Split the existing `holiday-peak` namespace into exactly **two namespaces**:
+
+| Namespace | Services | Node Pool | Purpose |
+|-----------|----------|-----------|---------|
+| `holiday-peak-crud` | `crud-service` (1 service) | `aks-crud` | Transactional system of record: products, orders, cart, customers |
+| `holiday-peak-agents` | All 26 agent services (including `truth-ingestion`, `truth-enrichment`, `truth-hitl`, `truth-export`) | `aks-agents` | Intelligence, enrichment, search, support, logistics, CRM, product management |
+
+### Why Two Namespaces, Not More
+
+Three or more namespaces (e.g., separating truth-layer or per-domain) were evaluated and rejected:
+
+- **Truth services** share the same scaling characteristics, node pool, memory patterns (ADR-028), and MCP communication topology as other agents. Separating them adds cross-namespace complexity without measurable security or operational benefit.
+- **Per-domain namespaces** (CRM, eCommerce, inventory, logistics, product-management) would create 6+ namespaces for 26 services, multiplying Flux Kustomizations, Istio policies, AGC routing rules, and RBAC bindings. The incremental isolation is not justified at current scale.
+
+The two-namespace split maximizes the ratio of isolation benefit to operational cost by targeting the single most meaningful workload boundary: transactional vs. intelligence.
+
+### Namespace Topology
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#1a1a2e', 'primaryTextColor': '#e0e0e0', 'primaryBorderColor': '#00d4ff', 'lineColor': '#00d4ff', 'secondaryColor': '#16213e', 'tertiaryColor': '#0f3460', 'background': '#0d1117', 'mainBkg': '#1a1a2e', 'nodeBorder': '#00d4ff', 'clusterBkg': '#16213e', 'clusterBorder': '#00d4ff', 'titleColor': '#00d4ff', 'edgeLabelBackground': '#1a1a2e', 'nodeTextColor': '#e0e0e0' }}}%%
+flowchart TB
+    subgraph AKS["AKS Cluster"]
+        direction TB
+
+        subgraph SYS["aks-system pool"]
+            direction LR
+            ISTIO[Istio Control Plane]
+            FLUX[Flux Controllers]
+            KEDA[KEDA Operator]
+        end
+
+        subgraph CRUD_NS["namespace: holiday-peak-crud<br/>(aks-crud pool — 1 node)"]
+            direction LR
+            CRUD[crud-service]
+        end
+
+        subgraph AGENTS_NS["namespace: holiday-peak-agents<br/>(aks-agents pool — 5 nodes)"]
+            direction LR
+            CRM1[crm-profile-aggregation]
+            CRM2[crm-segmentation-personalization]
+            CRM3[crm-support-assistance]
+            CRM4[crm-campaign-intelligence]
+            ECOM1[ecommerce-cart-intelligence]
+            ECOM2[ecommerce-catalog-search]
+            ECOM3[ecommerce-checkout-support]
+            ECOM4[ecommerce-order-status]
+            ECOM5[ecommerce-product-detail-enrichment]
+            INV1[inventory-alerts-triggers]
+            INV2[inventory-health-check]
+            INV3[inventory-jit-replenishment]
+            INV4[inventory-reservation-validation]
+            LOG1[logistics-carrier-selection]
+            LOG2[logistics-eta-computation]
+            LOG3[logistics-returns-support]
+            LOG4[logistics-route-issue-detection]
+            PM1[product-management-acp-transformation]
+            PM2[product-management-assortment-optimization]
+            PM3[product-management-consistency-validation]
+            PM4[product-management-normalization-classification]
+            SE[search-enrichment-agent]
+            T1[truth-ingestion]
+            T2[truth-enrichment]
+            T3[truth-hitl]
+            T4[truth-export]
+        end
+    end
+
+    EXT_APIM[Azure APIM + AGC] -->|north-south| CRUD
+    EXT_APIM -->|north-south| ECOM2
+    EXT_APIM -->|north-south| CRM3
+    CRUD -->|APIM gateway| CRM1
+    ECOM1 -->|cross-namespace DNS| CRUD
+    T1 -->|cross-namespace DNS| CRUD
+    CRM1 -->|MCP via APIM| CRM2
+```
+
+### Communication Paths After Namespace Split
+
+#### Agent → CRUD: Direct Cross-Namespace Kubernetes DNS (Option A — Selected)
+
+Agent services that need transactional data from the CRUD service will use the cross-namespace Kubernetes DNS FQDN:
+
+```
+http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000
+```
+
+**Why Option A over Option B (routing through APIM)**:
+
+| Criterion | Option A: Direct K8s DNS | Option B: Via APIM |
+|-----------|--------------------------|---------------------|
+| Latency | ~1-2 ms (in-cluster) | ~15-30 ms (APIM + AGC hop) |
+| Cost | Zero additional RU/request cost | APIM request units per call |
+| Reliability | No external dependency | APIM outage blocks agent→CRUD |
+| mTLS | Istio sidecar-to-sidecar | Terminated at AGC, re-encrypted to APIM |
+| Observability | Full Istio telemetry | Split across APIM logs + Istio |
+| Blast radius | Cluster-local, no public path | Uses public APIM facade for internal traffic |
+| Symmetry | Asymmetric with CRUD→Agent | Symmetric but architecturally wasteful |
+
+**Decision**: Option A. Agent→CRUD is a hot path (product lookups, order reads, cart validation) invoked by every agent enrichment cycle. Adding 15-30 ms per call across 26 services with multiple CRUD calls each would degrade the platform's primary value proposition — low-latency intelligent retail experiences. APIM exists as the **public facade** (ADR-027); using it for intra-cluster traffic violates separation of concerns.
+
+**Mitigation for asymmetry**: CRUD→Agent calls already go through APIM because CRUD is the entry point for external requests and agent calls are policy-gated intelligence lookups. Agent→CRUD calls are internal data-plane reads that benefit from locality. The asymmetry is intentional and architecturally sound.
+
+#### CRUD → Agent: Via APIM (No Change)
+
+Per ADR-027 and ADR-031, CRUD calls agent REST endpoints through APIM for enrichment/decision assist flows. This path is unchanged by the namespace split.
+
+#### Agent → Agent: MCP via APIM (No Change)
+
+Per ADR-031, agent-to-agent communication uses MCP tools routed through APIM. All 26 agent services are registered as MCP Servers in APIM. This path is namespace-agnostic and unchanged.
+
+#### External Traffic: APIM → AGC → ClusterIP (Updated)
+
+Per ADR-027, external traffic flows through APIM → AGC → AKS. AGC HTTPRoute resources will now target services in their respective namespaces. The AGC Gateway resource must reference both namespaces.
+
+### `CRUD_SERVICE_URL` Environment Variable Migration
+
+All 26 agent services read `CRUD_SERVICE_URL` from environment variables. The migration updates this single value:
+
+| Before | After |
+|--------|-------|
+| `http://crud-service-crud-service.holiday-peak.svc.cluster.local:8000` | `http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000` |
+
+This is set in Helm values per service and rendered into deployment manifests by `render-helm.sh`. The change is a values-only update — no application code changes required.
+
+### Istio Service Mesh Configuration
+
+#### PeerAuthentication (mTLS)
+
+Enable `STRICT` mTLS independently per namespace to ensure all inter-namespace traffic is encrypted and identity-verified:
+
+```yaml
+# holiday-peak-crud namespace
+apiVersion: security.istio.io/v1
+kind: PeerAuthentication
+metadata:
+  name: default
+  namespace: holiday-peak-crud
+spec:
+  mtls:
+    mode: STRICT
+---
+# holiday-peak-agents namespace
+apiVersion: security.istio.io/v1
+kind: PeerAuthentication
+metadata:
+  name: default
+  namespace: holiday-peak-agents
+spec:
+  mtls:
+    mode: STRICT
+```
+
+#### AuthorizationPolicy
+
+Restrict which workloads can reach the CRUD service. Only agent services from `holiday-peak-agents` and the Istio ingress gateway (for AGC traffic) are permitted:
+
+```yaml
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: crud-service-access
+  namespace: holiday-peak-crud
+spec:
+  selector:
+    matchLabels:
+      app: crud-service
+  action: ALLOW
+  rules:
+    # Allow agent services from the agents namespace
+    - from:
+        - source:
+            namespaces: ["holiday-peak-agents"]
+      to:
+        - operation:
+            ports: ["8000"]
+    # Allow AGC ingress gateway
+    - from:
+        - source:
+            namespaces: ["istio-system"]
+      to:
+        - operation:
+            ports: ["8000"]
+```
+
+Agent-to-agent communication within `holiday-peak-agents` is unrestricted (same-namespace, governed by ADR-031 MCP policy). A default-deny policy for agent services blocks external namespaces except `istio-system`:
+
+```yaml
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: agents-default-access
+  namespace: holiday-peak-agents
+spec:
+  action: ALLOW
+  rules:
+    # Allow intra-namespace (agent-to-agent)
+    - from:
+        - source:
+            namespaces: ["holiday-peak-agents"]
+    # Allow AGC ingress
+    - from:
+        - source:
+            namespaces: ["istio-system"]
+    # Allow CRUD callbacks (e.g., event confirmations)
+    - from:
+        - source:
+            namespaces: ["holiday-peak-crud"]
+```
+
+### Kubernetes NetworkPolicies (Defense in Depth)
+
+NetworkPolicies operate at L3/L4 as a defense-in-depth layer beneath Istio's L7 policies. If Istio sidecars fail to inject or are bypassed, these policies still enforce boundaries.
+
+```yaml
+# Deny all ingress by default in holiday-peak-crud
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: holiday-peak-crud
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+# Allow ingress to CRUD from agents namespace and istio-system
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-agents-and-ingress
+  namespace: holiday-peak-crud
+spec:
+  podSelector:
+    matchLabels:
+      app: crud-service
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: holiday-peak-agents
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: istio-system
+      ports:
+        - protocol: TCP
+          port: 8000
+---
+# Deny all ingress by default in holiday-peak-agents
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: holiday-peak-agents
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+# Allow ingress to agents from same namespace, crud namespace, and istio-system
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-internal-and-ingress
+  namespace: holiday-peak-agents
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: holiday-peak-agents
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: holiday-peak-crud
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: istio-system
+      ports:
+        - protocol: TCP
+          port: 8000
+```
+
+### Flux CD Multi-Kustomization (ADR-033 Extension)
+
+Split the single Flux `Kustomization` into two independent reconciliation units, one per namespace. This ensures a rendering error in one namespace does not block deployment of the other.
+
+```yaml
+# Kustomization for CRUD namespace
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: holiday-peak-crud
+  namespace: flux-system
+spec:
+  interval: 5m
+  path: .kubernetes/rendered/crud-service
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: holiday-peak-gitops
+  targetNamespace: holiday-peak-crud
+  healthChecks:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: crud-service-crud-service
+      namespace: holiday-peak-crud
+---
+# Kustomization for Agents namespace
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: holiday-peak-agents
+  namespace: flux-system
+spec:
+  interval: 5m
+  path: .kubernetes/rendered
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: holiday-peak-gitops
+  targetNamespace: holiday-peak-agents
+  dependsOn:
+    - name: holiday-peak-crud
+  healthChecks:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: search-enrichment-agent-search-enrichment-agent
+      namespace: holiday-peak-agents
+```
+
+The `dependsOn` ensures CRUD is healthy before agents reconcile, matching the existing deployment ordering requirement (ADR-009: "Deploy CRUD first").
+
+### Helm Chart Changes
+
+The Helm chart (`/.kubernetes/chart/values.yaml`) gains a `namespace` field per service, and `render-helm.sh` passes the correct namespace during rendering:
+
+```bash
+# render-helm.sh (pseudocode update)
+if [ "$SERVICE_NAME" = "crud-service" ]; then
+  NAMESPACE="holiday-peak-crud"
+else
+  NAMESPACE="holiday-peak-agents"
+fi
+
+helm template "$RELEASE_NAME" .kubernetes/chart/ \
+  --namespace "$NAMESPACE" \
+  --values "$VALUES_FILE" \
+  > ".kubernetes/rendered/$SERVICE_NAME/all.yaml"
+```
+
+### APIM MCP Server Registration
+
+All 26 agent services must be registered as MCP Servers in APIM. The APIM backend URLs will target AGC hostnames that route to `holiday-peak-agents` namespace services. The CRUD service backend URL targets `holiday-peak-crud`. This is a configuration extension of ADR-027, not a new pattern.
+
+### AGC Gateway Multi-Namespace Reference
+
+The AGC Gateway resource must allow route attachment from both namespaces:
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: holiday-peak-agc
+  namespace: holiday-peak-crud  # or a shared infra namespace
+spec:
+  gatewayClassName: azure-alb-external
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Selector
+          selector:
+            matchLabels:
+              holiday-peak/ingress-allowed: "true"
+```
+
+Both `holiday-peak-crud` and `holiday-peak-agents` namespaces receive the label `holiday-peak/ingress-allowed: "true"`.
+
+## Migration Strategy
+
+### Phase 0: Pre-Migration (No Downtime)
+
+1. Create both namespaces with labels and annotations:
+   ```bash
+   kubectl create namespace holiday-peak-crud
+   kubectl label namespace holiday-peak-crud \
+     holiday-peak/ingress-allowed=true \
+     istio-injection=enabled
+   kubectl create namespace holiday-peak-agents
+   kubectl label namespace holiday-peak-agents \
+     holiday-peak/ingress-allowed=true \
+     istio-injection=enabled
+   ```
+2. Deploy Istio `PeerAuthentication` in `PERMISSIVE` mode to both new namespaces.
+3. Deploy NetworkPolicies to both new namespaces.
+4. Create Flux Kustomizations for both namespaces (suspended).
+
+### Phase 1: CRUD Migration (Maintenance Window — ~15 min)
+
+1. Scale down `crud-service` in `holiday-peak` to 0 replicas.
+2. Unsuspend Flux Kustomization for `holiday-peak-crud` — Flux deploys CRUD to new namespace.
+3. Validate CRUD health endpoint via AGC and APIM.
+4. Update AGC HTTPRoute to target `holiday-peak-crud` namespace for CRUD paths.
+5. Smoke-test CRUD through APIM: `GET /api/health`, `GET /api/products`.
+
+### Phase 2: Agent Migration (Rolling — No Downtime)
+
+1. Update `CRUD_SERVICE_URL` in all agent Helm values to the new cross-namespace FQDN.
+2. Unsuspend Flux Kustomization for `holiday-peak-agents`.
+3. Migrate agents in domain batches (5 batches of ~5 services), validating each batch:
+   - Batch 1: `truth-*` services (4 services) — validates cross-namespace CRUD connectivity
+   - Batch 2: `ecommerce-*` services (5 services)
+   - Batch 3: `crm-*` services (4 services)
+   - Batch 4: `inventory-*` + `logistics-*` services (8 services)
+   - Batch 5: `product-management-*` + `search-enrichment-agent` (5 services)
+4. After each batch: verify MCP tool discovery via APIM, check agent→CRUD latency, confirm Istio telemetry.
+5. Update AGC HTTPRoutes for agent paths to target `holiday-peak-agents`.
+
+### Phase 3: Cutover and Harden
+
+1. Switch Istio `PeerAuthentication` from `PERMISSIVE` to `STRICT` in both namespaces.
+2. Delete all resources from old `holiday-peak` namespace.
+3. Delete old single-namespace Flux Kustomization.
+4. Archive old namespace: `kubectl delete namespace holiday-peak`.
+
+### Rollback Plan
+
+At any phase, rollback is:
+
+1. Suspend Flux Kustomizations for new namespaces.
+2. Scale up services in original `holiday-peak` namespace (Flux reconciles old Kustomization).
+3. Revert AGC HTTPRoutes to original namespace.
+4. Revert `CRUD_SERVICE_URL` values in agent Helm values.
+
+The old namespace and its resources remain untouched until Phase 3 explicit deletion, making rollback a configuration revert.
+
+## Consequences
+
+### Positive
+
+1. **Blast radius reduction** — CRUD and agent workloads have independent resource quotas, RBAC bindings, and failure domains. A runaway agent cannot starve the transactional system.
+2. **Deployment independence** — Separate Flux Kustomizations allow CRUD and agents to deploy, fail, and roll back independently (ADR-033 extension).
+3. **Security posture** — Namespace-scoped Secrets, ConfigMaps, and ServiceAccounts are no longer shared. NetworkPolicies and Istio AuthorizationPolicies enforce explicit allow-lists.
+4. **Observability clarity** — Per-namespace metrics, logs, and traces reduce noise and enable namespace-scoped alerting and dashboards.
+5. **Istio policy precision** — mTLS mode and authorization can evolve independently per namespace (e.g., STRICT for CRUD, PERMISSIVE for agents during rollout).
+6. **Future extensibility** — If a third workload class emerges (e.g., batch processing), adding a namespace follows this same pattern without redesign.
+
+### Negative
+
+1. **Operational complexity** — Two Flux Kustomizations, two sets of NetworkPolicies, two PeerAuthentication resources, and namespace-aware `render-helm.sh` add configuration surface area.
+2. **Cross-namespace DNS coupling** — Agent services depend on a specific DNS FQDN for CRUD. If the CRUD service name or namespace changes, all 26 agent values files must update. Mitigated by the FQDN being a single Helm value.
+3. **AGC multi-namespace routing** — HTTPRoute resources must reference services in their local namespace or use cross-namespace `ReferenceGrant`. This adds Gateway API administrative overhead.
+4. **Migration risk** — A ~15-minute maintenance window is required for CRUD cutover. Mitigated by defined rollback plan and phased approach.
+
+### Neutral
+
+1. **External PaaS services unaffected** — Redis, Cosmos DB, Blob Storage, Azure AI Foundry are namespace-agnostic; no changes required.
+2. **Memory namespace contract (ADR-028) unaffected** — The `<service>:<tenantId>:<sessionId>` key contract operates at application level, not Kubernetes namespace level.
+3. **MCP communication policy (ADR-031) unaffected** — Agent-to-agent MCP routing through APIM is namespace-transparent.
+4. **Node pool assignment unchanged** — Taints and tolerations already segregate compute (ADR-009). Namespace split aligns the logical boundary with the existing physical boundary.
+
+## Alternatives Considered
+
+### Alternative 1: Keep Single Namespace
+
+Retain `holiday-peak` and rely solely on Istio AuthorizationPolicies and RBAC for isolation.
+
+**Rejected**: Per-service policy proliferation (27 AuthorizationPolicies, 27 NetworkPolicies) is harder to maintain and audit than namespace-scoped defaults. Does not address deployment independence or resource quota isolation.
+
+### Alternative 2: Per-Domain Namespaces (6+ Namespaces)
+
+Split into `holiday-peak-crud`, `holiday-peak-crm`, `holiday-peak-ecommerce`, `holiday-peak-inventory`, `holiday-peak-logistics`, `holiday-peak-product-mgmt`, `holiday-peak-truth`.
+
+**Rejected**: Multiplies Flux Kustomizations, NetworkPolicies, Istio policies, and AGC routing by 7x. All agent services share the same node pool, scaling characteristics, and MCP communication mesh. The incremental isolation does not justify the operational cost at current scale (26 agent services).
+
+### Alternative 3: Route Agent→CRUD Through APIM (Option B)
+
+Use APIM for all service-to-service communication including agent→CRUD.
+
+**Rejected**: Adds 15-30 ms latency per agent→CRUD call on a hot path. Introduces APIM as a single point of failure for intra-cluster data reads. Consumes APIM request units for internal traffic. Violates the architectural principle that APIM is the **public facade** (ADR-027), not an internal service bus.


### PR DESCRIPTION
## Summary

Split the monolithic \holiday-peak\ namespace into two isolated namespaces per **ADR-034**:

| Namespace | Services | Node Pool |
|-----------|----------|-----------|
| \holiday-peak-crud\ | \crud-service\ (1 service) | \ks-crud\ |
| \holiday-peak-agents\ | All 26 agent services (incl. truth-*) | \ks-agents\ |

## Motivation
- **Blast radius reduction** — CRUD and agent workloads get independent resource quotas, RBAC, and failure domains
- **Deployment independence** — Separate Flux kustomizations enable independent reconciliation
- **Security posture** — Namespace-scoped secrets/configmaps, ready for Istio mTLS + AuthorizationPolicies
- **Observability clarity** — Per-namespace metrics and alerting

## Key Changes

### Architecture
- **ADR-034**: Namespace Isolation Strategy (new)
- Bicep FIC subjects updated for per-namespace ServiceAccount binding
- Flux multi-kustomization: \holiday-peak-crud\ + \holiday-peak-agents\ (agents depends on CRUD)

### Pipeline (\deploy-azd.yml\)
- Namespace creation steps in deploy jobs
- \K8S_CRUD_NAMESPACE\ and \K8S_AGENTS_NAMESPACE\ env vars
- All \kubectl\ commands use target namespace
- CRUD deploys to \holiday-peak-crud\, agents to \holiday-peak-agents\

### Scripts
- \ender-helm.sh/ps1\: Auto-routes CRUD → \holiday-peak-crud\, agents → \holiday-peak-agents\
- \sync-apim-agents.ps1\: Updated default namespace
- \nsure-foundry-agents.ps1\: Updated namespace resolution
- \seed-crud-demo-data.ps1\: Updated namespace resolution

### Manifests
- \zure.yaml\: Per-service namespace declarations
- All 27 rendered manifests updated with correct namespaces
- Flux kustomization split: \.kubernetes/rendered/crud/\ and \gents/\

## Integration Layer Impact

| Layer | Impact |
|-------|--------|
| Redis, Cosmos, Blob, Foundry | ✅ Safe — external Azure resources |
| APIM backends | ✅ Safe — external AGC hostname |
| CRUD→Agent (via APIM) | ✅ Safe — no change |
| Agent→CRUD | ⚠️ Updated via cross-namespace DNS |
| Helm chart | ✅ Safe — uses \{{ .Release.Namespace }}\ |

## Infrastructure Activated
- **Istio** service mesh: \mode: Istio\ (asm-1-27) with External ingress gateway ✅
- **KAITO** AI toolchain: \nabled: true\ ✅
- **KEDA** autoscaler: \nabled: true\ ✅ (unchanged)

## Tests
- 1142 tests passed, 0 failures

Refs: ADR-034, ADR-031, ADR-033