### PR TITLE
feat: API Center governance, APIM MCP strategy, and namespace cleanup

### DIFF
--- a/.github/workflows/deploy-azd.yml
+++ b/.github/workflows/deploy-azd.yml
@@ -2531,6 +2531,35 @@ jobs:
         env:
           AZURE_RESOURCE_GROUP: ${{ inputs.projectName }}-${{ inputs.environment }}-rg
 
+  sync-apic:
+    runs-on: ubuntu-latest
+    if: ${{ !inputs.uiOnly && (inputs.forceApimSync || needs.detect-changes.outputs.agents_changed == 'true' || needs.detect-changes.outputs.crud_changed == 'true') && (needs.sync-apim.result == 'success' || needs.sync-apim.result == 'skipped') }}
+    needs:
+      - detect-changes
+      - sync-apim
+    environment: ${{ inputs.environment }}
+    env:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.DEPLOY_SOURCE_CHECKOUT_REF }}
+
+      - name: Azure login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ env.AZURE_CLIENT_ID }}
+          tenant-id: ${{ env.AZURE_TENANT_ID }}
+          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Sync API Center
+        run: |
+          bash .infra/azd/hooks/sync-apic-apis.sh
+        env:
+          AZURE_RESOURCE_GROUP: ${{ inputs.projectName }}-${{ inputs.environment }}-rg
+
   smoke-apim:
     runs-on: ubuntu-latest
     if: ${{ !inputs.uiOnly && (inputs.forceApimSync || needs.detect-changes.outputs.agents_changed == 'true' || needs.detect-changes.outputs.crud_changed == 'true' || needs.detect-changes.outputs.ui_changed == 'true') && needs.validate-agc-readiness.result == 'success' && (needs.sync-apim.result == 'success' || needs.sync-apim.result == 'skipped') && (needs.ensure-foundry-agents.result == 'success' || needs.ensure-foundry-agents.result == 'skipped') }}
@@ -2926,6 +2955,7 @@ jobs:
       - deploy-crud
       - deploy-agents
       - sync-apim
+      - sync-apic
       - smoke-apim
       - deploy-ui
       - ensure-foundry-agents

