### PR TITLE
perf: parallelize memory reads/writes, add memory tools and gather_adapters (#799)

### DIFF
--- a/lib/src/holiday_peak_lib/agents/base_agent.py
+++ b/lib/src/holiday_peak_lib/agents/base_agent.py
@@ -1,5 +1,6 @@
 """Base agent abstraction with model selection and SDK integration points."""
 
+import asyncio
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from time import perf_counter
@@ -259,6 +260,44 @@ class BaseRetailAgent(BaseAgent, ABC):
 
     def attach_self_healing(self, self_healing_kernel: Any) -> None:
         self.self_healing_kernel = self_healing_kernel
+
+    def memory_tool_definitions(self) -> dict[str, Callable[..., Any]]:
+        """Return memory read/write as LLM-callable tool definitions.
+
+        These tools allow the model to manage session/conversation memory
+        directly, enabling a 'check memory first' strategy before deeper searches.
+        """
+        tools: dict[str, Callable[..., Any]] = {}
+        if self.memory_client is None:
+            return tools
+
+        async def memory_read(key: str) -> Any:
+            """Read a value from the agent's tiered memory by key."""
+            return await self.memory_client.get(key)
+
+        async def memory_write(key: str, value: Any) -> str:
+            """Write a value to the agent's tiered memory."""
+            await self.memory_client.set(key, value)
+            return "stored"
+
+        tools["memory_read"] = memory_read
+        tools["memory_write"] = memory_write
+        return tools
+
+    @staticmethod
+    async def gather_adapters(*coros: Awaitable[Any]) -> tuple[Any, ...]:
+        """Execute multiple adapter/MCP coroutines in parallel.
+
+        Provides a framework-level entry point so agents can dispatch
+        concurrent adapter and MCP calls without manually importing asyncio::
+
+            product, pricing, inventory = await self.gather_adapters(
+                self.adapters.products.build_product_context(sku),
+                self.adapters.pricing.build_price_context(sku),
+                self.adapters.inventory.build_inventory_context(sku),
+            )
+        """
+        return await asyncio.gather(*coros)
 
     def _get_foundry_tracer(self):
         service = self.service_name or type(self).__name__

--- a/lib/src/holiday_peak_lib/agents/memory/builder.py
+++ b/lib/src/holiday_peak_lib/agents/memory/builder.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from dataclasses import dataclass
 from typing import Any
@@ -40,44 +41,71 @@ class MemoryClient:
         self.rules = rules or MemoryRules()
 
     async def get(self, key: str) -> Any:
-        if self.hot:
-            value = await self.hot.get(key)
-            if value is not None:
-                return value
-
-        if not self.rules.read_fallback:
-            return None
-
-        if self.warm:
-            doc = await self.warm.read(item_id=key, partition_key=key)
-            if doc is not None:
-                value = doc.get("value", doc)
-                if self.promote_to_hot() and self.hot:
+        # Parallel hot + warm when both available
+        if self.hot and self.warm and self.rules.read_fallback:
+            hot_value, warm_doc = await asyncio.gather(
+                self.hot.get(key),
+                self.warm.read(item_id=key, partition_key=key),
+            )
+            if hot_value is not None:
+                return hot_value
+            if warm_doc is not None:
+                value = warm_doc.get("value", warm_doc)
+                if self.promote_to_hot():
                     await self.hot.set(key, value, ttl_seconds=self.rules.hot_ttl_seconds or 900)
                 return value
+        else:
+            # Single-tier fast path
+            if self.hot:
+                value = await self.hot.get(key)
+                if value is not None:
+                    return value
+            if not self.rules.read_fallback:
+                return None
+            if self.warm:
+                doc = await self.warm.read(item_id=key, partition_key=key)
+                if doc is not None:
+                    value = doc.get("value", doc)
+                    if self.promote_to_hot() and self.hot:
+                        await self.hot.set(
+                            key, value, ttl_seconds=self.rules.hot_ttl_seconds or 900
+                        )
+                    return value
 
+        # Cold fallback (sequential — archival tier, rarely hit)
         if self.cold:
             blob = await self.cold.download_text(key)
             if blob is None:
                 return None
             value = blob.decode("utf-8") if isinstance(blob, (bytes, bytearray)) else blob
+            # Parallel promotion from cold to hot + warm
+            promotion_tasks = []
             if self.promote_to_hot() and self.hot:
-                await self.hot.set(key, value, ttl_seconds=self.rules.hot_ttl_seconds or 900)
+                promotion_tasks.append(
+                    self.hot.set(key, value, ttl_seconds=self.rules.hot_ttl_seconds or 900)
+                )
             if self.promote_to_warm() and self.warm:
-                await self.warm.upsert(self._warm_item(key, value, ttl=self.rules.warm_ttl_seconds))
+                promotion_tasks.append(
+                    self.warm.upsert(self._warm_item(key, value, ttl=self.rules.warm_ttl_seconds))
+                )
+            if promotion_tasks:
+                await asyncio.gather(*promotion_tasks)
             return value
         return None
 
     async def set(self, key: str, value: Any) -> None:
+        tasks: list[Any] = []
         if self.hot:
-            await self.hot.set(key, value, ttl_seconds=self.rules.hot_ttl_seconds or 900)
-
+            tasks.append(self.hot.set(key, value, ttl_seconds=self.rules.hot_ttl_seconds or 900))
         if self.rules.write_through and self.warm:
-            await self.warm.upsert(self._warm_item(key, value, ttl=self.rules.warm_ttl_seconds))
-
+            tasks.append(
+                self.warm.upsert(self._warm_item(key, value, ttl=self.rules.warm_ttl_seconds))
+            )
         if self.rules.write_cold and self.cold:
             payload = value if isinstance(value, str) else json.dumps(value)
-            await self.cold.upload_text(key, payload)
+            tasks.append(self.cold.upload_text(key, payload))
+        if tasks:
+            await asyncio.gather(*tasks)
 
     def promote_to_hot(self) -> bool:
         return self.rules.promote_on_read and self.hot is not None

--- a/lib/tests/test_memory_builder.py
+++ b/lib/tests/test_memory_builder.py
@@ -96,3 +96,119 @@ async def test_memory_client_set_writes_through_and_to_cold_when_enabled() -> No
         {"id": "k3", "pk": "k3", "value": {"status": "ok"}, "ttl": 600}
     )
     cold.upload_text.assert_awaited_once_with("k3", '{"status": "ok"}')
