### PR TITLE
chore: add explicit contents:write permission to commit-rendered-manifests job

### DIFF
--- a/.github/workflows/deploy-azd.yml
+++ b/.github/workflows/deploy-azd.yml
@@ -2306,6 +2306,8 @@ jobs:
       - deploy-crud
       - deploy-agents
       - build-aks-images
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

Adds an explicit `permissions: contents: write` block to the `commit-rendered-manifests` job in the deploy workflow. This job pushes rendered Kubernetes manifests to `main` for Flux reconciliation.

### Changes
- Added job-level `permissions: contents: write` to `commit-rendered-manifests` (previously inherited from workflow-level)

### Admin Action Required

The `main-governance-baseline` ruleset (ID: `14638366`) currently has **no bypass actors**. For the `commit-rendered-manifests` job to push directly to `main`, a repo admin must add `github-actions[bot]` as a bypass actor.

This can be done via **Settings > Rules > main-governance-baseline > Bypass list > Add bypass > GitHub Actions**.

### Security Assessment
- Only `github-actions[bot]` commits with `[skip ci]` message
- Only `.kubernetes/rendered/` files are committed
- `GITHUB_TOKEN` scope is limited to the repository
- Path filters in `test.yml` and `lint.yml` prevent CI cascade

Closes #784