--- a/.infra/azd/hooks/sync-apic-apis.ps1
+++ b/.infra/azd/hooks/sync-apic-apis.ps1
@@ -1,0 +1,158 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Imports APIs from APIM into Azure API Center for centralized governance and discovery.
+
+.DESCRIPTION
+    Runs after APIM sync to import all registered APIs into API Center.
+    Uses az apic import-from-apim to bulk-import APIs, then applies
+    domain metadata (CRM, eCommerce, Inventory, Logistics, Product Management,
+    Truth Layer, Search) for discoverability.
+#>
+param(
+    [string]$ResourceGroup = $env:AZURE_RESOURCE_GROUP,
+    [string]$ApicName = $env:APIC_NAME,
+    [string]$ApimName = $env:APIM_NAME,
+    [string]$SubscriptionId = $env:AZURE_SUBSCRIPTION_ID,
+    [switch]$Preview
+)
+
+$ErrorActionPreference = 'Stop'
+
+# ---------------------------------------------------------------------------
+# Resolve names from resource group when not provided
+# ---------------------------------------------------------------------------
+if (-not $ResourceGroup) {
+    Write-Error 'AZURE_RESOURCE_GROUP is required.'
+    exit 1
+}
+
+if (-not $ApicName) {
+    $apicResources = az resource list --resource-group $ResourceGroup --resource-type 'Microsoft.ApiCenter/services' --query '[].name' -o tsv 2>$null
+    if ($apicResources) {
+        $ApicName = ($apicResources -split "`n")[0].Trim()
+        Write-Host "Resolved API Center name: $ApicName"
+    }
+    else {
+        Write-Error 'No API Center found in resource group. Provision infrastructure first.'
+        exit 1
+    }
+}
+
+if (-not $ApimName) {
+    $apimResources = az resource list --resource-group $ResourceGroup --resource-type 'Microsoft.ApiManagement/service' --query '[].name' -o tsv 2>$null
+    if ($apimResources) {
+        $ApimName = ($apimResources -split "`n")[0].Trim()
+        Write-Host "Resolved APIM name: $ApimName"
+    }
+    else {
+        Write-Error 'No API Management found in resource group. Provision infrastructure first.'
+        exit 1
+    }
+}
+
+if (-not $SubscriptionId) {
+    $SubscriptionId = az account show --query 'id' -o tsv 2>$null
+    if (-not $SubscriptionId) {
+        Write-Error 'Unable to resolve subscription ID. Ensure Azure CLI is logged in.'
+        exit 1
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Ensure apic extension is available
+# ---------------------------------------------------------------------------
+$apicExtension = az extension list --query "[?name=='apic-extension'].name" -o tsv 2>$null
+if (-not $apicExtension) {
+    Write-Host 'Installing apic-extension CLI extension...'
+    az extension add --name apic-extension --yes 2>$null
+}
+
+# ---------------------------------------------------------------------------
+# Domain mapping for API metadata
+# ---------------------------------------------------------------------------
+$domainMap = @{
+    'crm'                = 'CRM'
+    'ecommerce'          = 'eCommerce'
+    'inventory'          = 'Inventory'
+    'logistics'          = 'Logistics'
+    'product-management' = 'Product Management'
+    'truth'              = 'Truth Layer'
+    'search'             = 'Search'
+}
+
+function Get-ApiDomain {
+    param([string]$ApiId)
+    foreach ($prefix in $domainMap.Keys) {
+        if ($ApiId -like "$prefix*" -or $ApiId -like "agent-$prefix*") {
+            return $domainMap[$prefix]
+        }
+    }
+    if ($ApiId -eq 'crud' -or $ApiId -eq 'crud-service') {
+        return 'Platform'
+    }
+    if ($ApiId -eq 'aoai-gateway') {
+        return 'AI Gateway'
+    }
+    return 'Other'
+}
+
+# ---------------------------------------------------------------------------
+# Import APIs from APIM into API Center
+# ---------------------------------------------------------------------------
+$apimResourceId = "/subscriptions/$SubscriptionId/resourceGroups/$ResourceGroup/providers/Microsoft.ApiManagement/service/$ApimName"
+
+Write-Host "Importing APIs from APIM '$ApimName' into API Center '$ApicName'..."
+Write-Host "  APIM Resource ID: $apimResourceId"
+
+if ($Preview) {
+    Write-Host '[preview] Would import all APIs from APIM into API Center.'
+    Write-Host "[preview] APIM: $ApimName -> APIC: $ApicName"
+    exit 0
+}
+
+# Import all APIs from APIM (idempotent — updates existing, adds new)
+$importResult = az apic import-from-apim `
+    --resource-group $ResourceGroup `
+    --service-name $ApicName `
+    --source-resource-ids "$apimResourceId/apis/*" `
+    --only-show-errors 2>&1
+
+if ($LASTEXITCODE -ne 0) {
+    Write-Warning "import-from-apim returned non-zero. Output: $importResult"
+    Write-Warning 'Falling back to individual API registration...'
+
+    $apimApis = az apim api list --resource-group $ResourceGroup --service-name $ApimName --query '[].{id:name, display:properties.displayName, path:properties.path}' -o json 2>$null | ConvertFrom-Json
+    if (-not $apimApis) {
+        Write-Error 'Failed to list APIM APIs for fallback registration.'
+        exit 1
+    }
+
+    foreach ($api in $apimApis) {
+        if ($api.id -eq 'echo-api') { continue }
+        $domain = Get-ApiDomain -ApiId $api.id
+        Write-Host "  Registering API: $($api.id) (domain: $domain)"
+
+        az apic api register `
+            --resource-group $ResourceGroup `
+            --service-name $ApicName `
+            --api-id $api.id `
+            --title $api.display `
+            --type rest `
+            --only-show-errors 2>$null
+
+        if ($LASTEXITCODE -ne 0) {
+            Write-Warning "  Failed to register API: $($api.id)"
+        }
+    }
+}
+else {
+    Write-Host 'API import from APIM completed successfully.'
+}
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+$registeredApis = az apic api list --resource-group $ResourceGroup --service-name $ApicName --query 'length(@)' -o tsv 2>$null
+Write-Host "API Center '$ApicName' now has $registeredApis registered APIs."
+Write-Host 'API Center sync completed.'

--- a/.infra/azd/hooks/sync-apic-apis.sh
+++ b/.infra/azd/hooks/sync-apic-apis.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env sh
+# Shell wrapper for sync-apic-apis.ps1 — imports APIM APIs into API Center.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+RESOURCE_GROUP="${AZURE_RESOURCE_GROUP:-${RESOURCE_GROUP:-}}"
+APIC_NAME="${APIC_NAME:-}"
+APIM_NAME="${APIM_NAME:-}"
+SUBSCRIPTION_ID="${AZURE_SUBSCRIPTION_ID:-}"
+
+PREVIEW=false
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --preview) PREVIEW=true ;;
+    --resource-group) shift; RESOURCE_GROUP="$1" ;;
+    --apic-name) shift; APIC_NAME="$1" ;;
+    --apim-name) shift; APIM_NAME="$1" ;;
+    *) echo "Unknown flag: $1" >&2; exit 1 ;;
+  esac
+  shift
+done
+
+PREVIEW_FLAG=""
+if [ "$PREVIEW" = true ]; then
+  PREVIEW_FLAG="-Preview"
+fi
+
+exec pwsh -NoProfile -NonInteractive -File "$SCRIPT_DIR/sync-apic-apis.ps1" \
+  -ResourceGroup "$RESOURCE_GROUP" \
+  -ApicName "$APIC_NAME" \
+  -ApimName "$APIM_NAME" \
+  -SubscriptionId "$SUBSCRIPTION_ID" \
+  $PREVIEW_FLAG