+
+
+@pytest.mark.asyncio
+async def test_memory_client_parallel_hot_warm_read_hot_wins() -> None:
+    """When both hot and warm return values, hot value takes precedence."""
+    hot = AsyncMock()
+    hot.get = AsyncMock(return_value="hot-data")
+    warm = AsyncMock()
+    warm.read = AsyncMock(return_value={"id": "k", "value": "warm-data"})
+
+    client = MemoryBuilder().with_hot(hot).with_warm(warm).build()
+    value = await client.get("k")
+
+    assert value == "hot-data"
+    # Hot hit means no promotion needed
+    hot.set.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_memory_client_parallel_writes() -> None:
+    """Set should dispatch all tier writes concurrently."""
+    hot = AsyncMock()
+    warm = AsyncMock()
+    cold = AsyncMock()
+
+    client = (
+        MemoryBuilder()
+        .with_hot(hot)
+        .with_warm(warm)
+        .with_cold(cold)
+        .with_rules(write_through=True, write_cold=True)
+        .build()
+    )
+    await client.set("pk", "val")
+
+    hot.set.assert_awaited_once()
+    warm.upsert.assert_awaited_once()
+    cold.upload_text.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_memory_client_cold_parallel_promotion() -> None:
+    """Cold read should promote to hot and warm in parallel."""
+    hot = AsyncMock()
+    hot.get = AsyncMock(return_value=None)
+    warm = AsyncMock()
+    warm.read = AsyncMock(return_value=None)
+    cold = AsyncMock()
+    cold.download_text = AsyncMock(return_value="archive")
+
+    client = MemoryBuilder().with_hot(hot).with_warm(warm).with_cold(cold).build()
+    value = await client.get("ck")
+
+    assert value == "archive"
+    hot.set.assert_awaited_once()
+    warm.upsert.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_memory_client_single_hot_fast_path() -> None:
+    """When only hot is configured, use single-tier fast path."""
+    hot = AsyncMock()
+    hot.get = AsyncMock(return_value="cached")
+
+    client = MemoryBuilder().with_hot(hot).build()
+    value = await client.get("solo")
+
+    assert value == "cached"
+
+
+from holiday_peak_lib.agents.base_agent import AgentDependencies, BaseRetailAgent
+
+
+class _StubAgent(BaseRetailAgent):
+    async def handle(self, request: dict) -> dict:
+        return {}
+
+
+@pytest.mark.asyncio
+async def test_base_agent_memory_tool_definitions() -> None:
+    """Memory tools should be generated when memory_client is set."""
+    memory = AsyncMock()
+    memory.get = AsyncMock(return_value="recalled")
+    memory.set = AsyncMock()
+
+    deps = AgentDependencies(memory_client=memory)
+    agent = _StubAgent(config=deps)
+    tools = agent.memory_tool_definitions()
+
+    assert "memory_read" in tools
+    assert "memory_write" in tools
+
+    result = await tools["memory_read"](key="k")
+    assert result == "recalled"
+
+    result = await tools["memory_write"](key="k", value="v")
+    assert result == "stored"
+    memory.set.assert_awaited_once_with("k", "v")
+
+
+@pytest.mark.asyncio
+async def test_base_agent_gather_adapters() -> None:
+    """gather_adapters should execute coroutines concurrently."""
+
+    async def coro_a():
+        return "a"
+
+    async def coro_b():
+        return "b"
+
+    deps = AgentDependencies()
+    agent = _StubAgent(config=deps)
+    a, b = await agent.gather_adapters(coro_a(), coro_b())
+
+    assert a == "a"
+    assert b == "b"


