### PR TITLE
fix: CRUD_SERVICE_URL port 8000 to 80 for all agent deployments

### DIFF
--- a/.github/prompts/fix-issues-pipeline.prompt.md
+++ b/.github/prompts/fix-issues-pipeline.prompt.md
@@ -1,0 +1,95 @@
+---
+name: "Fix Issues Pipeline"
+description: "End-to-end issue fix pipeline: deep investigation with specialist agents, GitHub issue creation, branch + PR workflow, merge monitoring, and cleanup."
+agent: "TechLeadOrchestrator"
+argument-hint: "Describe the problem: symptoms, error messages, affected components, reproduction steps, and any logs or screenshots."
+---
+
+Run the full fix-issues pipeline for the described problem:
+
+## Phase 1 — Deep Investigation
+
+1. **Symptom Analysis** — Restate the problem clearly. Identify affected components, user impact, and severity.
+
+2. **Hypothesis Formation** — List the top 3 most likely root causes ranked by probability.
+
+3. **Evidence Gathering** — For each hypothesis, invoke the appropriate specialist via `#runSubagent`:
+   - `PlatformEngineer` — CI/CD failures, infrastructure, environment, dependency, and deployment issues (invoke first for platform-related symptoms)
+   - `PythonDeveloper` — Python stack traces, async bugs, type errors, test failures
+   - `RustDeveloper` — Rust panics, ownership issues, compilation failures
+   - `TypeScriptDeveloper` — TypeScript type errors, React rendering, bundle or build issues
+   - `SystemArchitect` — cross-service integration failures, architectural mismatches, data flow issues
+   - `UIDesigner` — UI rendering, accessibility regressions, layout/styling issues
+
+4. **Root Cause Isolation** — Narrow to the confirmed root cause. Document the full causal chain with file/function evidence.
+
+5. **Fix Design** — Decompose the fix into agent-assignable tasks with clear scope, acceptance criteria, and dependencies.
+
+## Phase 2 — GitHub Issue Creation
+
+6. **Open a GitHub Issue** describing the confirmed problem:
+   - **Title**: concise summary of the root cause
+   - **Body** must include:
+     - Problem statement with evidence from Phase 1
+     - Root cause analysis summary
+     - Acceptance criteria checklist (each criterion independently verifiable)
+     - Affected files and components
+     - Risks and dependencies
+   - Apply appropriate labels (e.g., `bug`, `fix`, affected service names)
+
+## Phase 3 — Branch, Implement, and PR
+
+7. **Create a Fix Branch** from `main`:
+   - Follow repository branch naming convention: `bug/<issue-number>-<short-description>`
+   - Keep the branch scoped exclusively to the issue
+
+8. **Implement the Fix** — Delegate each sub-task to the appropriate specialist via `#runSubagent`:
+   - `PlatformEngineer` for CI/CD, infra, or environment fixes
+   - `PythonDeveloper` for Python code and test fixes
+   - `RustDeveloper` for Rust code fixes
+   - `TypeScriptDeveloper` for TypeScript/React fixes
+   - `UIDesigner` for UI/accessibility fixes
+   - Ensure every change includes or updates unit and integration tests
+   - Run tests locally to confirm the fix before committing
+
+9. **Commit and Push** — Stage, commit with a descriptive message referencing the issue (`Fixes #<number>`), and push the branch.
+
+10. **Open a Pull Request** targeting `main`:
+    - Title references the issue number
+    - Description links back to the issue and summarizes changes
+    - Include verification evidence (test results, before/after comparison)
+
+## Phase 4 — Validation and Merge
+
+11. **PR Validation** — Monitor CI checks and review feedback:
+    - If checks fail, diagnose and apply fixes in the same branch
+    - Re-push and re-validate until all checks pass
+    - Invoke `PlatformEngineer` via `#runSubagent` for CI/infrastructure failures
+
+12. **Merge to Main** — Once all checks pass and the PR is approved, merge using the repository merge strategy.
+
+13. **Post-Merge Monitoring** — Watch post-merge workflows and deployments:
+    - If regressions appear, open follow-up fixes in the same pipeline
+    - Confirm the fix is live and the original problem is resolved
+
+## Phase 5 — Cleanup
+
+14. **Close the Issue** — Close the GitHub issue with merge evidence (PR link, commit SHA).
+
+15. **Delete the Remote Branch** — Remove the merged fix branch from the remote.
+
+16. **Local Cleanup** — Switch to `main`, pull latest, delete the local branch, and confirm `git status` is clean.
+
+## Delivery
+
+Produce a final execution report containing:
+
+| Section | Content |
+|---------|---------|
+| **Root Cause** | Confirmed cause with evidence chain |
+| **Issue** | GitHub issue number and link |
+| **Branch** | Branch name used |
+| **PR** | PR number, link, and merge status |
+| **Tests** | Test results and coverage evidence |
+| **Monitoring** | Post-merge workflow/deployment status |
+| **Cleanup** | Branch deletion and issue closure confirmation |