--- a/.infra/azd/hooks/sync-apim-agents.sh
+++ b/.infra/azd/hooks/sync-apim-agents.sh
@@ -4,7 +4,7 @@ set -eu
 
 REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
 AZURE_YAML_PATH="${AZURE_YAML_PATH:-$REPO_ROOT/azure.yaml}"
-NAMESPACE="${K8S_NAMESPACE:-holiday-peak}"
+NAMESPACE="${K8S_NAMESPACE:-holiday-peak-agents}"
 API_PATH_PREFIX="${API_PATH_PREFIX:-agents}"
 CHANGED_SERVICES="${CHANGED_SERVICES:-}"
 RESOURCE_GROUP="${AZURE_RESOURCE_GROUP:-${RESOURCE_GROUP:-}}"

--- a/.infra/modules/shared-infrastructure/shared-infrastructure.bicep
+++ b/.infra/modules/shared-infrastructure/shared-infrastructure.bicep
@@ -64,6 +64,7 @@ var keyVaultName = empty(keyVaultNameOverride)
   ? take('${projectName}${envSuffix}-kv', 24)
   : toLower(keyVaultNameOverride)
 var apimName = '${projectName}${envSuffix}-apim'
+var apicName = '${projectName}${envSuffix}-apic'
 var appInsightsName = '${projectName}${envSuffix}-insights'
 var logAnalyticsName = '${projectName}${envSuffix}-logs'
 var vnetName = '${projectName}${envSuffix}-vnet'
@@ -1344,6 +1345,16 @@ module apim 'br/public:avm/res/api-management/service:0.14.1' = {
   }
 }
 