### PR DESCRIPTION
Closes #799

## Root Cause

The shared \lib\ package had sequential memory operations across hot (Redis), warm (Cosmos DB), and cold (Blob) tiers. Memory was not exposed as LLM tools, and agents had to manually compose \syncio.gather\ for adapter calls.

## Changes

### 1. Parallel memory reads (\MemoryClient.get()\)
- When both hot and warm tiers are configured, dispatch reads in parallel via \syncio.gather\
- Hot value takes precedence when both return results
- Single-tier fast path when only one tier is configured (no overhead)
- Cold fallback remains sequential (archival tier, rarely hit)

### 2. Parallel memory writes (\MemoryClient.set()\)
- All tier writes (hot, warm, cold) dispatch concurrently instead of sequentially

### 3. Parallel cold promotions
- When reading from cold and promoting to hot + warm, both promotions run in parallel

### 4. Memory tool definitions (\BaseRetailAgent.memory_tool_definitions()\)
- Returns \memory_read\ and \memory_write\ closures for LLM tool use
- Enables 'check memory first' strategy before deeper searches

### 5. Framework-level parallel adapter dispatch (\BaseRetailAgent.gather_adapters()\)
- Static method that wraps \syncio.gather\ for concurrent adapter/MCP calls
- Agents can use \wait self.gather_adapters(...)\ instead of manual import

## Verification

- 11/11 memory builder tests pass (5 existing + 6 new)
- 1136/1136 lib tests pass (0 regressions)
- 660/660 app tests pass (0 regressions)
- pylint: 9.97/10 (only pre-existing broad-exception warning)