--- a/.infra/azd/hooks/render-helm.ps1
+++ b/.infra/azd/hooks/render-helm.ps1
@@ -397,7 +397,7 @@ if ($ServiceName -ne "crud-service") {
   $crudNs = if ($env:K8S_CRUD_NAMESPACE) { $env:K8S_CRUD_NAMESPACE }
             elseif ($env:K8S_NAMESPACE) { $env:K8S_NAMESPACE }
             else { "holiday-peak-crud" }
-  $defaultCrudUrl = "http://crud-service-crud-service.${crudNs}.svc.cluster.local:8000"
+  $defaultCrudUrl = "http://crud-service-crud-service.${crudNs}.svc.cluster.local:80"
   $envMappings["CRUD_SERVICE_URL"] = if ($env:CRUD_SERVICE_URL) { $env:CRUD_SERVICE_URL } else { $defaultCrudUrl }
 }
 

--- a/.infra/azd/hooks/render-helm.sh
+++ b/.infra/azd/hooks/render-helm.sh
@@ -419,7 +419,7 @@ add_env_arg "APPLICATIONINSIGHTS_CONNECTION_STRING" "${APPLICATIONINSIGHTS_CONNE
 # Cross-namespace CRUD service URL for agent→CRUD communication (ADR-034)
 if is_agent_service; then
   CRUD_NS="${K8S_CRUD_NAMESPACE:-${K8S_NAMESPACE:-holiday-peak-crud}}"
-  add_env_arg "CRUD_SERVICE_URL" "${CRUD_SERVICE_URL:-http://crud-service-crud-service.${CRUD_NS}.svc.cluster.local:8000}"
+  add_env_arg "CRUD_SERVICE_URL" "${CRUD_SERVICE_URL:-http://crud-service-crud-service.${CRUD_NS}.svc.cluster.local:80}"
 fi
 
 if [ "$SERVICE_NAME" = "ecommerce-catalog-search" ]; then

--- a/.kubernetes/rendered/crm-campaign-intelligence/all.yaml
+++ b/.kubernetes/rendered/crm-campaign-intelligence/all.yaml
@@ -1,4 +1,4 @@
-﻿---
+---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -94,7 +94,7 @@ spec:
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
             - name: CRUD_SERVICE_URL
-              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
+              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:80"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: EVENT_HUB_NAMESPACE

--- a/.kubernetes/rendered/crm-profile-aggregation/all.yaml
+++ b/.kubernetes/rendered/crm-profile-aggregation/all.yaml
@@ -1,4 +1,4 @@
-﻿---
+---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -94,7 +94,7 @@ spec:
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
             - name: CRUD_SERVICE_URL
-              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
+              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:80"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: EVENT_HUB_NAMESPACE

--- a/.kubernetes/rendered/crm-segmentation-personalization/all.yaml
+++ b/.kubernetes/rendered/crm-segmentation-personalization/all.yaml
@@ -1,4 +1,4 @@
-﻿---
+---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -94,7 +94,7 @@ spec:
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
             - name: CRUD_SERVICE_URL
-              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
+              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:80"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: EVENT_HUB_NAMESPACE

--- a/.kubernetes/rendered/crm-support-assistance/all.yaml
+++ b/.kubernetes/rendered/crm-support-assistance/all.yaml
@@ -1,4 +1,4 @@
-﻿---
+---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -94,7 +94,7 @@ spec:
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
             - name: CRUD_SERVICE_URL