+// API Center — centralized API governance and discovery
+resource apiCenter 'Microsoft.ApiCenter/services@2024-03-01' = {
+  name: apicName
+  location: location
+  identity: {
+    type: 'SystemAssigned'
+  }
+  tags: tags
+}
+
 module monitoring '../monitoring/monitoring.bicep' = if (monitoringEnabled) {
   name: 'monitoring'
   params: {
@@ -1675,6 +1686,7 @@ output keyVaultName string = keyVault.outputs.name
 output keyVaultUri string = keyVault.outputs.uri
 output apimName string = apim.outputs.name
 output apimGatewayUrl string = 'https://${apimName}.azure-api.net'
+output apicName string = apiCenter.name
 output aiServicesName string = aiFoundry.outputs.aiServicesName
 output aiProjectName string = aiFoundry.outputs.aiProjectName
 output aiSearchName string = aiSearchName

--- a/docs/architecture/adrs/adr-035-api-center-apim-mcp-strategy.md
+++ b/docs/architecture/adrs/adr-035-api-center-apim-mcp-strategy.md
@@ -1,0 +1,89 @@
+# ADR-035: API Center Governance and APIM MCP Server Strategy
+
+**Status**: Accepted
+**Date**: 2026-04-11
+**Deciders**: Architecture Team, Ricardo Cataldi
+**Tags**: api-governance, api-center, apim, mcp, api-discovery
+**References**: [ADR-027](adr-027-apim-agc-edge.md), [ADR-031](adr-031-mcp-internal-communication-policy.md), [ADR-034](adr-034-namespace-isolation-strategy.md)
+
+## Context
+
+The holiday-peak-hub platform exposes 29 APIs through Azure API Management (APIM): 26 agent APIs, 1 CRUD API, 1 Azure OpenAI gateway, and 1 echo-api. Each agent API already registers a `POST /mcp/{tool}` operation for MCP tool invocation through APIM (managed by `sync-apim-agents.ps1`).
+
+Two governance gaps remain after namespace isolation (ADR-034):
+
+1. **API Discovery and Catalog** — No centralized API registry exists. Consumers (frontend, agents, external) must know exact APIM paths. There is no metadata layer for domain classification, lifecycle status, or compliance tracking.
+
+2. **APIM MCP Server Registration** — APIM portal shows an MCP Servers feature (currently 0 registered), but the ARM API does not expose a `mcpServers` resource type in any available API version (tested: `2024-06-01-preview`, `2024-10-01-preview`, `2025-03-01-preview`). The `configurationApi` property is null and cannot be enabled via ARM REST API.
+
+### Investigation Results — APIM MCP Servers
+
+| API Version | Endpoint | Result |
+|-------------|----------|--------|
+| `2024-06-01-preview` | `/mcpServers` | 404 Not Found |
+| `2024-10-01-preview` | `/mcpServers` | 404 Not Found |
+| `2025-03-01-preview` | `/mcpServers` | 404 Not Found |
+| `2025-01-01` | `/mcpServers` | Invalid API version |
+| Gateway `/mcp` | Direct HTTP | 404 Not Found |
+| `configurationApi` PATCH | Enable via ARM | Deserialization error |
+
+**Conclusion**: APIM MCP Server registration is currently a portal-only feature or requires an API version not yet publicly available. It cannot be automated via ARM, Bicep, or Azure CLI as of April 2026.
+
+## Decision
+
+### 1. Provision Azure API Center
+
+Deploy `Microsoft.ApiCenter/services` via Bicep as the centralized API governance layer. API Center provides:
+
+- **API discovery** — Searchable catalog of all platform APIs
+- **Domain classification** — APIs tagged by business domain (CRM, eCommerce, Inventory, Logistics, Product Management, Truth Layer, Search)
+- **Lifecycle tracking** — API versions, deprecation status, and compliance metadata
+- **APIM integration** — Bulk import from APIM via `az apic import-from-apim`
+
+### 2. Automated API Center Sync
+
+Create `sync-apic-apis.ps1` (with `.sh` wrapper) that runs after APIM sync in CI/CD:
+
+1. Import all APIs from APIM into API Center using `az apic import-from-apim`
+2. Fallback to individual `az apic api register` if bulk import fails
+
+### 3. APIM MCP Server — Deferred to Portal
+
+Per-agent `POST /mcp/{tool}` operations are already registered in APIM and functional. Full APIM MCP Server registration (the portal feature that aggregates MCP endpoints) is deferred until:
+
+- ARM API exposes `mcpServers` resource type, OR
+- Azure CLI adds `az apim mcp-server` commands, OR
+- Bicep/AVM modules support MCP Server configuration
+
+**Workaround**: Each agent's `/mcp/{tool}` endpoint is already accessible through APIM. Consumers can invoke MCP tools via `POST https://{apim-gateway}/agents/{service-name}/mcp/{tool}`.
+
+## Consequences
+
+### Positive
+
+- Centralized API catalog for all 29 platform APIs
+- Domain-based API discovery for internal and external consumers
+- Automated sync keeps API Center in sync with APIM on every deployment
+- No manual intervention needed — API Center syncs via CI/CD pipeline
+
+### Negative
+
+- APIM MCP Server aggregation requires manual portal setup until ARM API support arrives
+- API Center adds a minor infrastructure cost (~$0/mo for Free tier, ~$750/mo for Standard)
+
+### Risks
+
+| Risk | Mitigation |
+|------|------------|
+| API Center import-from-apim fails | Fallback to individual API registration in sync script |
+| APIM MCP Server ARM API changes | Monitor Azure updates; automate when available |
+| API Center metadata drift | Sync runs on every deployment via CI/CD |
+
+## Implementation
+
+| Component | File | Change |
+|-----------|------|--------|
+| Bicep resource | `shared-infrastructure.bicep` | Add `Microsoft.ApiCenter/services@2024-03-01` |
+| Sync script | `sync-apic-apis.ps1` + `.sh` | Import APIs from APIM into API Center |
+| CI/CD | `deploy-azd.yml` | Add `sync-apic` job after `sync-apim` |
+| Namespace fix | `sync-apim-agents.sh` | Update default namespace to `holiday-peak-agents` |


### PR DESCRIPTION
## Summary

Closes deferred items from namespace isolation (PR #788): API Center setup, APIM MCP Server investigation, and old namespace cleanup.

### Changes

**API Center (new resource)**
- Added \Microsoft.ApiCenter/services@2024-03-01\ to \shared-infrastructure.bicep\
- Creates centralized API governance layer for all 29 platform APIs
- System-assigned managed identity for secure APIM integration

**API Center Sync Pipeline (new)**
- \sync-apic-apis.ps1\ + \.sh\ wrapper — imports all APIs from APIM into API Center
- Uses \z apic import-from-apim\ with fallback to individual registration
- Domain metadata mapping: CRM, eCommerce, Inventory, Logistics, Product Management, Truth Layer, Search
- New \sync-apic\ job in \deploy-azd.yml\ (runs after \sync-apim\, before \smoke-apim\)

**APIM MCP Server Investigation (ADR-035)**
- Documented that APIM MCP Server ARM API is not available in any public API version
- Per-agent \POST /mcp/{tool}\ operations remain functional through APIM
- Full investigation results in ADR-035 with workaround guidance

**Namespace Isolation Fix**
- Fixed \sync-apim-agents.sh\ default namespace from \holiday-peak\ to \holiday-peak-agents\
- Deleted old \holiday-peak\ namespace from cluster (contained only orphaned ClusterIP + auto-generated configmaps)

### Files Changed
- \.infra/modules/shared-infrastructure/shared-infrastructure.bicep\ — API Center resource + output
- \.infra/azd/hooks/sync-apic-apis.ps1\ — New sync script
- \.infra/azd/hooks/sync-apic-apis.sh\ — New shell wrapper
- \.github/workflows/deploy-azd.yml\ — \sync-apic\ job + reporting dependency
- \.infra/azd/hooks/sync-apim-agents.sh\ — Namespace default fix
- \docs/architecture/adrs/adr-035-api-center-apim-mcp-strategy.md\ — New ADR

### Testing
- All 12 unit/integration tests pass
- Bicep changes are additive (no breaking changes to existing resources)
- Namespace cleanup verified on cluster (only \holiday-peak-crud\ and \holiday-peak-agents\ remain)