### PR TITLE
fix: set MODEL_DEPLOYMENT_NAME_RICH to gpt-5 in deploy workflow

### DIFF
--- a/.github/workflows/deploy-azd.yml
+++ b/.github/workflows/deploy-azd.yml
@@ -1589,7 +1589,7 @@ jobs:
           PROJECT_ENDPOINT: ${{ needs.provision.outputs.PROJECT_ENDPOINT }}
           PROJECT_NAME: ${{ needs.provision.outputs.PROJECT_NAME }}
           MODEL_DEPLOYMENT_NAME_FAST: gpt-5-nano
-          MODEL_DEPLOYMENT_NAME_RICH: gpt-5-nano
+          MODEL_DEPLOYMENT_NAME_RICH: gpt-5
           POSTGRES_AUTH_MODE: ${{ needs.provision.outputs.POSTGRES_AUTH_MODE }}
           COSMOS_ACCOUNT_URI: ${{ needs.provision.outputs.COSMOS_ACCOUNT_URI }}
           COSMOS_DATABASE: ${{ needs.provision.outputs.COSMOS_DATABASE }}
@@ -2274,7 +2274,7 @@ jobs:
           FOUNDRY_AUTO_ENSURE_ON_STARTUP: ${{ env.FOUNDRY_RUNTIME_AUTO_ENSURE_ON_STARTUP }}
           FOUNDRY_STRICT_ENFORCEMENT: ${{ env.FOUNDRY_RUNTIME_STRICT_ENFORCEMENT }}
           MODEL_DEPLOYMENT_NAME_FAST: gpt-5-nano
-          MODEL_DEPLOYMENT_NAME_RICH: gpt-5-nano
+          MODEL_DEPLOYMENT_NAME_RICH: gpt-5
           POSTGRES_AUTH_MODE: ${{ needs.provision.outputs.POSTGRES_AUTH_MODE }}
           COSMOS_ACCOUNT_URI: ${{ needs.provision.outputs.COSMOS_ACCOUNT_URI }}
           COSMOS_DATABASE: ${{ needs.provision.outputs.COSMOS_DATABASE }}


### PR DESCRIPTION
## Summary

Sets \MODEL_DEPLOYMENT_NAME_RICH\ from \gpt-5-nano\ to \gpt-5\ in both \deploy-crud\ and \deploy-agents\ jobs.

### Changes
- Line 1592: \MODEL_DEPLOYMENT_NAME_RICH: gpt-5-nano\ → \gpt-5\
- Line 2277: \MODEL_DEPLOYMENT_NAME_RICH: gpt-5-nano\ → \gpt-5\

### Validation
- \MODEL_DEPLOYMENT_NAME_FAST\ remains \gpt-5-nano\ (unchanged)
- No remaining \gpt-5-nano\ rich-model assignments in the workflow
- Single file change, isolated scope

Closes #778