-              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
+              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:80"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: EVENT_HUB_NAMESPACE

--- a/.kubernetes/rendered/crud-service/all.yaml
+++ b/.kubernetes/rendered/crud-service/all.yaml
@@ -1,4 +1,4 @@
-﻿---
+---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -115,6 +115,8 @@ spec:
               value: "holiday_peak_crud"
             - name: POSTGRES_HOST
               value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
+            - name: POSTGRES_PORT
+              value: "5432"
             - name: POSTGRES_SSL
               value: "true"
             - name: POSTGRES_USER
@@ -158,3 +160,64 @@ spec:
             requests:
               cpu: 250m
               memory: 256Mi
+---
+# Source: holiday-peak-service/templates/agc-routing.yaml
+apiVersion: alb.networking.azure.io/v1
+kind: ApplicationLoadBalancer
+metadata:
+  name: holiday-peak-agc
+  namespace: holiday-peak-crud
+  labels:
+    app: crud-service
+spec:
+  associations:
+    - "/subscriptions/150e82e8-25db-4f1a-8e04-a2f6a77d26c4/resourceGroups/holidaypeakhub405-dev-rg/providers/Microsoft.Network/virtualNetworks/holidaypeakhub405-dev-vnet/subnets/agc"
+---
+# Source: holiday-peak-service/templates/agc-routing.yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: holiday-peak-agc
+  namespace: holiday-peak-crud
+  labels:
+    app: crud-service
+spec:
+  gatewayClassName: "azure-alb-external"
+  listeners:
+    - name: "http"
+      protocol: "HTTP"
+      port: 80
+      hostname: "e3g0avgfauc3e4cp.fz87.alb.azure.com"
+      allowedRoutes:
+        namespaces:
+          from: Same
+---
+# Source: holiday-peak-service/templates/agc-routing.yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: crud-service-crud-service-agc
+  namespace: holiday-peak-crud
+  labels:
+    app: crud-service
+spec:
+  parentRefs:
+    - name: "holiday-peak-agc"
+      namespace: "holiday-peak-crud"
+  hostnames:
+    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/health"
+      backendRefs:
+        - name: crud-service-crud-service
+          port: 80
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/api"
+      backendRefs:
+        - name: crud-service-crud-service
+          port: 80

--- a/.kubernetes/rendered/ecommerce-cart-intelligence/all.yaml
+++ b/.kubernetes/rendered/ecommerce-cart-intelligence/all.yaml
@@ -1,4 +1,4 @@
-﻿---
+---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -94,7 +94,7 @@ spec:
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
             - name: CRUD_SERVICE_URL
-              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
+              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:80"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: EVENT_HUB_NAMESPACE

--- a/.kubernetes/rendered/ecommerce-catalog-search/all.yaml
+++ b/.kubernetes/rendered/ecommerce-catalog-search/all.yaml
@@ -1,4 +1,4 @@
-﻿---
+---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -94,7 +94,7 @@ spec:
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
             - name: CRUD_SERVICE_URL
-              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
+              value: "https://holidaypeakhub405-dev-apim.azure-api.net"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: EVENT_HUB_NAMESPACE
@@ -121,6 +121,8 @@ spec:
               value: "holiday_peak_crud"
             - name: POSTGRES_HOST
               value: "holidaypeakhub405-dev-postgres.postgres.database.azure.com"
+            - name: POSTGRES_PORT
+              value: "5432"
             - name: POSTGRES_SSL
               value: "true"
             - name: POSTGRES_USER
@@ -168,3 +170,32 @@ spec:
             requests:
               cpu: 250m
               memory: 256Mi
+---
+# Source: holiday-peak-service/templates/agc-routing.yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ecommerce-catalog-search-ecommerce-catalog-search-agc
+  namespace: holiday-peak-agents
+  labels:
+    app: ecommerce-catalog-search
+spec:
+  parentRefs:
+    - name: "holiday-peak-agc"
+      namespace: "holiday-peak-agents"
+  hostnames:
+    - "e3g0avgfauc3e4cp.fz87.alb.azure.com"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/ecommerce-catalog-search"
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: "/"
+      backendRefs:
+        - name: ecommerce-catalog-search-ecommerce-catalog-search
+          port: 80

--- a/.kubernetes/rendered/ecommerce-checkout-support/all.yaml
+++ b/.kubernetes/rendered/ecommerce-checkout-support/all.yaml
@@ -1,4 +1,4 @@
-﻿---
+---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -94,7 +94,7 @@ spec:
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
             - name: CRUD_SERVICE_URL
-              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
+              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:80"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: EVENT_HUB_NAMESPACE

--- a/.kubernetes/rendered/ecommerce-order-status/all.yaml
+++ b/.kubernetes/rendered/ecommerce-order-status/all.yaml
@@ -1,4 +1,4 @@
-﻿---
+---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -94,7 +94,7 @@ spec:
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
             - name: CRUD_SERVICE_URL
-              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
+              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:80"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: EVENT_HUB_NAMESPACE

--- a/.kubernetes/rendered/ecommerce-product-detail-enrichment/all.yaml
+++ b/.kubernetes/rendered/ecommerce-product-detail-enrichment/all.yaml
@@ -1,4 +1,4 @@
-﻿---
+---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -94,7 +94,7 @@ spec:
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
             - name: CRUD_SERVICE_URL
-              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
+              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:80"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: EVENT_HUB_NAMESPACE

--- a/.kubernetes/rendered/inventory-alerts-triggers/all.yaml
+++ b/.kubernetes/rendered/inventory-alerts-triggers/all.yaml
@@ -1,4 +1,4 @@
-﻿---
+---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -94,7 +94,7 @@ spec:
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
             - name: CRUD_SERVICE_URL
-              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
+              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:80"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: EVENT_HUB_NAMESPACE

--- a/.kubernetes/rendered/inventory-health-check/all.yaml
+++ b/.kubernetes/rendered/inventory-health-check/all.yaml
@@ -1,4 +1,4 @@
-﻿---
+---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -94,7 +94,7 @@ spec:
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
             - name: CRUD_SERVICE_URL
-              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
+              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:80"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: EVENT_HUB_NAMESPACE

--- a/.kubernetes/rendered/inventory-jit-replenishment/all.yaml
+++ b/.kubernetes/rendered/inventory-jit-replenishment/all.yaml
@@ -1,4 +1,4 @@
-﻿---
+---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -94,7 +94,7 @@ spec:
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
             - name: CRUD_SERVICE_URL
-              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
+              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:80"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: EVENT_HUB_NAMESPACE

--- a/.kubernetes/rendered/inventory-reservation-validation/all.yaml
+++ b/.kubernetes/rendered/inventory-reservation-validation/all.yaml
@@ -1,4 +1,4 @@
-﻿---
+---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -94,7 +94,7 @@ spec:
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
             - name: CRUD_SERVICE_URL
-              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
+              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:80"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: EVENT_HUB_NAMESPACE

--- a/.kubernetes/rendered/logistics-carrier-selection/all.yaml
+++ b/.kubernetes/rendered/logistics-carrier-selection/all.yaml
@@ -1,4 +1,4 @@
-﻿---
+---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -94,7 +94,7 @@ spec:
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
             - name: CRUD_SERVICE_URL
-              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
+              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:80"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: EVENT_HUB_NAMESPACE

--- a/.kubernetes/rendered/logistics-eta-computation/all.yaml
+++ b/.kubernetes/rendered/logistics-eta-computation/all.yaml
@@ -1,4 +1,4 @@
-﻿---
+---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -94,7 +94,7 @@ spec:
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
             - name: CRUD_SERVICE_URL
-              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
+              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:80"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: EVENT_HUB_NAMESPACE

--- a/.kubernetes/rendered/logistics-returns-support/all.yaml
+++ b/.kubernetes/rendered/logistics-returns-support/all.yaml
@@ -1,4 +1,4 @@
-﻿---
+---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -94,7 +94,7 @@ spec:
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
             - name: CRUD_SERVICE_URL
-              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
+              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:80"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: EVENT_HUB_NAMESPACE

--- a/.kubernetes/rendered/logistics-route-issue-detection/all.yaml
+++ b/.kubernetes/rendered/logistics-route-issue-detection/all.yaml
@@ -1,4 +1,4 @@
-﻿---
+---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -94,7 +94,7 @@ spec:
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
             - name: CRUD_SERVICE_URL
-              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
+              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:80"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: EVENT_HUB_NAMESPACE

--- a/.kubernetes/rendered/product-management-acp-transformation/all.yaml
+++ b/.kubernetes/rendered/product-management-acp-transformation/all.yaml
@@ -1,4 +1,4 @@
-﻿---
+---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -94,7 +94,7 @@ spec:
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
             - name: CRUD_SERVICE_URL
-              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
+              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:80"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: EVENT_HUB_NAMESPACE

--- a/.kubernetes/rendered/product-management-assortment-optimization/all.yaml
+++ b/.kubernetes/rendered/product-management-assortment-optimization/all.yaml
@@ -1,4 +1,4 @@
-﻿---
+---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -94,7 +94,7 @@ spec:
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
             - name: CRUD_SERVICE_URL
-              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
+              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:80"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: EVENT_HUB_NAMESPACE

--- a/.kubernetes/rendered/product-management-consistency-validation/all.yaml
+++ b/.kubernetes/rendered/product-management-consistency-validation/all.yaml
@@ -1,4 +1,4 @@
-﻿---
+---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -94,7 +94,7 @@ spec:
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
             - name: CRUD_SERVICE_URL
-              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
+              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:80"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: FOUNDRY_AGENT_NAME_FAST

--- a/.kubernetes/rendered/product-management-normalization-classification/all.yaml
+++ b/.kubernetes/rendered/product-management-normalization-classification/all.yaml
@@ -1,4 +1,4 @@
-﻿---
+---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -94,7 +94,7 @@ spec:
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
             - name: CRUD_SERVICE_URL
-              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
+              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:80"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: EVENT_HUB_NAMESPACE

--- a/.kubernetes/rendered/search-enrichment-agent/all.yaml
+++ b/.kubernetes/rendered/search-enrichment-agent/all.yaml
@@ -1,4 +1,4 @@
-﻿---
+---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -94,7 +94,7 @@ spec:
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
             - name: CRUD_SERVICE_URL
-              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
+              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:80"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: FOUNDRY_AGENT_NAME_FAST

--- a/.kubernetes/rendered/truth-enrichment/all.yaml
+++ b/.kubernetes/rendered/truth-enrichment/all.yaml
@@ -1,4 +1,4 @@
-﻿---
+---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -94,7 +94,7 @@ spec:
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
             - name: CRUD_SERVICE_URL
-              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
+              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:80"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: FOUNDRY_AGENT_NAME_FAST

--- a/.kubernetes/rendered/truth-export/all.yaml
+++ b/.kubernetes/rendered/truth-export/all.yaml
@@ -1,4 +1,4 @@
-﻿---
+---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -102,7 +102,7 @@ spec:
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
             - name: CRUD_SERVICE_URL
-              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
+              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:80"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: FOUNDRY_AGENT_NAME_FAST

--- a/.kubernetes/rendered/truth-hitl/all.yaml
+++ b/.kubernetes/rendered/truth-hitl/all.yaml
@@ -1,4 +1,4 @@
-﻿---
+---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -94,7 +94,7 @@ spec:
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
             - name: CRUD_SERVICE_URL
-              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
+              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:80"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: FOUNDRY_AGENT_NAME_FAST

--- a/.kubernetes/rendered/truth-ingestion/all.yaml
+++ b/.kubernetes/rendered/truth-ingestion/all.yaml
@@ -1,4 +1,4 @@
-﻿---
+---
 # Source: holiday-peak-service/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -97,7 +97,7 @@ spec:
             - name: COSMOS_DATABASE
               value: "holiday-peak-db"
             - name: CRUD_SERVICE_URL
-              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000"
+              value: "http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:80"
             - name: EMBEDDING_DEPLOYMENT_NAME
               value: "text-embedding-3-large"
             - name: FOUNDRY_AGENT_NAME_FAST


### PR DESCRIPTION
Fix CRUD_SERVICE_URL port from 8000 (pod) to 80 (K8s service). Root cause: render-helm scripts generated wrong port. Flux reverted live patches. Post-merge: resume Flux kustomization.