### PR TITLE
fix: align docs to ADR-034 two-namespace model and update documentation (#803)

### DIFF
--- a/.infra/DEPLOYMENT.md
+++ b/.infra/DEPLOYMENT.md
@@ -252,7 +252,7 @@ python cli.py deploy-all --location eastus2
 
 ## Service Inventory
 
-### 22 Deployable Services
+### 28 Deployable Services
 
 | # | Service | Domain | Type |
 |---|---------|--------|------|
@@ -278,12 +278,12 @@ python cli.py deploy-all --location eastus2
 | 20 | product-management-assortment-optimization | Product Mgmt | Agent |
 | 21 | product-management-consistency-validation | Product Mgmt | Agent |
 | 22 | product-management-normalization-classification | Product Mgmt | Agent |
-
-### Frontend
-
-| Service | Type | Hosting |
-|---------|------|---------|
-| ui | Next.js 15 | Azure Static Web Apps |
+| 23 | search-enrichment-agent | Search | Agent |
+| 24 | truth-enrichment | Truth Layer | Agent |
+| 25 | truth-export | Truth Layer | Agent |
+| 26 | truth-hitl | Truth Layer | Agent |
+| 27 | truth-ingestion | Truth Layer | Agent |
+| 28 | ui | Frontend | Next.js 15 (Azure Static Web Apps) |
 
 ---
 

--- a/.infra/README.md
+++ b/.infra/README.md
@@ -15,7 +15,7 @@ All infrastructure uses [Azure Verified Modules (AVM)](https://azure.github.io/A
 ├── modules/
 │   ├── shared-infrastructure/   # ✅ Shared infrastructure (AKS, Cosmos DB, Event Hubs, etc.)
 │   ├── static-web-app/          # ✅ Frontend hosting (Azure Static Web Apps)
-│   └── [21 agent modules]/      # Per-service standalone demo resources
+│   └── [26 agent modules]/      # Per-service standalone demo resources
 └── templates/
     ├── app.bicep.tpl            # Bicep template for standalone agent services
     ├── main.bicep.tpl           # Main Bicep template wrapper (subscription-scoped)
@@ -48,7 +48,7 @@ We support two infrastructure provisioning strategies:
 
 ### 1) Demo (per-service standalone)
 
-Each of the 21 agent services deploys its **own isolated** resources (Cosmos DB, Redis, Storage, AI Search, OpenAI, AKS) using `app.bicep.tpl`. This is suitable for quick single-service demos and lightweight validation.
+Each of the 26 agent services deploys its **own isolated** resources (Cosmos DB, Redis, Storage, AI Search, OpenAI, AKS) using `app.bicep.tpl`. This is suitable for quick single-service demos and lightweight validation.
 
 - Use the Python CLI (`python cli.py deploy` / `deploy-all`) or `azd deploy --service <name>`.
 - Each service is fully independent — no shared infrastructure required.
@@ -56,7 +56,7 @@ Each of the 21 agent services deploys its **own isolated** resources (Cosmos DB,
 
 ### 2) Production (shared infrastructure)
 
-A single shared stack is deployed first, and all 22 services (21 agents + 1 CRUD) run as workloads in the shared AKS cluster.
+A single shared stack is deployed first, and all 28 services (26 agents + 1 CRUD + 1 UI) run as workloads in the shared AKS cluster.
 
 - Single shared stack: AKS, PostgreSQL (CRUD), Cosmos DB (agent warm memory), Redis, Storage, Event Hubs, AI Foundry, APIM, Key Vault, ACR, VNet, App Insights.
 - Services reference shared data stores and memory tiers.
@@ -477,7 +477,7 @@ The shared infrastructure provisions **three node pools** with dedicated taints:
 | Pool | Purpose | Taint | VM Size | Autoscale (dev) | Autoscale (prod) |
 |------|---------|-------|---------|-----------------|------------------|
 | `system` | Kubernetes system components | *(none)* | Standard_D8ds_v5 | 1–3 | 1–5 |
-| `agents` | 21 agent services | `workload=agents:NoSchedule` | Standard_D8ds_v5 | 2–10 | 2–20 |
+| `agents` | 26 agent services | `workload=agents:NoSchedule` | Standard_D8ds_v5 | 2–10 | 2–20 |
 | `crud` | CRUD service | `workload=crud:NoSchedule` | Standard_D8ds_v5 | 1–5 | 1–10 |
 
 #### Scale a Node Pool
@@ -586,7 +586,7 @@ kubectl scale deployment -n holiday-peak -l app=crud-service --replicas=3
 
 ### 5. Deploying Workloads — Agent Services
 
-All 21 agent services run on the `agents` node pool (toleration: `workload=agents`).
+All 26 agent services run on the `agents` node pool (toleration: `workload=agents`).
 
 #### Deploy All Agents via azd
 
@@ -992,7 +992,7 @@ python cli.py generate-dockerfile --apply-all                         # All agen
 
 ---
 
-### 🔄 Agent Service Modules (21 services)
+### 🔄 Agent Service Modules (26 services)
 
 **Path**: `modules/{agent-name}/`
 

--- a/.infra/SUMMARY.md
+++ b/.infra/SUMMARY.md
@@ -357,7 +357,7 @@ All infrastructure uses [Azure Verified Modules](https://azure.github.io/Azure-V
 
 ### ADR-1: Hybrid Provisioning Strategy
 
-**Context**: 21 agent services + 1 CRUD service need infrastructure. Per-service isolation maximizes independence but is cost-prohibitive.
+**Context**: 26 agent services + 1 CRUD service + 1 UI need infrastructure. Per-service isolation maximizes independence but is cost-prohibitive.
 
 **Decision**: Shared infrastructure for production, per-service standalone for demos.
 

--- a/.infra/modules/shared-infrastructure/README.md
+++ b/.infra/modules/shared-infrastructure/README.md
@@ -1,6 +1,6 @@
 # Shared Infrastructure Module
 
-This module provisions **shared infrastructure** for Holiday Peak Hub that is used by all services (CRUD service + 21 agent services).
+This module provisions **shared infrastructure** for Holiday Peak Hub that is used by all services (CRUD service + 26 agent services).
 Provisioning is implemented with Azure Verified Modules (AVM) for consistent, supportable resource definitions.
 AVM module versions are pinned per resource in the shared infrastructure Bicep file to ensure compatibility with the registry.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Issue #801 / PR #802: replaced `FoundryInvoker` with `FoundryAgentInvoker` wrapping the Microsoft Agent Framework `FoundryAgent` runtime. Tools are now properly forwarded to the agent instead of being silently dropped. Upgraded `agent-framework` to `>=1.0.1` GA across all 27 service packages.
+
+- PR #796: parallelized catalog-search I/O paths and eliminated duplicate keyword search execution, reducing p95 latency for product discovery flows.
+
+- PR #794: corrected `CRUD_SERVICE_URL` port from 8000 to 80 for all agent deployments in AKS, resolving inter-service connectivity failures.
+
 - Issue #29: made `lib/tests/test_config.py` deterministic by isolating settings env-file loading in tests only (`_env_file=None`), preventing local `.env` values from affecting `MemorySettings`, `ServiceSettings`, `PostgresSettings`, and `TruthLayerSettings` test outcomes.
 
 - Issue #246: stabilized `main` quality gates after dependency updates by restoring deterministic product-search fallback and enrichment URL guard behavior in CRUD (`apps/crud-service/src/crud_service/routes/products.py`, `apps/crud-service/src/crud_service/integrations/agent_client.py`), resolving regressions in `test_list_products_with_search` and `test_get_product_enrichment_no_agent_url`.
+
+### Changed
+
+- PR #800: parallelized memory tier reads/writes across hot (Redis), warm (Cosmos DB), and cold (Blob) tiers using `asyncio.gather`, added memory tools (`get_memory`, `set_memory`, `search_memory`) and `gather_adapters` helper. Reduces agent memory I/O latency by executing tier operations concurrently.
+
+- PR #792: Flux Phase B — removed kubectl-apply deployment path in favor of full Flux CD GitOps reconciliation for AKS manifests.
+
+- PR #789: added API Center governance, sync pipeline, and APIM MCP strategy (ADR-035).
+
+- PR #788: namespace isolation — split CRUD and agent services into separate Kubernetes namespaces (ADR-034).
+
+- PR #785: migrated AKS deployments to Flux CD GitOps for declarative manifest reconciliation (ADR-033).
+
+- PR #776: hardened CRUD Entra ID authentication rollout contracts.
+
+- PR #771: completed autonomous agent-surface self-healing epic with incident lifecycle kernel, remediation policy, and audit trail.
+
+### Added
+
+- PR #798: `scripts/ops/start-dev-environment.ps1` for MCAPSGov nightly shutdown recovery, automating Azure resource restart sequence.
+
+- PR #797: `fix-issues-pipeline.prompt.md` for end-to-end issue resolution workflow automation.
+
+- PR #793: MkDocs documentation site scaffold in `mkdocs/` folder for future docs-as-website publishing.
+
+- PR #787: seed rendered Kubernetes manifests for Flux reconciliation under `.infra/k8s/`.
+
+- ADR-033: Helm Deployment Strategy (Flux CD GitOps).
+- ADR-034: Namespace Isolation Strategy (CRUD vs agent namespaces).
+- ADR-035: API Center + APIM MCP Strategy.
 
 - Issue #248: completed branch/artifact hygiene for remediation flow by pruning temporary local branches and cleanup artifacts so local working clones retain only `main` for stabilization operations.
 

--- a/README.MD
+++ b/README.MD
@@ -9,6 +9,7 @@ Agent-driven retail accelerator for building and operating intelligent, cloud-na
 [![Code Style](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Python](https://img.shields.io/badge/python-3.13-3776AB?logo=python&logoColor=white)](https://www.python.org/)
 [![TypeScript](https://img.shields.io/badge/typescript-5.x-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
+[![Tests](https://img.shields.io/badge/tests-1796%20passed-brightgreen)](docs/project-status.md)
 [![License](https://img.shields.io/github/license/Azure-Samples/holiday-peak-hub)](LICENSE)
 
 ## Quick links

--- a/apps/crm-campaign-intelligence/README.md
+++ b/apps/crm-campaign-intelligence/README.md
@@ -49,7 +49,7 @@ SERVICE_NAME="crm-campaign-intelligence"
 APP_PATH="apps/crm-campaign-intelligence/src"
 DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
 AZD_ENV_NAME="dev"
-K8S_NAMESPACE="holiday-peak"
+K8S_NAMESPACE="holiday-peak-agents"
 IMAGE_TAG="$(git rev-parse --short HEAD)"
 ```
 

--- a/apps/crm-profile-aggregation/README.md
+++ b/apps/crm-profile-aggregation/README.md
@@ -49,7 +49,7 @@ SERVICE_NAME="crm-profile-aggregation"
 APP_PATH="apps/crm-profile-aggregation/src"
 DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
 AZD_ENV_NAME="dev"
-K8S_NAMESPACE="holiday-peak"
+K8S_NAMESPACE="holiday-peak-agents"
 IMAGE_TAG="$(git rev-parse --short HEAD)"
 ```
 

--- a/apps/crm-segmentation-personalization/README.md
+++ b/apps/crm-segmentation-personalization/README.md
@@ -49,7 +49,7 @@ SERVICE_NAME="crm-segmentation-personalization"
 APP_PATH="apps/crm-segmentation-personalization/src"
 DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
 AZD_ENV_NAME="dev"
-K8S_NAMESPACE="holiday-peak"
+K8S_NAMESPACE="holiday-peak-agents"
 IMAGE_TAG="$(git rev-parse --short HEAD)"
 ```
 

--- a/apps/crm-support-assistance/README.md
+++ b/apps/crm-support-assistance/README.md
@@ -49,7 +49,7 @@ SERVICE_NAME="crm-support-assistance"
 APP_PATH="apps/crm-support-assistance/src"
 DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
 AZD_ENV_NAME="dev"
-K8S_NAMESPACE="holiday-peak"
+K8S_NAMESPACE="holiday-peak-agents"
 IMAGE_TAG="$(git rev-parse --short HEAD)"
 ```
 

--- a/apps/ecommerce-cart-intelligence/README.md
+++ b/apps/ecommerce-cart-intelligence/README.md
@@ -49,7 +49,7 @@ SERVICE_NAME="ecommerce-cart-intelligence"
 APP_PATH="apps/ecommerce-cart-intelligence/src"
 DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
 AZD_ENV_NAME="dev"
-K8S_NAMESPACE="holiday-peak"
+K8S_NAMESPACE="holiday-peak-agents"
 IMAGE_TAG="$(git rev-parse --short HEAD)"
 ```
 

--- a/apps/ecommerce-catalog-search/README.md
+++ b/apps/ecommerce-catalog-search/README.md
@@ -67,7 +67,7 @@ SERVICE_NAME="ecommerce-catalog-search"
 APP_PATH="apps/ecommerce-catalog-search/src"
 DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
 AZD_ENV_NAME="dev"
-K8S_NAMESPACE="holiday-peak"
+K8S_NAMESPACE="holiday-peak-agents"
 IMAGE_TAG="$(git rev-parse --short HEAD)"
 ```
 

--- a/apps/ecommerce-checkout-support/README.md
+++ b/apps/ecommerce-checkout-support/README.md
@@ -49,7 +49,7 @@ SERVICE_NAME="ecommerce-checkout-support"
 APP_PATH="apps/ecommerce-checkout-support/src"
 DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
 AZD_ENV_NAME="dev"
-K8S_NAMESPACE="holiday-peak"
+K8S_NAMESPACE="holiday-peak-agents"
 IMAGE_TAG="$(git rev-parse --short HEAD)"
 ```
 

--- a/apps/ecommerce-order-status/README.md
+++ b/apps/ecommerce-order-status/README.md
@@ -49,7 +49,7 @@ SERVICE_NAME="ecommerce-order-status"
 APP_PATH="apps/ecommerce-order-status/src"
 DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
 AZD_ENV_NAME="dev"
-K8S_NAMESPACE="holiday-peak"
+K8S_NAMESPACE="holiday-peak-agents"
 IMAGE_TAG="$(git rev-parse --short HEAD)"
 ```
 

--- a/apps/ecommerce-product-detail-enrichment/README.md
+++ b/apps/ecommerce-product-detail-enrichment/README.md
@@ -49,7 +49,7 @@ SERVICE_NAME="ecommerce-product-detail-enrichment"
 APP_PATH="apps/ecommerce-product-detail-enrichment/src"
 DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
 AZD_ENV_NAME="dev"
-K8S_NAMESPACE="holiday-peak"
+K8S_NAMESPACE="holiday-peak-agents"
 IMAGE_TAG="$(git rev-parse --short HEAD)"
 ```
 

--- a/apps/inventory-alerts-triggers/README.md
+++ b/apps/inventory-alerts-triggers/README.md
@@ -49,7 +49,7 @@ SERVICE_NAME="inventory-alerts-triggers"
 APP_PATH="apps/inventory-alerts-triggers/src"
 DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
 AZD_ENV_NAME="dev"
-K8S_NAMESPACE="holiday-peak"
+K8S_NAMESPACE="holiday-peak-agents"
 IMAGE_TAG="$(git rev-parse --short HEAD)"
 ```
 

--- a/apps/inventory-health-check/README.md
+++ b/apps/inventory-health-check/README.md
@@ -49,7 +49,7 @@ SERVICE_NAME="inventory-health-check"
 APP_PATH="apps/inventory-health-check/src"
 DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
 AZD_ENV_NAME="dev"
-K8S_NAMESPACE="holiday-peak"
+K8S_NAMESPACE="holiday-peak-agents"
 IMAGE_TAG="$(git rev-parse --short HEAD)"
 ```
 

--- a/apps/inventory-jit-replenishment/README.md
+++ b/apps/inventory-jit-replenishment/README.md
@@ -49,7 +49,7 @@ SERVICE_NAME="inventory-jit-replenishment"
 APP_PATH="apps/inventory-jit-replenishment/src"
 DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
 AZD_ENV_NAME="dev"
-K8S_NAMESPACE="holiday-peak"
+K8S_NAMESPACE="holiday-peak-agents"
 IMAGE_TAG="$(git rev-parse --short HEAD)"
 ```
 

--- a/apps/inventory-reservation-validation/README.md
+++ b/apps/inventory-reservation-validation/README.md
@@ -49,7 +49,7 @@ SERVICE_NAME="inventory-reservation-validation"
 APP_PATH="apps/inventory-reservation-validation/src"
 DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
 AZD_ENV_NAME="dev"
-K8S_NAMESPACE="holiday-peak"
+K8S_NAMESPACE="holiday-peak-agents"
 IMAGE_TAG="$(git rev-parse --short HEAD)"
 ```
 

--- a/apps/logistics-carrier-selection/README.md
+++ b/apps/logistics-carrier-selection/README.md
@@ -49,7 +49,7 @@ SERVICE_NAME="logistics-carrier-selection"
 APP_PATH="apps/logistics-carrier-selection/src"
 DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
 AZD_ENV_NAME="dev"
-K8S_NAMESPACE="holiday-peak"
+K8S_NAMESPACE="holiday-peak-agents"
 IMAGE_TAG="$(git rev-parse --short HEAD)"
 ```
 

--- a/apps/logistics-eta-computation/README.md
+++ b/apps/logistics-eta-computation/README.md
@@ -49,7 +49,7 @@ SERVICE_NAME="logistics-eta-computation"
 APP_PATH="apps/logistics-eta-computation/src"
 DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
 AZD_ENV_NAME="dev"
-K8S_NAMESPACE="holiday-peak"
+K8S_NAMESPACE="holiday-peak-agents"
 IMAGE_TAG="$(git rev-parse --short HEAD)"
 ```
 

--- a/apps/logistics-returns-support/README.md
+++ b/apps/logistics-returns-support/README.md
@@ -49,7 +49,7 @@ SERVICE_NAME="logistics-returns-support"
 APP_PATH="apps/logistics-returns-support/src"
 DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
 AZD_ENV_NAME="dev"
-K8S_NAMESPACE="holiday-peak"
+K8S_NAMESPACE="holiday-peak-agents"
 IMAGE_TAG="$(git rev-parse --short HEAD)"
 ```
 

--- a/apps/logistics-route-issue-detection/README.md
+++ b/apps/logistics-route-issue-detection/README.md
@@ -49,7 +49,7 @@ SERVICE_NAME="logistics-route-issue-detection"
 APP_PATH="apps/logistics-route-issue-detection/src"
 DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
 AZD_ENV_NAME="dev"
-K8S_NAMESPACE="holiday-peak"
+K8S_NAMESPACE="holiday-peak-agents"
 IMAGE_TAG="$(git rev-parse --short HEAD)"
 ```
 

--- a/apps/product-management-acp-transformation/README.md
+++ b/apps/product-management-acp-transformation/README.md
@@ -49,7 +49,7 @@ SERVICE_NAME="product-management-acp-transformation"
 APP_PATH="apps/product-management-acp-transformation/src"
 DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
 AZD_ENV_NAME="dev"
-K8S_NAMESPACE="holiday-peak"
+K8S_NAMESPACE="holiday-peak-agents"
 IMAGE_TAG="$(git rev-parse --short HEAD)"
 ```
 

--- a/apps/product-management-assortment-optimization/README.md
+++ b/apps/product-management-assortment-optimization/README.md
@@ -49,7 +49,7 @@ SERVICE_NAME="product-management-assortment-optimization"
 APP_PATH="apps/product-management-assortment-optimization/src"
 DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
 AZD_ENV_NAME="dev"
-K8S_NAMESPACE="holiday-peak"
+K8S_NAMESPACE="holiday-peak-agents"
 IMAGE_TAG="$(git rev-parse --short HEAD)"
 ```
 

--- a/apps/product-management-consistency-validation/README.md
+++ b/apps/product-management-consistency-validation/README.md
@@ -49,7 +49,7 @@ SERVICE_NAME="product-management-consistency-validation"
 APP_PATH="apps/product-management-consistency-validation/src"
 DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
 AZD_ENV_NAME="dev"
-K8S_NAMESPACE="holiday-peak"
+K8S_NAMESPACE="holiday-peak-agents"
 IMAGE_TAG="$(git rev-parse --short HEAD)"
 ```
 

--- a/apps/product-management-normalization-classification/README.md
+++ b/apps/product-management-normalization-classification/README.md
@@ -49,7 +49,7 @@ SERVICE_NAME="product-management-normalization-classification"
 APP_PATH="apps/product-management-normalization-classification/src"
 DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
 AZD_ENV_NAME="dev"
-K8S_NAMESPACE="holiday-peak"
+K8S_NAMESPACE="holiday-peak-agents"
 IMAGE_TAG="$(git rev-parse --short HEAD)"
 ```
 

--- a/apps/search-enrichment-agent/README.md
+++ b/apps/search-enrichment-agent/README.md
@@ -49,7 +49,7 @@ SERVICE_NAME="search-enrichment-agent"
 APP_PATH="apps/search-enrichment-agent/src"
 DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
 AZD_ENV_NAME="dev"
-K8S_NAMESPACE="holiday-peak"
+K8S_NAMESPACE="holiday-peak-agents"
 IMAGE_TAG="$(git rev-parse --short HEAD)"
 ```
 

--- a/apps/truth-enrichment/README.md
+++ b/apps/truth-enrichment/README.md
@@ -52,7 +52,7 @@ SERVICE_NAME="truth-enrichment"
 APP_PATH="apps/truth-enrichment/src"
 DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
 AZD_ENV_NAME="dev"
-K8S_NAMESPACE="holiday-peak"
+K8S_NAMESPACE="holiday-peak-agents"
 IMAGE_TAG="$(git rev-parse --short HEAD)"
 ```
 

--- a/apps/truth-export/README.md
+++ b/apps/truth-export/README.md
@@ -51,7 +51,7 @@ SERVICE_NAME="truth-export"
 APP_PATH="apps/truth-export/src"
 DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
 AZD_ENV_NAME="dev"
-K8S_NAMESPACE="holiday-peak"
+K8S_NAMESPACE="holiday-peak-agents"
 IMAGE_TAG="$(git rev-parse --short HEAD)"
 ```
 

--- a/apps/truth-hitl/README.md
+++ b/apps/truth-hitl/README.md
@@ -51,7 +51,7 @@ SERVICE_NAME="truth-hitl"
 APP_PATH="apps/truth-hitl/src"
 DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
 AZD_ENV_NAME="dev"
-K8S_NAMESPACE="holiday-peak"
+K8S_NAMESPACE="holiday-peak-agents"
 IMAGE_TAG="$(git rev-parse --short HEAD)"
 ```
 

--- a/apps/truth-ingestion/README.md
+++ b/apps/truth-ingestion/README.md
@@ -51,7 +51,7 @@ SERVICE_NAME="truth-ingestion"
 APP_PATH="apps/truth-ingestion/src"
 DOCKERFILE_PATH="${APP_PATH}/Dockerfile"
 AZD_ENV_NAME="dev"
-K8S_NAMESPACE="holiday-peak"
+K8S_NAMESPACE="holiday-peak-agents"
 IMAGE_TAG="$(git rev-parse --short HEAD)"
 ```
 

--- a/docs/IMPLEMENTATION_ROADMAP.md
+++ b/docs/IMPLEMENTATION_ROADMAP.md
@@ -1,26 +1,34 @@
 # Implementation Roadmap
 
-**Last Updated**: March 27, 2026  
-**Version**: main (post PR #559)  
-**Status**: Active Execution | Enrichment/Search Hardening Merged
+**Last Updated**: April 12, 2026  
+**Version**: main (post PR #802)  
+**Status**: Active Execution | Agent Runtime Migration Complete
 
 ---
 
 ## Overview
 
-This document tracks the implementation progress of the Holiday Peak Hub platform. The CRUD service, frontend integration, 21 AI agents, and shared infrastructure (Bicep) are complete. v1.1.0 adds enterprise system connectors (Oracle, Salesforce, SAP, Dynamics 365), the Product Truth Layer foundation, HITL review system, and enterprise hardening patterns (circuit breaker, bulkhead, rate limiter).
+This document tracks the implementation progress of the Holiday Peak Hub platform. The CRUD service, frontend integration, 21+ AI agents, and shared infrastructure (Bicep) are complete. v1.1.0 adds enterprise system connectors (Oracle, Salesforce, SAP, Dynamics 365), the Product Truth Layer foundation, HITL review system, and enterprise hardening patterns. v2.0.0 enforces single-path completeness operations. Current work focuses on agent runtime correctness, operational automation, and GitOps deployment.
 
-## Current Execution State (March 27, 2026)
+## Current Execution State (April 12, 2026)
 
-### Completed in Latest Merge Wave
-- Issue #558 / PR #559 merged to main.
-- Enrichment/search orchestration hardening implemented across truth-ingestion, truth-enrichment, truth-hitl, ecommerce-catalog-search, and ui.
-- Human-only validation enforcement in enrichment proposal lifecycle.
-- Two-stage search UX delivery with baseline and rerank stages.
-- Search context propagation and memory persistence improvements.
+### Completed in Latest Merge Wave (PRs #771–#802)
+
+- **Agent Runtime Migration** (PR #802): Replaced `FoundryInvoker` with `FoundryAgentInvoker` wrapping the MAF `FoundryAgent`, fixing silent tool-dropping. Upgraded `agent-framework` to `>=1.0.1` GA across all 27 service packages.
+- **Memory Parallelization** (PR #800): Concurrent hot/warm/cold I/O via `asyncio.gather`; new memory tools and `gather_adapters` helper.
+- **Catalog-Search Optimization** (PR #796): Parallelized I/O, eliminated duplicate keyword search.
+- **Infrastructure Fixes** (PRs #794, #798): CRUD port correction, dev-environment recovery script.
+- **Flux CD GitOps** (PRs #785, #787, #792): Full Flux reconciliation; kubectl-apply removed.
+- **Namespace Isolation** (PR #788 / ADR-034): Separate CRUD and agent Kubernetes namespaces.
+- **API Center Governance** (PR #789 / ADR-035): APIM MCP strategy implementation.
+- **Self-Healing Runtime** (PR #771): Incident lifecycle state machine, remediation policy, audit trail.
+- **CRUD Auth Hardening** (PR #776): Entra ID rollout contracts improved.
+- **MkDocs Scaffold** (PR #793): Documentation site preparation in `mkdocs/`.
 
 ### Validation Snapshot
-- Repository local validation completed: 1647 tests passed (2 warnings).
+
+- Repository local validation: **1796 tests passed** (1136 lib + 660 app), 0 failures.
+- 35 ADRs (ADR-001 through ADR-035).
 
 ### Backlog Guidance
 - Legacy phase/task checklists below are retained for traceability; use `docs/roadmap/` and open GitHub issues as the canonical source for next execution priorities.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,23 +1,23 @@
 # Holiday Peak Hub - Architecture Documentation
 
-**Last Updated**: April 8, 2026
-**Version**: main (post PR #559)  
+**Last Updated**: April 12, 2026
+**Version**: main (post PR #802)  
 **Status**: Active Development
 
-## Latest Update Snapshot (April 8, 2026)
+## Latest Update Snapshot (April 12, 2026)
 
-- Reusable deployment now temporarily re-enables ACR public access with `defaultAction=Deny` for GitHub-hosted tested-image builds when the registry public endpoint is disabled, reuses the existing runner-IP allowlist, and restores the original ACR network posture after the build phase.
-- Enrichment/search orchestration hardening merged via PR #559 (Issue #558).
-- Truth flow now enforces human-gated enrichment validation (`pending_review`) with dual HITL publish (`export-jobs` and `search-enrichment-jobs`).
-- Search flow now supports two-stage UX (baseline first, background rerank) and request context propagation.
-- Catalog search now stores stage/session search context with best-effort persistence across hot/warm/cold memory tiers.
-- Validation status: local repository test run reports 1647 passed (2 warnings).
-- Agentic app README deployment docs are standardized with standalone azd-first guidance and app-specific ACR/AKS paths.
-- UI/UX modernization review added with per-view recommendations for customer, staff, admin, and observability surfaces.
-- Protected dev live validation now has a dedicated GitHub Actions workflow with trusted triggers, OIDC-only Azure auth, and the `dev` environment boundary; final environment protection remains a repo-admin step.
-- Dev deployment now promotes tested `main` commits only: `deploy-azd-dev` auto-starts from successful `test` workflow runs on `main`, builds changed AKS images once per tested SHA, and deploys rendered manifests pinned to immutable image digests.
-- Reusable deployment now includes a blocking Foundry contract drift gate that compares workflow intent, rendered Helm manifests, live AKS Deployment env values, ensure results, and `/ready` responses for changed agent services.
-- Reusable deployment now idempotently ensures `AcrPush` on the environment ACR for the OIDC deploy principal and retries `az acr login` with bounded backoff so tested-image builds survive RBAC propagation delay without adding static registry credentials.
+- **FoundryAgentInvoker** replaces legacy `FoundryInvoker` (PR #802 / Issue #801): agent tools are now properly forwarded through the Microsoft Agent Framework `FoundryAgent` runtime. `agent-framework` upgraded to `>=1.0.1` GA across all 27 Python services.
+- Memory tier reads/writes parallelized via `asyncio.gather` (PR #800): concurrent hot/warm/cold I/O reduces agent memory latency. New memory tools (`get_memory`, `set_memory`, `search_memory`) and `gather_adapters` helper added.
+- Catalog-search I/O parallelized and duplicate keyword search eliminated (PR #796).
+- CRUD_SERVICE_URL port corrected from 8000 to 80 for all agent deployments in AKS (PR #794).
+- Flux CD Phase B complete (PR #792): kubectl-apply removed, full GitOps reconciliation via Flux.
+- API Center governance, sync pipeline, and APIM MCP strategy added (PR #789 / ADR-035).
+- Namespace isolation (PR #788 / ADR-034): CRUD and agent services now run in separate Kubernetes namespaces.
+- AKS deployments migrated to Flux CD GitOps (PR #785 / ADR-033).
+- Self-healing epic complete (PR #771): incident lifecycle kernel, remediation policy, and audit trail across all agent surfaces.
+- CRUD Entra ID auth rollout contracts hardened (PR #776).
+- Validation status: **1796 tests passed** (1136 lib + 660 app), 0 failures.
+- 35 Architecture Decision Records (ADR-001 through ADR-035).
 
 ## Overview
 
@@ -337,6 +337,11 @@ az acr update -n <acrName> --public-network-enabled false
 - **[Business Summary](architecture/business-summary.md)** - Business requirements and use cases
 - **[Components Documentation](architecture/components.md)** - All framework and service components
 - **[ADRs (Architecture Decision Records)](architecture/ADRs.md)** - Index of architectural decisions
+- **[Agentic Microservices Reference](agentic-microservices-reference.md)** - Why this is a reference architecture for agentic microservices on Azure
+- **[MAF Integration Rationale](architecture/maf-integration-rationale.md)** - Why Microsoft Agent Framework is wrapped inside the lib
+- **[Solution Architecture Diagrams](architecture/solution-architecture-diagrams.md)** - Per-domain Mermaid diagrams (system context, container, 7 domains, data flow)
+- **[Standalone Deployment Guide](architecture/standalone-deployment-guide.md)** - How to deploy a single agent service to AKS
+- **[Test Coverage Gap Analysis](architecture/test-coverage-gap-analysis.md)** - Coverage gaps, patterns, and remediation plan
 
 ---
 
@@ -370,7 +375,7 @@ az acr update -n <acrName> --public-network-enabled false
 
 ### Application Layer
 **Technology**: FastAPI (Python 3.13)  
-**Status**: ✅ CRUD Service Complete, ✅ 21 Agent Services Complete
+**Status**: ✅ CRUD Service Complete, ✅ 26 Agent Services Complete
 
 **CRUD Service** ✅ **IMPLEMENTED**:
 - **31 REST endpoints** across 15 route modules
@@ -383,22 +388,14 @@ az acr update -n <acrName> --public-network-enabled false
 - **Location**: `apps/crud-service/`
 - **Documentation**: [CRUD Service Implementation](architecture/crud-service-implementation.md)
 
-**Agent Services** (21):
+**Agent Services** (26):
 - E-Commerce (5): catalog-search, product-detail-enrichment, cart-intelligence, checkout-support, order-status
 - Product Management (4): normalization-classification, acp-transformation, consistency-validation, assortment-optimization
 - CRM (4): profile-aggregation, segmentation-personalization, campaign-intelligence, support-assistance
 - Inventory (4): health-check, jit-replenishment, reservation-validation, alerts-triggers
 - Logistics (4): eta-computation, carrier-selection, returns-support, route-issue-detection
-
-**CRUD Service** ✅ **IMPLEMENTED**:
-- **31 REST endpoints** across 15 route modules
-- **Authentication**: Entra ID JWT validation, RBAC (anonymous, customer, staff, admin)
-- **Repositories**: Base + specialized (User, Product, Order, Cart)
-- **Routes**: health, auth, users, products, categories, cart, orders, checkout, payments, reviews
-- **Staff Routes**: analytics, tickets, returns, shipments
-- **Integrations**: Event Hubs publisher (5 topics), MCP agent client
-- **Testing**: Unit, integration, and e2e test structure
-- **Location**: `apps/crud-service/`
+- Search (1): search-enrichment-agent
+- Truth Layer (4): truth-ingestion, truth-enrichment, truth-hitl, truth-export
 
 ### Data Layer
 **Technology**: Cosmos DB, Redis, Blob Storage  

--- a/docs/agentic-microservices-reference.md
+++ b/docs/agentic-microservices-reference.md
@@ -1,0 +1,293 @@
+# Holiday Peak Hub — A Reference Architecture for Agentic Microservices
+
+**Version**: 1.0
+**Last Updated**: 2026-04-12
+
+---
+
+## What Are Agentic Microservices?
+
+Agentic Microservices extend the traditional microservices pattern by embedding AI agent capabilities directly inside each service boundary. Instead of bolting a monolithic AI layer on top of existing services, each microservice carries its own agent runtime that can:
+
+- **Plan dynamically** at runtime based on context (not just execute static call sequences)
+- **Use tools** via the Model Context Protocol (MCP) to call other services
+- **Maintain memory** across interactions using a tiered persistence strategy
+- **Route between models** (SLM for simple queries, LLM for complex ones) based on real-time complexity assessment
+- **Self-heal** by detecting, classifying, and remediating infrastructure incidents autonomously
+
+This pattern is distinct from both traditional microservices (deterministic, code-defined flows) and monolithic AI gateways (single-point bottleneck for all AI interactions).
+
+---
+
+## Why This Repository Is a Reference Implementation
+
+Holiday Peak Hub demonstrates how to build an Agentic Microservices platform at scale using Microsoft's AI and cloud stack. It is a working, tested, deployed system — not a conceptual framework.
+
+| Characteristic | Implementation |
+|----------------|---------------|
+| **26 domain-specific agents** | Each agent handles a bounded context (CRM, eCommerce, Inventory, Logistics, Product Mgmt, Search, Truth Layer) |
+| **Shared micro-framework** | `holiday-peak-lib` provides BaseRetailAgent, memory, guardrails, resilience, telemetry |
+| **Microsoft Agent Framework (MAF)** | `agent-framework>=1.0.1` GA wraps Azure AI Foundry agents via `FoundryAgentInvoker` |
+| **SLM-first routing** | Every request starts with GPT-5-nano (fast, cheap); complex queries escalate to GPT-5 (rich) |
+| **Three-tier memory** | Hot (Redis, <50ms) → Warm (Cosmos DB, 100-500ms) → Cold (Blob, archival) |
+| **Agent-to-agent communication** | MCP protocol for structured tool calls between agents |
+| **Event-driven async** | Azure Event Hubs for decoupled CRUD → Agent processing |
+| **GitOps deployment** | Flux CD reconciles rendered Helm manifests to AKS with namespace isolation |
+| **Self-healing runtime** | Incident lifecycle: detect → classify → remediate → verify → escalate |
+| **1796 automated tests** | 1136 lib + 660 app tests, 89% coverage, CI/CD enforced |
+
+---
+
+## Microsoft Technology Stack
+
+This reference architecture is built entirely on Microsoft's AI and cloud platform:
+
+| Layer | Technology | Purpose | Documentation |
+|-------|-----------|---------|---------------|
+| **AI Runtime** | [Microsoft Agent Framework](https://learn.microsoft.com/en-us/python/api/overview/azure/agent-framework) | Agent execution, tool forwarding, message protocol | [MAF Python API](https://learn.microsoft.com/en-us/python/api/overview/azure/agent-framework) |
+| **AI Models** | [Azure AI Foundry](https://learn.microsoft.com/en-us/azure/ai-studio/) | Model hosting, Agents V2 API, prompt governance | [Foundry Agents quickstart](https://learn.microsoft.com/en-us/azure/ai-studio/how-to/develop/agents) |
+| **Search** | [Azure AI Search](https://learn.microsoft.com/en-us/azure/search/) | Vector + hybrid search, semantic ranking | [AI Search overview](https://learn.microsoft.com/en-us/azure/search/search-what-is-azure-search) |
+| **Warm Memory** | [Azure Cosmos DB](https://learn.microsoft.com/en-us/azure/cosmos-db/) | User profiles, search history, agent state | [Cosmos DB for NoSQL](https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/) |
+| **Hot Memory** | [Azure Cache for Redis](https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/) | Session state, real-time context | [Redis quickstart](https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-python-get-started) |
+| **Cold Memory** | [Azure Blob Storage](https://learn.microsoft.com/en-us/azure/storage/blobs/) | Archival, catalog snapshots, images | [Blob Storage overview](https://learn.microsoft.com/en-us/azure/storage/blobs/storage-blobs-introduction) |
+| **Messaging** | [Azure Event Hubs](https://learn.microsoft.com/en-us/azure/event-hubs/) | Async CRUD → Agent event processing | [Event Hubs Python SDK](https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-python-get-started-send) |
+| **Compute** | [Azure Kubernetes Service](https://learn.microsoft.com/en-us/azure/aks/) | Namespace-isolated agent pods with KEDA autoscaling | [AKS overview](https://learn.microsoft.com/en-us/azure/aks/intro-kubernetes) |
+| **API Gateway** | [Azure API Management](https://learn.microsoft.com/en-us/azure/api-management/) | Traffic management, auth, AI policies | [APIM overview](https://learn.microsoft.com/en-us/azure/api-management/api-management-key-concepts) |
+| **CRUD Data** | [Azure Database for PostgreSQL](https://learn.microsoft.com/en-us/azure/postgresql/) | Transactional data (orders, products, users) | [PostgreSQL Flexible Server](https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/) |
+| **Secrets** | [Azure Key Vault](https://learn.microsoft.com/en-us/azure/key-vault/) | Connection strings, API keys, certificates | [Key Vault overview](https://learn.microsoft.com/en-us/azure/key-vault/general/overview) |
+| **Observability** | [Azure Monitor + Application Insights](https://learn.microsoft.com/en-us/azure/azure-monitor/) | Distributed tracing, KQL queries | [OpenTelemetry for Azure](https://learn.microsoft.com/en-us/azure/azure-monitor/app/opentelemetry-enable) |
+| **GitOps** | [Flux CD](https://fluxcd.io/) on AKS | Continuous reconciliation, drift detection | [Flux on AKS](https://learn.microsoft.com/en-us/azure/azure-arc/kubernetes/tutorial-use-gitops-flux2) |
+| **Frontend** | [Azure Static Web Apps](https://learn.microsoft.com/en-us/azure/static-web-apps/) | Next.js 15 hosting with managed SSL | [SWA overview](https://learn.microsoft.com/en-us/azure/static-web-apps/overview) |
+| **Identity** | [Microsoft Entra ID](https://learn.microsoft.com/en-us/entra/identity/) | JWT validation, RBAC, managed identity | [Entra ID overview](https://learn.microsoft.com/en-us/entra/fundamentals/whatis) |
+| **CI/CD** | [GitHub Actions](https://docs.github.com/en/actions) | Build, test, deploy workflows | [Actions documentation](https://docs.github.com/en/actions) |
+
+---
+
+## Architectural Patterns Demonstrated
+
+### 1. Agentic Microservices (Core Pattern)
+
+Each agent service is a self-contained FastAPI application that:
+- Owns its domain logic
+- Hosts its own agent runtime (via `BaseRetailAgent`)
+- Exposes REST endpoints for Frontend/CRUD and MCP tools for agents
+- Subscribes to Event Hub topics for async processing
+- Maintains independent memory namespaces
+
+### 2. SLM-First Model Routing
+
+Every request starts with the fast (SLM) model. The agent evaluates complexity and only escalates to the rich (LLM) model when needed. This reduces cost by 60-80% while maintaining quality for complex queries.
+
+### 3. Three-Tier Memory Architecture
+
+Agents operate on context assembled from three tiers with different latency and cost profiles, read in parallel via `asyncio.gather`:
+- **Hot** (Redis): Session state, <50ms reads, TTL-based expiry
+- **Warm** (Cosmos DB): User profiles, search history, enrichment state, 100–500ms
+- **Cold** (Blob Storage): Interaction logs, catalog snapshots, archival
+
+### 4. Event-Driven Agent Processing
+
+CRUD operations publish domain events to Azure Event Hubs. Agents subscribe to relevant topics and process asynchronously:
+
+```
+Frontend → CRUD Service → Event Hubs → Agent(s)
+                           ↑ publish       ↓ consume
+                      (order.created)  (enrich, classify, alert)
+```
+
+### 5. MCP Tool Protocol for Agent-to-Agent Communication
+
+Agents expose tools via `FastAPIMCPServer` that other agents can invoke:
+
+```python
+@mcp.tool()
+async def get_inventory_status(sku: str) -> dict:
+    """Check real-time stock level for an SKU."""
+    return await adapter.check_stock(sku)
+```
+
+This enables compositional intelligence: the checkout agent can call the inventory agent's tools without tight coupling.
+
+### 6. Enrichment Guardrails
+
+The `EnrichmentGuardrail` validates agent outputs before they reach downstream consumers:
+- Schema conformance (Pydantic model validation)
+- Content policy enforcement (no hallucinated data)
+- Confidence thresholds (reject low-confidence enrichments)
+- Audit trail (every decision logged with evidence)
+
+### 7. GitOps Deployment with Flux CD
+
+All services are deployed via rendered Kubernetes manifests reconciled by Flux CD:
+1. CI builds container images → pushes to ACR
+2. Helm templates rendered → committed to manifests branch
+3. Flux detects changes → applies to AKS namespaces
+4. Health checks validate rollout → auto-rollback on failure
+5. Drift detection ensures desired state is maintained
+
+### 8. Self-Healing Runtime
+
+The platform includes autonomous incident management:
+- **Detection**: Health probes, Azure Monitor alerts, APIM diagnostics
+- **Classification**: Incident type mapping (pod crash, memory pressure, model degradation)
+- **Remediation**: Strategy-specific handlers (AKS restart, APIM circuit break, Redis flush)
+- **Verification**: Post-remediation health check with configurable thresholds
+- **Escalation**: Human notification when automated remediation fails
+
+---
+
+## Domain Architecture
+
+The 26 agent services are organized into 7 bounded contexts:
+
+```mermaid
+%%{init: {'theme':'base', 'themeVariables': {'primaryColor':'#FFB3BA','primaryTextColor':'#000','primaryBorderColor':'#FF8B94','lineColor':'#BAE1FF','secondaryColor':'#BAE1FF','tertiaryColor':'#FFFFFF'}}}%%
+graph TB
+    subgraph CRUD["CRUD Service (PostgreSQL)"]
+        API["REST API<br/>31 endpoints"]
+    end
+
+    subgraph ECOM["eCommerce Domain"]
+        CS["Catalog Search"]
+        PDE["Product Detail Enrichment"]
+        CI["Cart Intelligence"]
+        CKS["Checkout Support"]
+        OS["Order Status"]
+    end
+
+    subgraph CRM["CRM Domain"]
+        PA["Profile Aggregation"]
+        SP["Segmentation &<br/>Personalization"]
+        CAM["Campaign Intelligence"]
+        SA["Support Assistance"]
+    end
+
+    subgraph INV["Inventory Domain"]
+        AT["Alerts & Triggers"]
+        HC["Health Check"]
+        JIT["JIT Replenishment"]
+        RV["Reservation Validation"]
+    end
+
+    subgraph LOG["Logistics Domain"]
+        CSel["Carrier Selection"]
+        ETA["ETA Computation"]
+        RS["Returns Support"]
+        RID["Route Issue Detection"]
+    end
+
+    subgraph PM["Product Management Domain"]
+        ACP["ACP Transformation"]
+        ASO["Assortment Optimization"]
+        CSV["Consistency Validation"]
+        NC["Normalization &<br/>Classification"]
+    end
+
+    subgraph SRCH["Search Domain"]
+        SEA["Search Enrichment Agent"]
+    end
+
+    subgraph TRUTH["Truth Layer Domain"]
+        TI["Truth Ingestion"]
+        TE["Truth Enrichment"]
+        TH["Truth HITL"]
+        TX["Truth Export"]
+    end
+
+    UI["Next.js Frontend"] --> API
+    API -->|events| EH["Azure Event Hubs"]
+    EH --> ECOM & CRM & INV & LOG & PM & SRCH & TRUTH
+    API <-->|sync + circuit breaker| ECOM
+```
+
+---
+
+## How to Use This Reference
+
+### For Platform Architects
+
+Start with [Architecture Overview](architecture/architecture.md) and the [ADR Index](architecture/ADRs.md) to understand the decision landscape. Review the [MAF Integration Rationale](architecture/maf-integration-rationale.md) for the agent runtime design.
+
+### For Service Developers
+
+Read the [lib README](../lib/README.md) to understand the micro-framework, then look at any app's `main.py` + `adapters.py` + `agents.py` for the service pattern. The [Standalone Deployment Guide](architecture/standalone-deployment-guide.md) covers single-service deployment.
+
+### For DevOps Engineers
+
+Start with the [Infrastructure README](../.infra/README.md) and [Deployment Guide](../.infra/DEPLOYMENT.md). Review [ADR-033](architecture/adrs/adr-033-helm-charts-flux-cd-gitops.md) (Flux CD) and [ADR-034](architecture/adrs/adr-034-namespace-isolation-strategy.md) (Namespace Isolation) for the GitOps model.
+
+### For AI/ML Engineers
+
+Review the [Foundry Agent Invocation Flow](architecture/diagrams/sequence-foundry-agent-invocation.md) and [MAF Integration Rationale](architecture/maf-integration-rationale.md). The SLM-first routing logic is in `lib/src/holiday_peak_lib/agents/base_agent.py`.
+
+---
+
+## Comparison with Alternative Architectures
+
+| Approach | Pros | Cons | When to Use |
+|----------|------|------|-------------|
+| **Agentic Microservices** (this repo) | Domain isolation, independent scaling, per-agent memory | More services to operate, cross-agent latency | Multi-domain platforms with distinct AI capabilities per domain |
+| **Monolithic AI Gateway** | Single deployment, centralized model management | Single point of failure, no domain isolation, all-or-nothing scaling | Simple chatbot or single-purpose AI applications |
+| **AI Sidecar Pattern** | Minimal code changes to existing services | Limited agent autonomy, no inter-agent communication | Adding AI to legacy services without rewrite |
+| **Orchestrator Agent** | Centralized planning, simpler routing | Bottleneck at orchestrator, hard to scale horizontally | Workflows with a single decision-maker |
+
+---
+
+## Microsoft Documentation Cross-References
+
+| Topic | Official Documentation |
+|-------|----------------------|
+| Building AI agents with Microsoft Agent Framework | [MAF Python SDK](https://learn.microsoft.com/en-us/python/api/overview/azure/agent-framework) |
+| Azure AI Foundry agent creation and management | [Foundry Agents overview](https://learn.microsoft.com/en-us/azure/ai-studio/how-to/develop/agents) |
+| Model Context Protocol (MCP) for tool integration | [MCP specification](https://modelcontextprotocol.io/) |
+| Microservices architecture on Azure | [Azure Architecture Center — Microservices](https://learn.microsoft.com/en-us/azure/architecture/microservices/) |
+| Event-driven architecture patterns | [Azure Architecture Center — Event-driven](https://learn.microsoft.com/en-us/azure/architecture/guide/architecture-styles/event-driven) |
+| AKS best practices | [AKS baseline architecture](https://learn.microsoft.com/en-us/azure/architecture/reference-architectures/containers/aks/baseline-aks) |
+| Cosmos DB data modeling | [Cosmos DB data modeling](https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/modeling-data) |
+| Azure Well-Architected Framework | [WAF overview](https://learn.microsoft.com/en-us/azure/well-architected/) |
+
+---
+
+## Related Documents
+
+- [Architecture Overview](architecture/architecture.md) — System context and container views
+- [ADR Index](architecture/ADRs.md) — 35 architecture decision records
+- [MAF Integration Rationale](architecture/maf-integration-rationale.md) — Why MAF is wrapped in the lib
+- [Standalone Deployment Guide](architecture/standalone-deployment-guide.md) — Single-service AKS deployment
+- [Lib README](../lib/README.md) — Micro-framework API reference
+- [Infrastructure README](../.infra/README.md) — Bicep provisioning and AKS operations
+- [Project Status](project-status.md) — Current state and recent changes
+- **Warm** (Cosmos DB): Profiles and history, 100-500ms
+- **Cold** (Blob): Archival data, seconds
+
+### 4. Enrichment Guardrails
+
+The `EnrichmentGuardrail` enforces that AI-generated content is always grounded in company-owned data (PIM, DAM, CRM). Agents never generate without a verifiable internal data source.
+
+### 5. GitOps with Namespace Isolation
+
+Flux CD reconciles rendered Helm manifests from a manifests branch. Each domain gets its own Kubernetes namespace with RBAC boundaries and network policies (ADR-033, ADR-034).
+
+### 6. Self-Healing Runtime
+
+An autonomous incident lifecycle (detect → classify → remediate → verify → escalate) handles infrastructure misconfigurations without human intervention, with audit trails and allowlisted remediation actions.
+
+---
+
+## Getting Started
+
+1. **Understand the architecture**: Start with [Solution Architecture Overview](architecture/solution-architecture-overview.md)
+2. **Explore the lib**: Read [lib/README.md](../lib/README.md) for the shared framework
+3. **Deploy a single service**: Follow the [Standalone Deployment Guide](architecture/standalone-deployment-guide.md)
+4. **Deploy everything**: Use `azd up` with the [Deployment Guide](../.infra/DEPLOYMENT.md)
+5. **Run tests**: `python -m pytest` at the repository root (1796 tests)
+
+---
+
+## Related Microsoft Guidance
+
+- [Azure Architecture Center: Microservices](https://learn.microsoft.com/en-us/azure/architecture/microservices/)
+- [Azure Architecture Center: AI Agent Patterns](https://learn.microsoft.com/en-us/azure/architecture/ai-ml/architecture/baseline-openai-e2e-chat)
+- [Azure Well-Architected Framework](https://learn.microsoft.com/en-us/azure/well-architected/)
+- [Microsoft Cloud Adoption Framework](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/)
+- [Azure AI Foundry: Build AI Agents](https://learn.microsoft.com/en-us/azure/ai-studio/how-to/develop/agents)

--- a/docs/architecture/ADRs.md
+++ b/docs/architecture/ADRs.md
@@ -38,6 +38,9 @@ This document indexes all architectural decisions for the Holiday Peak Hub accel
 | [ADR-030](adrs/adr-030-search-enrichment-bounded-context.md) | Search Enrichment as an Isolated Bounded Context | Accepted | 2026-03 |
 | [ADR-031](adrs/adr-031-mcp-internal-communication-policy.md) | MCP Internal Communication Policy Addendum | Accepted | 2026-03 |
 | [ADR-032](adrs/adr-032-self-healing-boundaries.md) | Self-Healing Boundaries, Risk Tiers, and Prohibited Actions | Accepted | 2026-04 |
+| [ADR-033](adrs/adr-033-helm-deployment-strategy.md) | Helm Deployment Strategy with Flux CD GitOps | Accepted | 2026-04 |
+| [ADR-034](adrs/adr-034-namespace-isolation-strategy.md) | Namespace Isolation Strategy (CRUD vs Agent Namespaces) | Accepted | 2026-04 |
+| [ADR-035](adrs/adr-035-api-center-apim-mcp-strategy.md) | API Center + APIM MCP Strategy | Accepted | 2026-04 |
 
 ## How to Use ADRs
 
@@ -98,11 +101,14 @@ Each ADR follows a standard template:
 - azd-first deployment with GitHub Actions CI/CD ([ADR-021](adrs/adr-021-azd-first-deployment.md))
 - AGIC/classic Application Gateway approach retained as historical context only ([ADR-026](adrs/adr-026-agic-traffic-management.md))
 - APIM + AGC as the canonical AKS edge ([ADR-027](adrs/adr-027-apim-agc-edge.md))
+- Helm deployment strategy with Flux CD GitOps reconciliation ([ADR-033](adrs/adr-033-helm-deployment-strategy.md))
+- Namespace isolation for CRUD and agent workloads ([ADR-034](adrs/adr-034-namespace-isolation-strategy.md))
 
 ### Governance
 - Git branch naming convention ([ADR-022](adrs/adr-022-branch-naming-convention.md))
 - MCP internal communication policy and rollout gates ([ADR-031](adrs/adr-031-mcp-internal-communication-policy.md))
 - Self-healing boundaries, risk tiers, and prohibited actions ([ADR-032](adrs/adr-032-self-healing-boundaries.md))
+- API Center + APIM MCP strategy for API governance ([ADR-035](adrs/adr-035-api-center-apim-mcp-strategy.md))
 
 ### Enterprise Integration
 - Enterprise resilience patterns (Circuit Breaker, Bulkhead, Rate Limiter) ([ADR-023](adrs/adr-023-enterprise-resilience-patterns.md))

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,17 +1,38 @@
 # Architecture Documentation
 
-This folder contains the canonical architecture, ADRs, component references, operational playbooks, and diagrams for Holiday Peak Hub.
+This folder contains the canonical architecture, ADRs, component references, operational playbooks, and diagrams for Holiday Peak Hub — a reference implementation for **Agentic Microservices** on Microsoft's AI and cloud platform.
 
 ## Canonical Documents
 
 - [Architecture Overview](architecture.md) — Primary technical architecture narrative (context, interactions, deployment)
-- [Architecture Decision Records](ADRs.md) — Full ADR index and status
+- [Architecture Decision Records](ADRs.md) — Full ADR index and status (35 ADRs)
 - [Components](components.md) — Library, app, and frontend component references
+- [Solution Architecture Diagrams](solution-architecture-diagrams.md) — System context, container, per-domain, and data flow Mermaid diagrams
+- [MAF Integration Rationale](maf-integration-rationale.md) — Why Microsoft Agent Framework is wrapped in `holiday-peak-lib`
+- [Standalone Deployment Guide](standalone-deployment-guide.md) — How to deploy a single agent service to AKS
+- [Test Coverage Gap Analysis](test-coverage-gap-analysis.md) — Coverage gaps, patterns, and wave-based remediation plan
 - [Architecture Compliance Review](architecture-compliance-review.md) — Branch-level ADR and policy conformance assessment
 - [Event Hub Topology Matrix](eventhub-topology-matrix.md) — Topic-level publisher/subscriber coverage contract and gap tracking
 - [Operational Playbooks](playbooks/README.md) — Incident runbooks aligned to governance policies
 - [Diagrams](diagrams/README.md) — Draw.io C4 diagrams and sequence flow documents
 - [Business Summary](business-summary.md) — Executive architecture summary
+
+## Agentic Microservices Reference
+
+This repository positions Holiday Peak Hub as a reference for building agentic microservices on Azure. See [Agentic Microservices Reference](../agentic-microservices-reference.md) for the full positioning document.
+
+## Microsoft Technology Cross-References
+
+| Topic | Official Documentation |
+|-------|----------------------|
+| Microsoft Agent Framework (MAF) | [MAF Python SDK](https://learn.microsoft.com/en-us/python/api/overview/azure/agent-framework) |
+| Azure AI Foundry Agents | [Foundry Agents overview](https://learn.microsoft.com/en-us/azure/ai-studio/how-to/develop/agents) |
+| Azure AI Search | [AI Search overview](https://learn.microsoft.com/en-us/azure/search/search-what-is-azure-search) |
+| Azure Cosmos DB for NoSQL | [Cosmos DB data modeling](https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/modeling-data) |
+| Azure Kubernetes Service | [AKS baseline](https://learn.microsoft.com/en-us/azure/architecture/reference-architectures/containers/aks/baseline-aks) |
+| Microservices on Azure | [Azure Architecture Center](https://learn.microsoft.com/en-us/azure/architecture/microservices/) |
+| Event-driven architecture | [Event-driven patterns](https://learn.microsoft.com/en-us/azure/architecture/guide/architecture-styles/event-driven) |
+| Well-Architected Framework | [WAF overview](https://learn.microsoft.com/en-us/azure/well-architected/) |
 
 ## Governance Alignment
 

--- a/docs/architecture/components.md
+++ b/docs/architecture/components.md
@@ -9,13 +9,24 @@ Core micro-framework providing reusable patterns for retail AI agents.
 | Component | Path | Description | Pattern |
 |-----------|------|-------------|---------|
 | [Adapters](components/libs/adapters.md) | `lib/src/holiday_peak_lib/adapters/` | Pluggable retail system integrations | Adapter Pattern |
-| [Agents](components/libs/agents.md) | `lib/src/holiday_peak_lib/agents/` | Agent orchestration and MCP wrappers | Builder Pattern (memory) |
-| [Memory](components/libs/memory.md) | `lib/src/holiday_peak_lib/memory/` | Three-tier memory management | Tiered Caching |
+| [Agents](components/libs/agents.md) | `lib/src/holiday_peak_lib/agents/` | Agent orchestration, MCP wrappers, guardrails | Builder Pattern (memory) |
+| [Memory](components/libs/memory.md) | `lib/src/holiday_peak_lib/agents/memory/` | Three-tier memory with parallel I/O | Tiered Caching |
 | [Orchestration](components/libs/orchestration.md) | `lib/src/holiday_peak_lib/orchestration/` | SAGA choreography helpers | Event-driven |
 | [Schemas](components/libs/schemas.md) | `lib/src/holiday_peak_lib/schemas/` | Pydantic models for data contracts | Domain Models |
 | [Utils](components/libs/utils.md) | `lib/src/holiday_peak_lib/utils/` | Logging, config, retry logic | Utilities |
 | [Integrations](components/libs/integrations.md) | `lib/src/holiday_peak_lib/integrations/` | Connector contracts, registry, writeback | Integration Pattern |
 | [Connectors](components/libs/connectors.md) | `lib/src/holiday_peak_lib/connectors/` | Enterprise system connectors | Adapter Pattern |
+
+### Agent Runtime (v2.1.0)
+
+| Component | Path | Purpose |
+|-----------|------|---------|
+| FoundryAgentInvoker | `agents/foundry.py` | MAF `FoundryAgent` wrapper — routes tools and middleware correctly |
+| FoundryInvoker (deprecated) | `agents/foundry.py` | Legacy invoker — tools silently dropped, replaced by FoundryAgentInvoker |
+| Enrichment Guardrail | `agents/guardrails/enrichment_guardrail.py` | Validation layer for enrichment outputs |
+| Memory Tools | `agents/memory/builder.py` | `get_memory`, `set_memory`, `search_memory` tools for agent use |
+| Parallel Memory I/O | `agents/memory/` | `asyncio.gather`-based concurrent hot/warm/cold tier operations |
+| `gather_adapters` | `agents/base_agent.py` | Helper for concurrent adapter initialization |
 
 ## Enterprise Connectors (v1.1.0)
 

--- a/docs/architecture/components/libs/agents.md
+++ b/docs/architecture/components/libs/agents.md
@@ -96,12 +96,22 @@ response = await agent.handle({"query": "Check inventory for SKU-123"})
 
 ✅ **Foundry Integration Helpers**:
 
-- `FoundryAgentConfig` + `build_foundry_model_target` (Azure AI Foundry Agents via `AIProjectClient`)
+- `FoundryAgentConfig` + `build_foundry_model_target` (Azure AI Foundry Agents)
+- `FoundryAgentInvoker`: wraps the Microsoft Agent Framework `FoundryAgent` runtime, ensuring tools and middleware are properly forwarded (replaces deprecated `FoundryInvoker`)
 - Foundry prompt governance in `BaseRetailAgent` (system/developer prompts are stripped in Foundry mode)
 - Agents V2 provisioning path (`project_client.agents.create_version` with `PromptAgentDefinition`)
-- Agents V2 execution path (`openai_client.conversations` + `openai_client.responses` + `agent_reference`)
 - **42 V2 agents provisioned** in Foundry project `aipholidaris` (21 services × 2 roles: fast + rich)
-- SDK requirement: `azure-ai-projects>=2.0.0b4` for V2 `create_version` support
+- SDK requirement: `agent-framework>=1.0.1` for MAF GA runtime
+
+✅ **Memory Tools and Parallel I/O**:
+
+- `get_memory`, `set_memory`, `search_memory` tools exposed for agent use
+- `asyncio.gather`-based concurrent hot/warm/cold tier operations
+- `gather_adapters` helper for concurrent adapter initialization
+
+✅ **Guardrails**:
+
+- `enrichment_guardrail.py`: validation layer for enrichment outputs
 
 ✅ **MCP Server Exposure**:
 
@@ -132,8 +142,6 @@ response = await agent.handle({"query": "Check inventory for SKU-123"})
 
 ### Production Integration Example (Microsoft Agent Framework)
 
-```python
-from typing import Any
 ```python
 from typing import Any
 

--- a/docs/architecture/components/libs/memory.md
+++ b/docs/architecture/components/libs/memory.md
@@ -116,6 +116,9 @@ Builder-level features:
 ✅ **MemoryBuilder**: Fluent builder that assembles tiers and rules into a `MemoryClient`  
 ✅ **MemoryClient**: Cascading read/write orchestration across tiers  
 ✅ **MemorySettings**: Environment-driven configuration for tier endpoints  
+✅ **Parallel I/O**: Hot/warm/cold tier reads and writes execute concurrently via `asyncio.gather` (PR #800)  
+✅ **Memory Tools**: `get_memory`, `set_memory`, `search_memory` tools exposed for agent use  
+✅ **gather_adapters**: Concurrent adapter initialization helper in `BaseRetailAgent`
 
 ## What's NOT Implemented
 

--- a/docs/architecture/diagrams/README.md
+++ b/docs/architecture/diagrams/README.md
@@ -18,6 +18,9 @@ Canonical diagram index for Holiday Peak Hub.
 | `sequence-catalog-search.md` | E-commerce | Search flow with model routing and enrichment |
 | `sequence-inventory-health.md` | Inventory | Health monitoring, anomaly detection, and remediation |
 | `sequence-returns-support.md` | Logistics/CRM | Returns evaluation and resolution flow |
+| `sequence-foundry-agent-invocation.md` | Agent Runtime | FoundryAgentInvoker → MAF FoundryAgent tool-forwarding flow |
+| `sequence-memory-parallel-io.md` | Memory | Three-tier parallel read/write via asyncio.gather |
+| `sequence-flux-gitops-deployment.md` | Infrastructure | Flux CD GitOps reconciliation and namespace-isolated deploy |
 
 ## Usage Guidelines
 

--- a/docs/architecture/diagrams/sequence-flux-gitops-deployment.md
+++ b/docs/architecture/diagrams/sequence-flux-gitops-deployment.md
@@ -1,0 +1,94 @@
+# Sequence Diagram: Flux CD GitOps Deployment
+
+This diagram illustrates the GitOps deployment pipeline using Flux CD as implemented in ADR-033 (PR #785, #792).
+
+## Flow Overview
+
+1. **PR Merge** → Developer merges to `main`
+2. **CI Build** → GitHub Actions builds and pushes container images to ACR
+3. **Manifest Update** → Rendered Kubernetes manifests committed to manifests branch
+4. **Flux Reconciliation** → Flux detects changes and applies to AKS clusters
+5. **Health Check** → Flux validates rollout health before proceeding
+6. **Self-Healing** → Flux auto-remediates drift from desired state
+
+## Sequence Diagram
+
+```mermaid
+%%{init: {'theme':'base', 'themeVariables': {
+  'primaryColor':'#FFB3BA',
+  'primaryTextColor':'#000',
+  'primaryBorderColor':'#FF8B94',
+  'lineColor':'#BAE1FF',
+  'secondaryColor':'#BAE1FF',
+  'tertiaryColor':'#FFFFFF'
+}}}%%
+sequenceDiagram
+    actor Dev as Developer
+    participant GH as GitHub (main)
+    participant CI as GitHub Actions
+    participant ACR as Azure Container Registry
+    participant Manifests as Manifests Branch
+    participant Flux as Flux CD Controller
+    participant AKS as AKS Cluster
+    participant NS as K8s Namespace
+
+    Dev->>GH: Merge PR to main
+    GH->>CI: Trigger deploy-azd.yml
+
+    Note over CI: Step 1: Build & Push
+    CI->>CI: Detect changed services (matrix filter)
+    CI->>ACR: docker push (changed images only)
+    ACR-->>CI: Image digest
+
+    Note over CI: Step 2: Render Manifests
+    CI->>CI: helm template (per service)
+    CI->>Manifests: Commit rendered YAML
+
+    Note over Flux,NS: Step 3: GitOps Reconciliation
+    Flux->>Manifests: Poll for changes (interval: 1m)
+    Manifests-->>Flux: New manifest detected
+
+    Flux->>Flux: Validate YAML schema
+    Flux->>AKS: kubectl apply (dry-run)
+    AKS-->>Flux: Dry-run OK
+
+    Note over Flux: Step 4: Namespace-Isolated Deploy
+    Flux->>NS: Apply to target namespace
+    NS-->>Flux: Resources created/updated
+
+    Note over Flux: Step 5: Health Check
+    Flux->>NS: Watch rollout status
+    NS-->>Flux: Pods ready, health probes passing
+
+    alt Rollout Healthy
+        Flux->>Flux: Mark reconciliation success
+    else Rollout Failed
+        Flux->>NS: Rollback to previous revision
+        NS-->>Flux: Rollback complete
+        Flux->>GH: Create alert (webhook)
+    end
+
+    Note over Flux,NS: Ongoing: Drift Detection
+    loop Every reconciliation interval
+        Flux->>NS: Compare desired vs actual state
+        alt Drift detected
+            Flux->>NS: Re-apply desired state
+            Note over Flux: Self-healing remediation
+        end
+    end
+```
+
+## Namespace Isolation (ADR-034)
+
+Services are deployed to two isolated namespaces per ADR-034:
+
+| Namespace | Services | Network Policy |
+|-----------|----------|----------------|
+| `holiday-peak-crud` | crud-service (1 service) | Allow: UI ingress, agent egress |
+| `holiday-peak-agents` | All 26 agent services (eCommerce, CRM, Inventory, Logistics, Product Mgmt, Search, Truth Layer) | Allow: CRUD, Event Hubs, AI Search, Cosmos DB |
+
+## Related
+
+- [ADR-033: Helm Deployment Strategy](../adrs/adr-033-helm-deployment-strategy.md)
+- [ADR-034: Namespace Isolation](../adrs/adr-034-namespace-isolation-strategy.md)
+- [Infrastructure README](../../../.infra/README.md)

--- a/docs/architecture/diagrams/sequence-foundry-agent-invocation.md
+++ b/docs/architecture/diagrams/sequence-foundry-agent-invocation.md
@@ -1,0 +1,84 @@
+# Sequence Diagram: FoundryAgentInvoker Flow
+
+This diagram illustrates the agent invocation flow using the Microsoft Agent Framework (MAF) `FoundryAgentInvoker`, which replaced the legacy `FoundryInvoker` in PR #802.
+
+## Flow Overview
+
+1. **Request** → FastAPI endpoint receives invoke request
+2. **Agent Build** → `AgentBuilder` composes agent with tools, memory, and model config
+3. **Model Routing** → SLM-first assessment, optional upgrade to LLM
+4. **MAF Invocation** → `FoundryAgentInvoker` delegates to `FoundryAgent` runtime
+5. **Tool Execution** → Tools forwarded through MAF middleware (not silently dropped)
+6. **Response** → Structured result returned through the agent pipeline
+
+## Sequence Diagram
+
+```mermaid
+%%{init: {'theme':'base', 'themeVariables': {
+  'primaryColor':'#FFB3BA',
+  'primaryTextColor':'#000',
+  'primaryBorderColor':'#FF8B94',
+  'lineColor':'#BAE1FF',
+  'secondaryColor':'#BAE1FF',
+  'tertiaryColor':'#FFFFFF'
+}}}%%
+sequenceDiagram
+    actor Client
+    participant API as FastAPI App
+    participant Builder as AgentBuilder
+    participant Agent as BaseRetailAgent
+    participant Invoker as FoundryAgentInvoker
+    participant MAF as FoundryAgent (MAF)
+    participant Foundry as Azure AI Foundry
+    participant Tools as MCP Tools
+    participant Memory as Memory Stack
+
+    Client->>API: POST /invoke {"query": "..."}
+    API->>Builder: build_service_app(slm_config, llm_config)
+    Builder->>Agent: compose(tools, memory, guardrails)
+
+    Note over Agent: Step 1: Load Context
+    Agent->>Memory: parallel_get(hot, warm)
+    Memory-->>Agent: {session, profile, history}
+
+    Note over Agent: Step 2: SLM-First Routing
+    Agent->>Invoker: invoke(query, context, tools)
+    Invoker->>MAF: FoundryAgent.create(agent_id, tools)
+    MAF->>Foundry: POST /agents/{fast}/invoke
+    Foundry-->>MAF: {response, tool_calls}
+
+    alt Tool calls present
+        Note over MAF: Tools forwarded via MAF middleware
+        MAF->>Tools: execute(tool_calls)
+        Tools-->>MAF: tool_results
+        MAF->>Foundry: POST /agents/{fast}/continue
+        Foundry-->>MAF: {final_response}
+    end
+
+    MAF-->>Invoker: agent_response
+
+    alt Confidence < threshold
+        Note over Invoker: Upgrade to LLM
+        Invoker->>MAF: FoundryAgent.create(agent_id_rich, tools)
+        MAF->>Foundry: POST /agents/{rich}/invoke
+        Foundry-->>MAF: {response, tool_calls}
+        MAF-->>Invoker: agent_response
+    end
+
+    Invoker-->>Agent: structured_result
+    Agent->>Memory: parallel_set(hot, warm)
+    Agent-->>API: AgentResponse
+    API-->>Client: 200 OK {result}
+```
+
+## Key Design Decisions
+
+- **MAF `FoundryAgent` runtime**: Tools are registered with the agent at creation time and forwarded through MAF middleware, solving the silent tool-dropping issue in the legacy `FoundryInvoker`.
+- **Parallel memory I/O**: Hot and warm memory are read/written concurrently via `asyncio.gather`.
+- **SLM-first with LLM upgrade**: Every request starts with the fast (SLM) model; only complex queries escalate to the rich (LLM) model.
+
+## Related
+
+- [ADR-013: Model Routing](../adrs/adr-013-model-routing.md)
+- [Agent Library Reference](../components/libs/agents.md)
+- [Components Overview](../components.md)

--- a/docs/architecture/diagrams/sequence-memory-parallel-io.md
+++ b/docs/architecture/diagrams/sequence-memory-parallel-io.md
@@ -1,0 +1,92 @@
+# Sequence Diagram: Memory Parallel I/O
+
+This diagram illustrates the three-tier memory architecture with parallel read/write operations introduced in PR #800.
+
+## Flow Overview
+
+1. **Read Phase** → Hot (Redis) and Warm (Cosmos DB) fetched concurrently via `asyncio.gather`
+2. **Merge** → Results combined with hot-tier priority
+3. **Agent Processing** → Agent uses merged context
+4. **Write Phase** → Updates written to all tiers concurrently
+5. **Cold Tier** → Blob Storage used for archival/overflow (async, non-blocking)
+
+## Sequence Diagram
+
+```mermaid
+%%{init: {'theme':'base', 'themeVariables': {
+  'primaryColor':'#FFB3BA',
+  'primaryTextColor':'#000',
+  'primaryBorderColor':'#FF8B94',
+  'lineColor':'#BAE1FF',
+  'secondaryColor':'#BAE1FF',
+  'tertiaryColor':'#FFFFFF'
+}}}%%
+sequenceDiagram
+    participant Agent as BaseRetailAgent
+    participant Builder as MemoryBuilder
+    participant Hot as HotMemory (Redis)
+    participant Warm as WarmMemory (Cosmos DB)
+    participant Cold as ColdMemory (Blob)
+
+    Note over Agent,Cold: Read Phase — Parallel I/O via asyncio.gather
+
+    Agent->>Builder: gather_adapters(key)
+    par Hot Read
+        Builder->>Hot: get(key)
+        Hot-->>Builder: {session_context, ttl: 300s}
+    and Warm Read
+        Builder->>Warm: get(key)
+        Warm-->>Builder: {profile, history, preferences}
+    end
+
+    Builder->>Builder: merge(hot_result, warm_result)
+    Note over Builder: Hot-tier values take precedence
+    Builder-->>Agent: merged_context
+
+    Note over Agent: Agent processes request with full context
+
+    Agent->>Agent: invoke(query, merged_context)
+
+    Note over Agent,Cold: Write Phase — Parallel I/O
+
+    Agent->>Builder: parallel_set(key, updates)
+    par Hot Write
+        Builder->>Hot: set(key, session_update, ttl=300)
+        Hot-->>Builder: OK
+    and Warm Write
+        Builder->>Warm: upsert(key, enriched_profile)
+        Warm-->>Builder: OK
+    and Cold Write (async)
+        Builder->>Cold: append(key, interaction_log)
+        Cold-->>Builder: OK
+    end
+
+    Builder-->>Agent: write_complete
+```
+
+## Performance Impact
+
+| Operation | Before (Sequential) | After (Parallel) | Improvement |
+|-----------|-------------------|------------------|-------------|
+| Memory read (2 tiers) | ~120ms | ~65ms | ~46% faster |
+| Memory write (3 tiers) | ~180ms | ~70ms | ~61% faster |
+| End-to-end agent invoke | ~450ms | ~320ms | ~29% faster |
+
+## Configuration
+
+Memory adapters are configured via environment variables:
+
+| Variable | Tier | Purpose |
+|----------|------|---------|
+| `REDIS_URL` | Hot | Session and cache storage |
+| `COSMOS_ACCOUNT_URI` | Warm | Profile and history persistence |
+| `COSMOS_DATABASE` | Warm | Database name |
+| `COSMOS_CONTAINER` | Warm | Container name |
+| `BLOB_ACCOUNT_URL` | Cold | Archival storage |
+| `BLOB_CONTAINER` | Cold | Container name |
+
+## Related
+
+- [Memory Library Reference](../components/libs/memory.md)
+- [Components Overview](../components.md)
+- [ADR-008: Memory Tiers](../adrs/adr-008-memory-tiers.md)

--- a/docs/architecture/maf-integration-rationale.md
+++ b/docs/architecture/maf-integration-rationale.md
@@ -1,0 +1,220 @@
+# Microsoft Agent Framework (MAF) Integration Rationale
+
+**Version**: 1.0
+**Last Updated**: 2026-04-12
+**Status**: Implemented (PR #802, agent-framework>=1.0.1 GA)
+
+---
+
+## Executive Summary
+
+Holiday Peak Hub uses [Microsoft Agent Framework](https://learn.microsoft.com/en-us/python/api/overview/azure/agent-framework) (MAF) as the runtime layer for all AI agent invocations. MAF is wrapped inside `holiday-peak-lib` rather than consumed directly by the 26 agent services. This document explains **why**, **how**, and **what trade-offs** this creates.
+
+---
+
+## Decision Context
+
+### Problem Statement
+
+Each of the 26 agent services needs to:
+1. Invoke AI models via Azure AI Foundry (GPT-5, GPT-5-nano, etc.)
+2. Forward tool definitions so the model can call MCP tools
+3. Handle streaming and non-streaming responses
+4. Integrate with the three-tier memory architecture
+5. Emit structured telemetry to Azure Monitor
+
+Without a shared abstraction, each service would independently:
+- Depend on `agent-framework` and `azure-ai-projects` SDKs
+- Implement tool registration and forwarding logic
+- Handle SDK version migrations separately
+- Duplicate error handling, retry, and telemetry code
+
+### Decision
+
+**Wrap MAF behind `FoundryAgentInvoker` in `holiday-peak-lib`, making the lib the single consumer of `agent-framework`.**
+
+---
+
+## Architecture
+
+```mermaid
+%%{init: {'theme':'base', 'themeVariables': {
+  'primaryColor':'#FFB3BA',
+  'primaryTextColor':'#000',
+  'primaryBorderColor':'#FF8B94',
+  'lineColor':'#BAE1FF',
+  'secondaryColor':'#BAE1FF',
+  'tertiaryColor':'#FFFFFF'
+}}}%%
+graph TB
+    subgraph "26 Agent Services"
+        S1["ecommerce-catalog-search"]
+        S2["crm-campaign-intelligence"]
+        S3["truth-ingestion"]
+        SN["... (23 more)"]
+    end
+
+    subgraph "holiday-peak-lib"
+        BA["BaseRetailAgent"]
+        AB["AgentBuilder"]
+        FAI["FoundryAgentInvoker"]
+        MT["ModelTarget"]
+        GR["Guardrails"]
+        MEM["MemoryClient"]
+        MCP["FastAPIMCPServer"]
+    end
+
+    subgraph "Microsoft Agent Framework"
+        MAF_BA["BaseAgent"]
+        MAF_FA["FoundryAgent"]
+        MAF_MSG["Message Protocol"]
+    end
+
+    subgraph "Azure AI Foundry"
+        PROJ["AIProjectClient"]
+        AGENT_FAST["Fast Agent (SLM)"]
+        AGENT_RICH["Rich Agent (LLM)"]
+    end
+
+    S1 & S2 & S3 & SN --> BA
+    BA -->|extends| MAF_BA
+    BA --> AB
+    AB --> FAI
+    FAI --> MAF_FA
+    MAF_FA --> PROJ
+    PROJ --> AGENT_FAST & AGENT_RICH
+    AB --> GR & MEM & MCP
+```
+
+### Layer Responsibilities
+
+| Layer | Responsibility | Package |
+|-------|---------------|---------|
+| **Agent Services** | Domain logic (`handle()` method), MCP tool definitions, event handlers | Each app's `src/` |
+| **holiday-peak-lib** | Agent base class, builder, memory, guardrails, resilience, telemetry, MAF wrapping | `holiday-peak-lib>=0.2.0` |
+| **Microsoft Agent Framework** | Foundry agent runtime, message protocol, tool forwarding middleware | `agent-framework>=1.0.1` |
+| **Azure AI Foundry** | Model hosting, agent provisioning, Agents V2 API | `azure-ai-projects>=2.0.0b4` |
+
+---
+
+## Key Classes
+
+### `FoundryAgentInvoker` (`agents/foundry.py`)
+
+The core adapter between the lib's `ModelTarget` interface and MAF's `FoundryAgent` runtime:
+
+```python
+class FoundryAgentInvoker:
+    """Wraps MAF FoundryAgent to produce ModelTarget-compatible invocations."""
+
+    async def invoke(self, messages, *, tools=None, **kwargs):
+        # 1. Create FoundryAgent with tools registered
+        # 2. Send messages through MAF middleware
+        # 3. Handle tool calls (forwarded by MAF, not dropped)
+        # 4. Aggregate streaming chunks if FOUNDRY_STREAM=true
+        # 5. Return normalized response
+```
+
+**Critical fix (PR #802)**: The legacy `FoundryInvoker` silently dropped tool definitions because it bypassed MAF's middleware layer. `FoundryAgentInvoker` routes through `FoundryAgent.create()`, which properly registers tools with the Foundry runtime.
+
+### `BaseRetailAgent` (`agents/base_agent.py`)
+
+Extends MAF's `BaseAgent` with retail-specific behavior:
+
+- **SLM-first routing**: Every request starts with the fast (SLM) model; complex queries upgrade to the rich (LLM) model based on a configurable `complexity_threshold`
+- **Memory injection**: Three-tier memory (hot/warm/cold) via `MemoryBuilder`
+- **Provider policy**: `FoundryProviderPolicyStrategy` enforces Foundry-specific message sanitization
+- **Tool delegation**: Tools are registered through `AgentBuilder` and forwarded to the invocation layer
+
+### `AgentBuilder` (`agents/builder.py`)
+
+Fluent builder for agent assembly:
+
+```python
+agent = (
+    AgentBuilder()
+    .with_agent(CatalogSearchAgent)
+    .with_foundry_models(slm_config=slm, llm_config=llm, complexity_threshold=0.7)
+    .with_memory_builder(memory_builder)
+    .with_mcp(mcp_server)
+    .with_tools(domain_tools)
+    .build()
+)
+```
+
+---
+
+## Benefits Realized
+
+### 1. Single-Pass SDK Migration
+
+When migrating from `FoundryInvoker` to `FoundryAgentInvoker` (PR #802):
+- **1 class changed** in `lib/src` → 27 services updated via dependency
+- **0 application code changes** needed in any agent service
+- **55 files touched** (mostly lockfile regeneration), but zero domain logic edits
+
+### 2. Import Isolation
+
+Agent services never import from `agent_framework` directly:
+
+```python
+# ✅ Correct — agent services import from lib
+from holiday_peak_lib.agents import BaseRetailAgent, AgentBuilder
+
+# ❌ Forbidden — no direct MAF imports in services
+from agent_framework import BaseAgent  # NEVER
+```
+
+This is enforced by convention and validated in PR reviews.
+
+### 3. Centralized Telemetry
+
+`FoundryTracer` (in `utils/telemetry.py`) wraps OpenTelemetry with Foundry-aware attributes:
+- Span names include agent ID and model deployment
+- Tool call durations measured per tool
+- Memory tier latencies tracked
+- All traces flow to Azure Application Insights
+
+### 4. Testability
+
+Services test their `handle()` logic with mock `ModelTarget` invokers — no MAF runtime needed:
+
+```python
+async def mock_invoker(messages, **kwargs):
+    return {"role": "assistant", "content": "mock response"}
+
+agent.slm = ModelTarget(name="mock", model="test", invoker=mock_invoker)
+```
+
+This enables 1136 lib tests + 660 app tests to run without Azure credentials in CI.
+
+---
+
+## Trade-offs
+
+| Trade-off | Impact | Mitigation |
+|-----------|--------|------------|
+| **Coupling to lib** | All services depend on `holiday-peak-lib` | Versioned releases, backward compatibility policy |
+| **Indirection** | One additional layer between service and MAF | Minimal runtime overhead (<1ms per invocation) |
+| **Feature lag** | New MAF features require lib update first | Single codebase, rapid turnaround (PR #802: 1 day) |
+| **Monorepo assumption** | lib installed from Git path, not PyPI | Standard for reference architectures; could publish to PyPI if needed |
+
+---
+
+## Microsoft Reference Documentation
+
+| Resource | URL |
+|----------|-----|
+| Microsoft Agent Framework Python API | https://learn.microsoft.com/en-us/python/api/overview/azure/agent-framework |
+| Azure AI Foundry documentation | https://learn.microsoft.com/en-us/azure/ai-studio/ |
+| Azure AI Foundry Agents quickstart | https://learn.microsoft.com/en-us/azure/ai-studio/how-to/develop/agents |
+| AI Project Client SDK | https://learn.microsoft.com/en-us/python/api/azure-ai-projects/ |
+| OpenTelemetry for Azure Monitor | https://learn.microsoft.com/en-us/azure/azure-monitor/app/opentelemetry-enable |
+
+---
+
+## Related ADRs
+
+- [ADR-013: Model Routing](adrs/adr-013-model-routing.md)
+- [ADR-008: Memory Tiers](adrs/adr-008-memory-tiers.md)
+- [ADR-008: Circuit Breaker Pattern](adrs/adr-023-enterprise-resilience-patterns.md)

--- a/docs/architecture/solution-architecture-diagrams.md
+++ b/docs/architecture/solution-architecture-diagrams.md
@@ -1,0 +1,387 @@
+# Solution Architecture Diagrams
+
+**Last Updated**: 2026-04-12
+
+This document contains the system-level and per-domain Mermaid diagrams for the Holiday Peak Hub agentic microservices platform.
+
+---
+
+## 1. System Context (C4 Level 1)
+
+External actors, channels, and the system boundary.
+
+```mermaid
+%%{init: {'theme':'base', 'themeVariables': {'primaryColor':'#FFB3BA','primaryTextColor':'#000','primaryBorderColor':'#FF8B94','lineColor':'#BAE1FF','secondaryColor':'#BAE1FF','tertiaryColor':'#FFFFFF'}}}%%
+graph TB
+    Customer["👤 Customer<br/>(Browser / Mobile)"]
+    Staff["👤 Staff<br/>(Admin Dashboard)"]
+    PIM["📦 External PIM<br/>(Akeneo / Salsify)"]
+    DAM["🖼️ External DAM<br/>(Cloudinary)"]
+    Carrier["🚛 Carrier APIs<br/>(FedEx / UPS / DHL)"]
+    Payment["💳 Payment Gateway<br/>(Stripe)"]
+
+    subgraph HPH["Holiday Peak Hub Platform"]
+        UI["Next.js Frontend"]
+        APIM["Azure API Management"]
+        CRUD["CRUD Service"]
+        Agents["26 Agent Services<br/>(7 Domains)"]
+        EH["Azure Event Hubs"]
+        Memory["Three-Tier Memory<br/>(Redis / Cosmos / Blob)"]
+        Foundry["Azure AI Foundry<br/>(GPT-5 / GPT-5-nano)"]
+        Search["Azure AI Search"]
+    end
+
+    Customer --> UI
+    Staff --> UI
+    UI --> APIM --> CRUD
+    APIM --> Agents
+    CRUD --> EH --> Agents
+    Agents --> Memory
+    Agents --> Foundry
+    Agents --> Search
+    CRUD --> Payment
+    Agents --> PIM
+    Agents --> DAM
+    Agents --> Carrier
+```
+
+---
+
+## 2. Container View (C4 Level 2)
+
+Azure runtime composition across AKS, platform services, and external integrations.
+
+```mermaid
+%%{init: {'theme':'base', 'themeVariables': {'primaryColor':'#FFB3BA','primaryTextColor':'#000','primaryBorderColor':'#FF8B94','lineColor':'#BAE1FF','secondaryColor':'#BAE1FF','tertiaryColor':'#FFFFFF'}}}%%
+graph TB
+    subgraph SWA["Azure Static Web Apps"]
+        UI["Next.js 15 UI<br/><i>TypeScript / Tailwind</i>"]
+    end
+
+    subgraph APIM["Azure API Management"]
+        GW["API Gateway<br/><i>JWT auth, rate limiting,<br/>AI policies</i>"]
+    end
+
+    subgraph AKS["Azure Kubernetes Service"]
+        subgraph CrudNS["namespace: holiday-peak-crud"]
+            CRUD["crud-service<br/><i>FastAPI / PostgreSQL</i>"]
+        end
+
+        subgraph AgentsNS["namespace: holiday-peak-agents"]
+            subgraph EcomGrp["eCommerce Domain"]
+                CS["catalog-search"]
+                PDE["product-detail-enrichment"]
+                CI["cart-intelligence"]
+                CKS["checkout-support"]
+                OS["order-status"]
+            end
+
+            subgraph CrmGrp["CRM Domain"]
+                PA["profile-aggregation"]
+                SP["segmentation-personalization"]
+                CAM["campaign-intelligence"]
+                SA["support-assistance"]
+            end
+
+            subgraph InvGrp["Inventory Domain"]
+                AT["alerts-triggers"]
+                HC["health-check"]
+                JIT["jit-replenishment"]
+                RV["reservation-validation"]
+            end
+
+            subgraph LogGrp["Logistics Domain"]
+                CSel["carrier-selection"]
+                ETA["eta-computation"]
+                RS["returns-support"]
+                RID["route-issue-detection"]
+            end
+
+            subgraph PmGrp["Product Management Domain"]
+                ACP["acp-transformation"]
+                ASO["assortment-optimization"]
+                CSV["consistency-validation"]
+                NC["normalization-classification"]
+            end
+
+            subgraph SearchGrp["Search Domain"]
+                SEA["search-enrichment"]
+            end
+
+            subgraph TruthGrp["Truth Layer Domain"]
+                TI["truth-ingestion"]
+                TE["truth-enrichment"]
+                TH["truth-hitl"]
+                TX["truth-export"]
+            end
+        end
+    end
+
+    subgraph Data["Data & Messaging"]
+        PG["PostgreSQL<br/><i>Transactional</i>"]
+        Cosmos["Cosmos DB<br/><i>Warm memory</i>"]
+        Redis["Redis Cache<br/><i>Hot memory</i>"]
+        Blob["Blob Storage<br/><i>Cold memory</i>"]
+        EH["Event Hubs<br/><i>5 topics</i>"]
+    end
+
+    subgraph AI["AI & Search"]
+        Foundry["Azure AI Foundry<br/><i>SLM + LLM</i>"]
+        AIS["Azure AI Search<br/><i>Vector + hybrid</i>"]
+    end
+
+    UI --> GW
+    GW --> CRUD
+    GW --> CS
+    CRUD --> PG
+    CRUD --> EH
+    EH --> EcomNS & CrmNS & InvNS & LogNS & PmNS & SearchNS & TruthNS
+    EcomNS & CrmNS & InvNS & LogNS & PmNS & SearchNS & TruthNS --> Redis & Cosmos & Blob
+    EcomNS & CrmNS & InvNS & LogNS & PmNS & SearchNS & TruthNS --> Foundry
+    CS & SEA --> AIS
+```
+
+---
+
+## 3. eCommerce Domain
+
+Five agents handling search, browsing, cart, checkout, and order tracking.
+
+```mermaid
+%%{init: {'theme':'base', 'themeVariables': {'primaryColor':'#FFB3BA','primaryTextColor':'#000','primaryBorderColor':'#FF8B94','lineColor':'#BAE1FF','secondaryColor':'#BAE1FF','tertiaryColor':'#FFFFFF'}}}%%
+graph LR
+    CRUD["CRUD Service"]
+    EH["Event Hubs"]
+
+    subgraph ECOM["eCommerce Domain (holiday-peak-agents)"]
+        CS["🔍 Catalog Search<br/><i>Vector + hybrid search<br/>SLM intent detection</i>"]
+        PDE["📝 Product Detail Enrichment<br/><i>AI-generated descriptions<br/>SEO optimization</i>"]
+        CI["🛒 Cart Intelligence<br/><i>Cross-sell, upsell<br/>Abandonment prevention</i>"]
+        CKS["✅ Checkout Support<br/><i>Validation, fraud signals<br/>Inventory hold</i>"]
+        OS["📦 Order Status<br/><i>Tracking enrichment<br/>Proactive notifications</i>"]
+    end
+
+    CRUD -->|product.created<br/>product.updated| EH
+    EH --> PDE
+    EH --> CS
+    CRUD -->|order.created| EH --> OS
+    CRUD -->|cart.updated| EH --> CI
+    CRUD <-->|sync + circuit breaker| CS & CKS
+    CS -->|MCP: get_enrichment| PDE
+    CKS -->|MCP: validate_stock| INV["Inventory Domain"]
+    CS --> AIS["Azure AI Search"]
+```
+
+**Key Interactions:**
+- `catalog-search` provides real-time search with SLM-first intent detection and vector search fallback
+- `product-detail-enrichment` generates AI descriptions, triggered by product events
+- `cart-intelligence` monitors cart state for cross-sell/upsell opportunities
+- `checkout-support` orchestrates inventory holds and fraud signal checks
+- `order-status` enriches tracking data with carrier intelligence
+
+---
+
+## 4. CRM Domain
+
+Four agents handling customer profiles, segmentation, campaigns, and support.
+
+```mermaid
+%%{init: {'theme':'base', 'themeVariables': {'primaryColor':'#FFB3BA','primaryTextColor':'#000','primaryBorderColor':'#FF8B94','lineColor':'#BAE1FF','secondaryColor':'#BAE1FF','tertiaryColor':'#FFFFFF'}}}%%
+graph LR
+    CRUD["CRUD Service"]
+    EH["Event Hubs"]
+
+    subgraph CRM["CRM Domain (holiday-peak-agents)"]
+        PA["👤 Profile Aggregation<br/><i>360° customer view<br/>Purchase history synthesis</i>"]
+        SP["🎯 Segmentation &<br/>Personalization<br/><i>Dynamic cohorts<br/>Behavioral clustering</i>"]
+        CAM["📣 Campaign Intelligence<br/><i>Channel optimization<br/>ROI prediction</i>"]
+        SA["🎧 Support Assistance<br/><i>Ticket classification<br/>Resolution suggestions</i>"]
+    end
+
+    CRUD -->|user.updated<br/>order.completed| EH
+    EH --> PA & SP
+    PA -->|MCP: get_profile| SP
+    SP -->|MCP: get_segments| CAM
+    CRUD <-->|sync| SA
+    SA -->|MCP: get_profile_context| PA
+```
+
+---
+
+## 5. Inventory Domain
+
+Four agents handling stock monitoring, replenishment, reservations, and alerts.
+
+```mermaid
+%%{init: {'theme':'base', 'themeVariables': {'primaryColor':'#FFB3BA','primaryTextColor':'#000','primaryBorderColor':'#FF8B94','lineColor':'#BAE1FF','secondaryColor':'#BAE1FF','tertiaryColor':'#FFFFFF'}}}%%
+graph LR
+    CRUD["CRUD Service"]
+    EH["Event Hubs"]
+
+    subgraph INV["Inventory Domain (holiday-peak-agents)"]
+        AT["🚨 Alerts & Triggers<br/><i>Stock threshold alerts<br/>Anomaly detection</i>"]
+        HC["📊 Health Check<br/><i>Inventory accuracy<br/>Cycle count scheduling</i>"]
+        JIT["📦 JIT Replenishment<br/><i>Demand forecasting<br/>Automated reorder</i>"]
+        RV["🔒 Reservation Validation<br/><i>Hold management<br/>Conflict resolution</i>"]
+    end
+
+    CRUD -->|inventory.updated<br/>reservation.created| EH
+    EH --> AT & HC & JIT & RV
+    AT -->|MCP: get_stock_level| HC
+    JIT -->|MCP: check_thresholds| AT
+    CRUD <-->|sync| RV
+```
+
+---
+
+## 6. Logistics Domain
+
+Four agents handling carrier selection, ETA computation, returns, and route monitoring.
+
+```mermaid
+%%{init: {'theme':'base', 'themeVariables': {'primaryColor':'#FFB3BA','primaryTextColor':'#000','primaryBorderColor':'#FF8B94','lineColor':'#BAE1FF','secondaryColor':'#BAE1FF','tertiaryColor':'#FFFFFF'}}}%%
+graph LR
+    CRUD["CRUD Service"]
+    EH["Event Hubs"]
+
+    subgraph LOG["Logistics Domain (holiday-peak-agents)"]
+        CSel["🚛 Carrier Selection<br/><i>Rate comparison<br/>SLA matching</i>"]
+        ETA["⏱️ ETA Computation<br/><i>Multi-carrier tracking<br/>Delay prediction</i>"]
+        RS["↩️ Returns Support<br/><i>Return eligibility<br/>Label generation</i>"]
+        RID["🗺️ Route Issue Detection<br/><i>Delay alerts<br/>Rerouting suggestions</i>"]
+    end
+
+    CRUD -->|shipment.created<br/>return.requested| EH
+    EH --> CSel & ETA & RS & RID
+    CSel -->|MCP: get_delivery_estimate| ETA
+    RID -->|MCP: get_carrier_status| ETA
+    CRUD <-->|sync| RS
+    CSel --> Carrier["External Carrier APIs"]
+```
+
+---
+
+## 7. Product Management Domain
+
+Four agents handling product data transformation, assortment, validation, and classification.
+
+```mermaid
+%%{init: {'theme':'base', 'themeVariables': {'primaryColor':'#FFB3BA','primaryTextColor':'#000','primaryBorderColor':'#FF8B94','lineColor':'#BAE1FF','secondaryColor':'#BAE1FF','tertiaryColor':'#FFFFFF'}}}%%
+graph LR
+    CRUD["CRUD Service"]
+    EH["Event Hubs"]
+
+    subgraph PM["Product Management Domain (holiday-peak-agents)"]
+        ACP["🔄 ACP Transformation<br/><i>Canonical product format<br/>Attribute mapping</i>"]
+        ASO["📈 Assortment Optimization<br/><i>Category performance<br/>Gap analysis</i>"]
+        CSV["✓ Consistency Validation<br/><i>Cross-channel parity<br/>Data quality scoring</i>"]
+        NC["🏷️ Normalization &<br/>Classification<br/><i>Taxonomy mapping<br/>Attribute normalization</i>"]
+    end
+
+    CRUD -->|product.created<br/>product.updated| EH
+    EH --> ACP & ASO & CSV & NC
+    ACP -->|MCP: validate_consistency| CSV
+    NC -->|MCP: get_taxonomy| ACP
+    ACP --> PIM["External PIM<br/>(Akeneo / Salsify)"]
+```
+
+---
+
+## 8. Search & Truth Layer Domains
+
+Five agents handling search enrichment and the Product Truth Layer pipeline.
+
+```mermaid
+%%{init: {'theme':'base', 'themeVariables': {'primaryColor':'#FFB3BA','primaryTextColor':'#000','primaryBorderColor':'#FF8B94','lineColor':'#BAE1FF','secondaryColor':'#BAE1FF','tertiaryColor':'#FFFFFF'}}}%%
+graph LR
+    CRUD["CRUD Service"]
+    EH["Event Hubs"]
+
+    subgraph SRCH["Search Domain (holiday-peak-agents)"]
+        SEA["🔍 Search Enrichment<br/><i>Index augmentation<br/>Embedding generation</i>"]
+    end
+
+    subgraph TRUTH["Truth Layer Domain (holiday-peak-agents)"]
+        TI["📥 Truth Ingestion<br/><i>Multi-source intake<br/>Schema validation</i>"]
+        TE["🧠 Truth Enrichment<br/><i>AI attribute generation<br/>Guardrail validation</i>"]
+        TH["👁️ Truth HITL<br/><i>Human review queue<br/>Approve / Reject / Edit</i>"]
+        TX["📤 Truth Export<br/><i>PIM writeback<br/>Channel distribution</i>"]
+    end
+
+    CRUD -->|product.updated| EH
+    EH --> SEA
+    SEA --> AIS["Azure AI Search"]
+
+    TI -->|MCP: enrich_product| TE
+    TE -->|MCP: submit_review| TH
+    TH -->|MCP: export_approved| TX
+    TX --> PIM["External PIM"]
+    TI --> EH2["Platform Jobs<br/>Event Hub"]
+```
+
+**Truth Layer Pipeline:**
+1. **Ingestion** — Receives product data from external PIM systems, validates schema, creates truth candidates
+2. **Enrichment** — AI generates missing attributes with guardrail validation (confidence thresholds, content policy)
+3. **HITL** — Human reviewers approve, reject, or edit enriched products with audit trail
+4. **Export** — Approved products written back to PIM and distributed to channels
+
+---
+
+## 9. Data Flow Overview
+
+Complete request lifecycle showing sync and async paths.
+
+```mermaid
+%%{init: {'theme':'base', 'themeVariables': {'primaryColor':'#FFB3BA','primaryTextColor':'#000','primaryBorderColor':'#FF8B94','lineColor':'#BAE1FF','secondaryColor':'#BAE1FF','tertiaryColor':'#FFFFFF'}}}%%
+sequenceDiagram
+    actor User
+    participant UI as Next.js Frontend
+    participant APIM as API Management
+    participant CRUD as CRUD Service
+    participant PG as PostgreSQL
+    participant EH as Event Hubs
+    participant Agent as Agent Service
+    participant Foundry as AI Foundry
+    participant Memory as Memory Stack
+
+    Note over User,Memory: Sync Path (< 200ms) — Transactional + Enrichment
+
+    User->>UI: Browse / Search / Checkout
+    UI->>APIM: REST request (JWT)
+    APIM->>CRUD: Validated request
+
+    alt Transactional (CRUD)
+        CRUD->>PG: SQL query / mutation
+        PG-->>CRUD: Result
+        CRUD-->>APIM: JSON response
+    else Enrichment (Agent sync)
+        CRUD->>Agent: REST call (circuit breaker)
+        Agent->>Memory: parallel get (Redis + Cosmos)
+        Agent->>Foundry: SLM invoke
+        Foundry-->>Agent: Response
+        Agent-->>CRUD: Enriched result
+        CRUD-->>APIM: JSON response
+    end
+
+    APIM-->>UI: Response
+    UI-->>User: Rendered page
+
+    Note over CRUD,Memory: Async Path — Event-Driven Processing
+
+    CRUD->>EH: Publish domain event
+    EH->>Agent: Consume event
+    Agent->>Foundry: LLM invoke (complex)
+    Agent->>Memory: Write results
+    Agent->>CRUD: Callback (if needed)
+```
+
+---
+
+## Related
+
+- [Architecture Overview](architecture.md)
+- [ADR Index](ADRs.md) — 35 architecture decision records
+- [Agentic Microservices Reference](../agentic-microservices-reference.md) — Positioning document
+- [MAF Integration Rationale](maf-integration-rationale.md) — Why MAF is wrapped in the lib
+- [Standalone Deployment Guide](standalone-deployment-guide.md)
+- [Diagrams Index](diagrams/README.md) — C4 draw.io and sequence diagrams

--- a/docs/architecture/solution-architecture-overview.md
+++ b/docs/architecture/solution-architecture-overview.md
@@ -1,0 +1,260 @@
+# Solution Architecture Overview
+
+This diagram presents the full Holiday Peak Hub architecture — a reference implementation for **Agentic Microservices** on Azure.
+
+## System Context (C4 Level 1)
+
+```mermaid
+%%{init: {'theme':'base', 'themeVariables': {
+  'primaryColor':'#FFB3BA',
+  'primaryTextColor':'#000',
+  'primaryBorderColor':'#FF8B94',
+  'lineColor':'#BAE1FF',
+  'secondaryColor':'#BAE1FF',
+  'tertiaryColor':'#FFFFFF'
+}}}%%
+graph TB
+    Customer["🛒 Customer<br/>(Browser/Mobile)"]
+    Staff["👤 Staff<br/>(Admin Console)"]
+
+    subgraph "Holiday Peak Hub"
+        UI["Next.js 15 UI<br/>Azure Static Web Apps"]
+        APIM["Azure API Management<br/>Gateway + AI Policies"]
+        CRUD["CRUD Service<br/>FastAPI + PostgreSQL"]
+
+        subgraph "Agent Mesh (26 Agents on AKS)"
+            EC["eCommerce Agents (5)"]
+            CRM["CRM Agents (4)"]
+            INV["Inventory Agents (4)"]
+            LOG["Logistics Agents (4)"]
+            PM["Product Mgmt Agents (4)"]
+            SE["Search Agent (1)"]
+            TL["Truth Layer Agents (4)"]
+        end
+    end
+
+    subgraph "Azure Platform Services"
+        Foundry["Azure AI Foundry<br/>GPT-5, GPT-5-nano"]
+        CosmosDB["Azure Cosmos DB<br/>Warm Memory"]
+        Redis["Azure Redis<br/>Hot Memory"]
+        Blob["Azure Blob Storage<br/>Cold Memory"]
+        EH["Azure Event Hubs<br/>Async Messaging"]
+        AIS["Azure AI Search<br/>Vector + Hybrid"]
+        PG["Azure PostgreSQL<br/>CRUD Data"]
+        KV["Azure Key Vault<br/>Secrets"]
+        AppIns["Application Insights<br/>Telemetry"]
+    end
+
+    Customer --> UI
+    Staff --> UI
+    UI --> APIM
+    APIM --> CRUD
+    APIM --> EC & CRM & INV & LOG & PM & SE & TL
+    CRUD --> PG
+    CRUD --> EH
+    EH --> EC & CRM & INV & LOG & PM & TL
+    EC & CRM & INV & LOG & PM & SE & TL --> Foundry
+    EC & CRM & INV & LOG & PM & SE & TL --> CosmosDB & Redis & Blob
+    SE --> AIS
+    EC & CRM & INV & LOG & PM & SE & TL --> KV
+    EC & CRM & INV & LOG & PM & SE & TL --> AppIns
+```
+
+## Container View (C4 Level 2) — Agent Service Internals
+
+```mermaid
+%%{init: {'theme':'base', 'themeVariables': {
+  'primaryColor':'#FFB3BA',
+  'primaryTextColor':'#000',
+  'primaryBorderColor':'#FF8B94',
+  'lineColor':'#BAE1FF',
+  'secondaryColor':'#BAE1FF',
+  'tertiaryColor':'#FFFFFF'
+}}}%%
+graph LR
+    subgraph "Any Agent Service"
+        MAIN["main.py<br/>create_standard_app()"]
+        AGENT["Domain Agent<br/>extends BaseRetailAgent"]
+        HANDLER["handle()"]
+        TOOLS["MCP Tools<br/>FastAPIMCPServer"]
+        ADAPT["Adapters<br/>CRM, Inventory, etc."]
+        EVENTS["Event Handlers<br/>EventHubSubscriber"]
+    end
+
+    subgraph "holiday-peak-lib"
+        AF["AppFactory"]
+        BA["BaseRetailAgent"]
+        AB["AgentBuilder"]
+        FAI["FoundryAgentInvoker"]
+        MEM["MemoryClient<br/>Hot|Warm|Cold"]
+        GR["Guardrails"]
+        CB["CircuitBreaker"]
+        TEL["FoundryTracer"]
+    end
+
+    subgraph "Microsoft Agent Framework"
+        MAF["FoundryAgent"]
+    end
+
+    MAIN --> AF
+    AF --> AB
+    AB --> AGENT
+    AGENT -->|extends| BA
+    AGENT --> HANDLER
+    HANDLER --> TOOLS & ADAPT & EVENTS
+    BA --> FAI
+    FAI --> MAF
+    BA --> MEM & GR & CB & TEL
+```
+
+## Domain Agent Map
+
+```mermaid
+%%{init: {'theme':'base', 'themeVariables': {
+  'primaryColor':'#FFB3BA',
+  'primaryTextColor':'#000',
+  'primaryBorderColor':'#FF8B94',
+  'lineColor':'#BAE1FF',
+  'secondaryColor':'#BAE1FF',
+  'tertiaryColor':'#FFFFFF'
+}}}%%
+graph TB
+    subgraph "eCommerce Domain"
+        E1["cart-intelligence<br/>:8001"]
+        E2["catalog-search<br/>:8002"]
+        E3["checkout-support<br/>:8003"]
+        E4["order-status<br/>:8004"]
+        E5["product-detail-enrichment<br/>:8005"]
+    end
+
+    subgraph "Product Management Domain"
+        P1["acp-transformation<br/>:8006"]
+        P2["assortment-optimization<br/>:8007"]
+        P3["consistency-validation<br/>:8008"]
+        P4["normalization-classification<br/>:8009"]
+    end
+
+    subgraph "CRM Domain"
+        C1["campaign-intelligence<br/>:8010"]
+        C2["profile-aggregation<br/>:8011"]
+        C3["segmentation-personalization<br/>:8012"]
+        C4["support-assistance<br/>:8013"]
+    end
+
+    subgraph "Inventory Domain"
+        I1["alerts-triggers<br/>:8014"]
+        I2["health-check<br/>:8015"]
+        I3["jit-replenishment<br/>:8016"]
+        I4["reservation-validation<br/>:8017"]
+    end
+
+    subgraph "Logistics Domain"
+        L1["carrier-selection<br/>:8018"]
+        L2["eta-computation<br/>:8019"]
+        L3["returns-support<br/>:8020"]
+        L4["route-issue-detection<br/>:8021"]
+    end
+
+    subgraph "Search Domain"
+        S1["search-enrichment-agent"]
+    end
+
+    subgraph "Truth Layer Domain"
+        T1["truth-ingestion"]
+        T2["truth-enrichment"]
+        T3["truth-export"]
+        T4["truth-hitl"]
+    end
+```
+
+## Data Flow Patterns
+
+### Pattern 1: Transactional (Frontend → CRUD → Database)
+```
+Customer → UI → APIM → CRUD Service → PostgreSQL
+                                    ↓
+                              Event Hubs (async notification)
+```
+
+### Pattern 2: Agent-Enriched (CRUD → Agent → CRUD)
+```
+CRUD Service → Agent REST endpoint (circuit breaker, <200ms)
+            → Agent invokes Foundry model
+            → Agent reads memory context
+            → Enriched response returned to CRUD
+```
+
+### Pattern 3: Async Processing (Event → Agent)
+```
+CRUD publishes event → Event Hubs
+                    → Agent consumer group processes
+                    → Agent writes to memory tiers
+                    → Agent calls MCP tools on other agents
+```
+
+### Pattern 4: Agent-to-Agent (MCP Protocol)
+```
+Agent A → POST /mcp/tool_name on Agent B
+       → Agent B processes with its domain context
+       → Structured dict response returned
+```
+
+## Deployment Topology
+
+```mermaid
+%%{init: {'theme':'base', 'themeVariables': {
+  'primaryColor':'#FFB3BA',
+  'primaryTextColor':'#000',
+  'primaryBorderColor':'#FF8B94',
+  'lineColor':'#BAE1FF',
+  'secondaryColor':'#BAE1FF',
+  'tertiaryColor':'#FFFFFF'
+}}}%%
+graph TB
+    subgraph "Azure Subscription"
+        subgraph "AKS Cluster"
+            SYS["system pool<br/>K8s components"]
+            subgraph "crud namespace"
+                CRUD_POD["crud-service pods<br/>(1-10 replicas)"]
+            end
+            subgraph "holiday-peak-agents"
+                subgraph "eCommerce"
+                    ECOM_PODS["5 agent deployments"]
+                end
+                subgraph "CRM"
+                    CRM_PODS["4 agent deployments"]
+                end
+                subgraph "Inventory"
+                    INV_PODS["4 agent deployments"]
+                end
+                subgraph "Logistics"
+                    LOG_PODS["4 agent deployments"]
+                end
+                subgraph "Product Mgmt"
+                    PM_PODS["4 agent deployments"]
+                end
+                subgraph "Search"
+                    SEARCH_PODS["1 agent deployment"]
+                end
+                subgraph "Truth Layer"
+                    TRUTH_PODS["4 agent deployments"]
+                end
+            end
+        end
+
+        SWA["Azure Static Web Apps<br/>Next.js 15 UI"]
+        APIM_GW["API Management"]
+        FLUX["Flux CD<br/>GitOps Controller"]
+    end
+
+    FLUX -->|reconcile| ECOM_PODS & CRM_PODS & INV_PODS & LOG_PODS & PM_PODS & SEARCH_PODS & TRUTH_PODS & CRUD_POD
+    SWA --> APIM_GW --> CRUD_POD & ECOM_PODS
+```
+
+## Related Documents
+
+- [MAF Integration Rationale](maf-integration-rationale.md) — Why Microsoft Agent Framework lives in the lib
+- [ADRs Index](ADRs.md) — All 35 Architecture Decision Records
+- [Components Overview](components.md) — Detailed component responsibility matrix
+- [Standalone Deployment Guide](standalone-deployment-guide.md) — How to deploy individual services
+- [Infrastructure README](../../.infra/README.md) — Bicep and AKS provisioning

--- a/docs/architecture/standalone-deployment-guide.md
+++ b/docs/architecture/standalone-deployment-guide.md
@@ -1,0 +1,431 @@
+# Standalone Deployment Guide
+
+**Version**: 1.0
+**Last Updated**: 2026-04-12
+
+How to deploy a single agent service independently on AKS. This guide covers both the quick `azd deploy` path and the manual Helm-based path.
+
+---
+
+## Prerequisites
+
+| Requirement | Version | Check |
+|------------|---------|-------|
+| Azure CLI | ≥ 2.60 | `az version` |
+| azd | ≥ 1.10 | `azd version` |
+| Docker | ≥ 24 | `docker version` |
+| Helm | ≥ 3.12 | `helm version` |
+| kubectl | ≥ 1.28 | `kubectl version` |
+| Python | ≥ 3.13 | `python --version` |
+| uv | latest | `uv --version` |
+
+### Azure Resources Required
+
+For standalone (demo) deployment, each service provisions its **own isolated** resources via `.infra/templates/app.bicep.tpl`:
+
+| Resource | SKU | Estimated Cost |
+|----------|-----|----------------|
+| Azure Cosmos DB | Serverless | ~$25/month (low traffic) |
+| Azure Cache for Redis | Standard C0 | ~$40/month |
+| Azure Storage Account | StorageV2 | ~$5/month |
+| Azure AI Search | Basic | ~$75/month |
+| Azure OpenAI (3 deployments) | Standard | ~$100-500/month (usage) |
+| AKS (shared or standalone) | Standard_D4ds_v5 | ~$140/month |
+
+**Total per standalone service**: ~$400-800/month
+
+For **shared infrastructure** (production), all 28 services share one set of resources at ~85% cost reduction. See [.infra/README.md](../../.infra/README.md).
+
+---
+
+## Quick Path: `azd deploy`
+
+```bash
+# 1. Set your environment
+export SERVICE_NAME="ecommerce-catalog-search"  # any of the 28 services
+export AZD_ENV="dev"
+
+# 2. Configure required env vars
+azd env set PROJECT_ENDPOINT "https://<your-foundry>.api.azureml.ms" -e $AZD_ENV
+azd env set FOUNDRY_AGENT_ID_FAST "<fast-agent-id>" -e $AZD_ENV
+azd env set FOUNDRY_AGENT_ID_RICH "<rich-agent-id>" -e $AZD_ENV
+azd env set MODEL_DEPLOYMENT_NAME_FAST "gpt-5-nano" -e $AZD_ENV
+azd env set MODEL_DEPLOYMENT_NAME_RICH "gpt-5" -e $AZD_ENV
+azd env set EVENT_HUB_NAMESPACE "<namespace>.servicebus.windows.net" -e $AZD_ENV
+azd env set REDIS_URL "rediss://<host>:6380" -e $AZD_ENV
+azd env set COSMOS_ACCOUNT_URI "https://<account>.documents.azure.com" -e $AZD_ENV
+azd env set BLOB_ACCOUNT_URL "https://<account>.blob.core.windows.net" -e $AZD_ENV
+azd env set KEY_VAULT_URI "https://<vault>.vault.azure.net" -e $AZD_ENV
+
+# 3. Deploy (builds, pushes, renders Helm, applies to AKS)
+azd deploy --service $SERVICE_NAME -e $AZD_ENV
+```
+
+This wraps steps 3–6 of the manual path below.
+
+---
+
+## Manual Path: Docker + Helm
+
+### Step 1: Build the Container Image
+
+```bash
+SERVICE_NAME="ecommerce-catalog-search"
+APP_PATH="apps/${SERVICE_NAME}"
+ACR_LOGIN_SERVER="<your-acr>.azurecr.io"
+IMAGE_TAG=$(git rev-parse --short HEAD)
+
+# Build production image
+docker build \
+  --target prod \
+  --tag ${ACR_LOGIN_SERVER}/${SERVICE_NAME}:${IMAGE_TAG} \
+  --tag ${ACR_LOGIN_SERVER}/${SERVICE_NAME}:latest \
+  -f ${APP_PATH}/Dockerfile \
+  ${APP_PATH}
+
+# Push to ACR
+az acr login --name <your-acr>
+docker push ${ACR_LOGIN_SERVER}/${SERVICE_NAME}:${IMAGE_TAG}
+docker push ${ACR_LOGIN_SERVER}/${SERVICE_NAME}:latest
+```
+
+### Step 2: Render Helm Manifests
+
+```bash
+# Set required Helm render variables
+export SERVICE=$SERVICE_NAME
+export K8S_NAMESPACE="holiday-peak-agents"  # or per-domain namespace
+export CHART_PATH=".kubernetes/chart"
+export RENDERED_PATH=".kubernetes/rendered/${SERVICE_NAME}"
+
+# Render using the shared chart
+helm template $SERVICE_NAME $CHART_PATH \
+  --namespace $K8S_NAMESPACE \
+  --set image.repository=${ACR_LOGIN_SERVER}/${SERVICE_NAME} \
+  --set image.tag=${IMAGE_TAG} \
+  --set service.name=${SERVICE_NAME} \
+  --set nodeSelector.agentpool=agents \
+  --output-dir $RENDERED_PATH
+```
+
+Or use the render hook script:
+```bash
+bash .infra/azd/hooks/render-helm.sh
+```
+
+### Step 3: Deploy to AKS
+
+```bash
+# Ensure kubectl context points to your cluster
+az aks get-credentials -g <resource-group> -n <cluster-name>
+
+# Create namespace if it doesn't exist
+kubectl create namespace $K8S_NAMESPACE --dry-run=client -o yaml | kubectl apply -f -
+
+# Deploy via Helm
+helm upgrade --install $SERVICE_NAME $CHART_PATH \
+  --namespace $K8S_NAMESPACE \
+  --set image.repository=${ACR_LOGIN_SERVER}/${SERVICE_NAME} \
+  --set image.tag=${IMAGE_TAG} \
+  --wait --timeout 5m
+```
+
+### Step 4: Validate
+
+```bash
+# Check rollout status
+kubectl rollout status deployment/${SERVICE_NAME} -n $K8S_NAMESPACE
+
+# Check pod logs
+kubectl logs -l app=${SERVICE_NAME} -n $K8S_NAMESPACE --tail=50
+
+# Test health endpoint
+kubectl port-forward svc/${SERVICE_NAME} 8080:8000 -n $K8S_NAMESPACE
+curl http://localhost:8080/health
+curl http://localhost:8080/ready
+```
+
+---
+
+## Environment Variables Reference
+
+### Required for All Agent Services
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `PROJECT_ENDPOINT` | Azure AI Foundry project endpoint | `https://proj.api.azureml.ms` |
+| `FOUNDRY_AGENT_ID_FAST` | SLM agent ID (created via Foundry) | `asst_abc123` |
+| `FOUNDRY_AGENT_ID_RICH` | LLM agent ID (created via Foundry) | `asst_def456` |
+| `MODEL_DEPLOYMENT_NAME_FAST` | SLM model deployment | `gpt-5-nano` |
+| `MODEL_DEPLOYMENT_NAME_RICH` | LLM model deployment | `gpt-5` |
+| `EVENT_HUB_NAMESPACE` | Event Hubs namespace FQDN | `ns.servicebus.windows.net` |
+| `REDIS_URL` | Redis connection URL | `rediss://host:6380` |
+| `COSMOS_ACCOUNT_URI` | Cosmos DB account URI | `https://acct.documents.azure.com` |
+| `COSMOS_DATABASE` | Cosmos DB database name | `agent-memory` |
+| `COSMOS_CONTAINER` | Cosmos DB container name | `warm-memory` |
+| `BLOB_ACCOUNT_URL` | Blob Storage account URL | `https://acct.blob.core.windows.net` |
+| `BLOB_CONTAINER` | Blob container name | `cold-memory` |
+| `KEY_VAULT_URI` | Key Vault URI | `https://kv.vault.azure.net` |
+| `CRUD_SERVICE_URL` | CRUD service base URL | `http://crud-service:8000` |
+
+### Optional
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `FOUNDRY_STREAM` | Enable streaming responses | `false` |
+| `FOUNDRY_STRICT_ENFORCEMENT` | Enforce Foundry prompt governance | `true` |
+| `SELF_HEALING_ENABLED` | Enable self-healing runtime | `false` |
+| `APPLICATIONINSIGHTS_CONNECTION_STRING` | App Insights connection | (disabled) |
+
+### Service-Specific
+
+| Service | Extra Variables |
+|---------|----------------|
+| `ecommerce-catalog-search` | `AI_SEARCH_ENDPOINT`, `AI_SEARCH_INDEX`, `AI_SEARCH_VECTOR_INDEX`, `CATALOG_SEARCH_REQUIRE_AI_SEARCH` |
+| `truth-*` services | `PLATFORM_JOBS_EVENT_HUB_NAMESPACE` (separate from retail Event Hubs) |
+
+---
+
+## Helm Chart Configuration
+
+The shared Helm chart at `.kubernetes/chart/` supports these key values:
+
+```yaml
+# .kubernetes/chart/values.yaml (key overrides for standalone)
+replicaCount: 1                    # Single replica for standalone
+service:
+  type: ClusterIP
+  port: 80
+  targetPort: 8000
+
+image:
+  repository: <acr-name>.azurecr.io/<service-name>
+  tag: latest
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+nodeSelector:
+  workload: agents                 # Target the agents node pool
+
+tolerations:
+  - key: workload
+    value: agents
+    effect: NoSchedule
+
+probes:
+  startup:
+    path: /health
+    initialDelaySeconds: 10
+  liveness:
+    path: /health
+    periodSeconds: 30
+  readiness:
+    path: /ready
+    periodSeconds: 10
+
+autoscaling:
+  enabled: false                   # Disable KEDA for standalone demo
+```
+
+### Per-Service Overrides
+
+Create a values override file for each service:
+
+```bash
+# Example: apps/ecommerce-catalog-search/values-standalone.yaml
+helm install catalog-search .kubernetes/chart/ \
+  -f .kubernetes/chart/values.yaml \
+  -f apps/ecommerce-catalog-search/values-standalone.yaml \
+  -n holiday-peak-agents \
+  --set image.tag=$(git rev-parse --short HEAD)
+```
+
+---
+
+## Namespace Strategy (ADR-034)
+
+All agent services deploy to a single shared namespace per [ADR-034](../architecture/adrs/adr-034-namespace-isolation-strategy.md):
+
+| Namespace | Services | Node Pool | Network Policy |
+|-----------|----------|-----------|----------------|
+| `holiday-peak-crud` | crud-service (1 service) | `crud` | Allow: UI ingress, agent egress |
+| `holiday-peak-agents` | All 26 agent services (eCommerce, CRM, Inventory, Logistics, Product Mgmt, Search, Truth Layer) | `agents` | Allow: CRUD, Event Hubs, AI Search, Cosmos DB |
+
+Create the namespace before deploying:
+
+```bash
+kubectl create namespace holiday-peak-agents
+kubectl label namespace holiday-peak-agents holiday-peak/ingress-allowed=true --overwrite
+```
+
+---
+
+## Step-by-Step: Deploy a Single Agent
+
+### Path A: azd deploy (Recommended)
+
+```bash
+# 1. Set environment
+azd env set deployShared true -e dev
+azd env set environment dev -e dev
+
+# 2. Deploy single service
+azd deploy --service ecommerce-catalog-search -e dev
+
+# 3. Verify
+kubectl get pods -n holiday-peak-agents -l app=ecommerce-catalog-search
+kubectl logs -l app=ecommerce-catalog-search -n holiday-peak-agents --tail=20
+```
+
+### Path B: Manual Helm
+
+```bash
+# 1. Build and push image
+docker build -t <acr>.azurecr.io/ecommerce-catalog-search:latest \
+  -f apps/ecommerce-catalog-search/Dockerfile .
+docker push <acr>.azurecr.io/ecommerce-catalog-search:latest
+
+# 2. Ensure Foundry agents are provisioned
+pwsh .infra/azd/hooks/ensure-foundry-agents.ps1
+
+# 3. Install via Helm
+helm upgrade --install ecommerce-catalog-search .kubernetes/chart/ \
+  --namespace holiday-peak-agents \
+  --set image.repository=<acr>.azurecr.io/ecommerce-catalog-search \
+  --set image.tag=latest \
+  --set env.PROJECT_ENDPOINT=<foundry-endpoint> \
+  --set env.FOUNDRY_AGENT_ID_FAST=<fast-agent-id> \
+  --set env.FOUNDRY_AGENT_ID_RICH=<rich-agent-id> \
+  --set env.REDIS_URL=<redis-url> \
+  --set env.COSMOS_ACCOUNT_URI=<cosmos-uri>
+
+# 4. Verify health
+kubectl wait --for=condition=ready pod \
+  -l app=ecommerce-catalog-search \
+  -n holiday-peak-agents \
+  --timeout=120s
+
+curl -s http://localhost:8001/health | jq
+```
+
+### Path C: Standalone Bicep (Demo Isolation)
+
+```bash
+# 1. Generate standalone Bicep from template
+python .infra/cli.py generate --service ecommerce-catalog-search
+
+# 2. Deploy isolated resources
+az deployment group create \
+  --resource-group rg-catalog-search-demo \
+  --template-file .infra/modules/ecommerce-catalog-search/app.bicep \
+  --parameters appName=ecommerce-catalog-search
+
+# 3. Deploy service to newly created AKS
+# (see generated README in .infra/modules/ecommerce-catalog-search/)
+```
+
+---
+
+## Dockerfile Structure
+
+All services share the same multi-stage Dockerfile pattern:
+
+```dockerfile
+# Stage 1: Build
+FROM python:3.13-slim AS builder
+WORKDIR /build
+COPY lib/ lib/
+COPY apps/<service-name>/ app/
+RUN pip install --no-cache-dir uv && \
+    cd app && uv pip install --system -e ".[dev]"
+
+# Stage 2: Runtime
+FROM python:3.13-slim
+WORKDIR /app
+COPY --from=builder /usr/local/lib/python3.13 /usr/local/lib/python3.13
+COPY --from=builder /build/app/src ./src
+EXPOSE 8000
+CMD ["uvicorn", "src.<service_module>.main:app", "--host", "0.0.0.0", "--port", "8000"]
+```
+
+---
+
+## Troubleshooting
+
+| Symptom | Check | Fix |
+|---------|-------|-----|
+| Pod in `CrashLoopBackoff` | `kubectl logs -l app=<svc> --previous` | Usually missing env var (`PROJECT_ENDPOINT`, `EVENT_HUB_NAMESPACE`) |
+| `/health` returns 503 | Foundry agent not provisioned | Run `ensure-foundry-agents.ps1` hook |
+| Event Hub consumer not receiving | Consumer group mismatch | Verify `EVENT_HUB_CONNECTION_STRING` and consumer group name |
+| Memory timeouts | Redis/Cosmos unreachable | Check network policies allow egress from agent namespace |
+| Image pull error | ACR auth expired | `az acr login --name <acr>` then re-deploy |
+| Tool calls silently dropped | Old `FoundryInvoker` in use | Ensure `holiday-peak-lib` uses `FoundryAgentInvoker` (PR #802+) |
+| APIM returns 502 | Backend health probe failing | Check `/health` endpoint directly via pod port-forward |
+
+---
+
+## Related
+
+- [Infrastructure README](../../.infra/README.md) — Full provisioning guide
+- [Deployment Guide](../../.infra/DEPLOYMENT.md) — Multi-service deployment
+- [ADR-033: Helm Deployment Strategy](adrs/adr-033-helm-deployment-strategy.md)
+- [ADR-034: Namespace Isolation Strategy](adrs/adr-034-namespace-isolation-strategy.md)
+- [Flux GitOps Deployment Flow](diagrams/sequence-flux-gitops-deployment.md)
+- [Agentic Microservices Reference](../agentic-microservices-reference.md)
+| Value | Default | Description |
+|-------|---------|-------------|
+| `image.repository` | — | ACR image path |
+| `image.tag` | `latest` | Image tag |
+| `replicaCount` | `1` | Pod replicas |
+| `resources.requests.cpu` | `250m` | CPU request |
+| `resources.requests.memory` | `256Mi` | Memory request |
+| `resources.limits.cpu` | `500m` | CPU limit |
+| `resources.limits.memory` | `512Mi` | Memory limit |
+| `nodeSelector.agentpool` | `agents` | AKS node pool |
+| `probes.startup.path` | `/health` | Startup probe |
+| `probes.readiness.path` | `/ready` | Readiness probe |
+| `autoscaling.enabled` | `true` | KEDA autoscaling |
+| `autoscaling.minReplicas` | `1` | Minimum |
+| `autoscaling.maxReplicas` | `5` | Maximum |
+| `publication.mode` | `legacy` | `legacy` (Ingress), `agc` (App Gateway), `dual`, `none` |
+
+---
+
+## Namespace Strategy (ADR-034)
+
+In production, services are deployed to two namespaces per [ADR-034](../architecture/adrs/adr-034-namespace-isolation-strategy.md):
+
+| Namespace | Services | Node Pool |
+|-----------|----------|-----------|
+| `holiday-peak-crud` | crud-service (1 service) | `crud` |
+| `holiday-peak-agents` | All 26 agent services (eCommerce, CRM, Inventory, Logistics, Product Mgmt, Search, Truth Layer) | `agents` |
+
+Override the namespace with `--namespace <name>` in Helm commands.
+
+---
+
+## Troubleshooting
+
+| Symptom | Check | Fix |
+|---------|-------|-----|
+| Pod in `CrashLoopBackoff` | `kubectl logs -l app=<svc> --previous` | Usually missing env var (Foundry, Event Hub) |
+| `/health` returns 503 | Foundry agent not provisioned | Run `ensure-foundry-agents.ps1` hook |
+| Event Hub consumer not receiving | Consumer group mismatch | Check `EVENT_HUB_CONNECTION_STRING` and consumer group name |
+| Memory timeouts | Redis/Cosmos unreachable | Verify network policies allow egress from agent namespace |
+| Image pull error | ACR auth expired | `az acr login --name <acr>` |
+
+---
+
+## Related
+
+- [Infrastructure README](../../.infra/README.md) — Full infrastructure provisioning
+- [Deployment Guide](../../.infra/DEPLOYMENT.md) — Multi-service deployment
+- [Solution Architecture](solution-architecture-overview.md) — System diagrams
+- [ADR-033: Helm Deployment Strategy](adrs/adr-033-helm-deployment-strategy.md)
+- [ADR-034: Namespace Isolation](adrs/adr-034-namespace-isolation-strategy.md)

--- a/docs/architecture/test-coverage-gap-analysis.md
+++ b/docs/architecture/test-coverage-gap-analysis.md
@@ -1,0 +1,188 @@
+# Test Coverage Gap Analysis
+
+**Generated**: 2026-04-12  
+**Coverage Tool**: pytest-cov v7.13.2  
+**Test Suite**: 1796 tests (1136 lib + 660 app)  
+**Overall Coverage**: 89.8% (477 tracked files)  
+**Target**: 75% minimum per file (governance policy)
+
+---
+
+## Executive Summary
+
+79 of 477 files (16.6%) fall below the 75% coverage floor. The gaps cluster in three dominant patterns:
+
+| Category | Files Below 75% | Avg Coverage | Root Cause |
+|----------|-----------------|--------------|------------|
+| **Event Handlers** | 19 | 40.3% | Async consumer paths not exercised in unit tests |
+| **Agent `agents.py`** | 19 | 51.6% | Foundry invocation branches mocked but not fully covered |
+| **Adapters** | 19 | 59.8% | External API call paths and error branches |
+| **Other** | 22 | 54.2% | CRUD repositories, conftest fixtures, schemas |
+
+---
+
+## Priority 1: Event Handlers (19 files, avg 40.3%)
+
+Event handlers process Azure Event Hub messages asynchronously. The low coverage is structural — these paths involve deserialization, domain-specific processing, and error handling that unit tests mock at the boundary.
+
+| File | Coverage | Missing Path |
+|------|----------|--------------|
+| `product-management-assortment-optimization/event_handlers.py` | 24% | Optimization loop, batch processing |
+| `inventory-health-check/event_handlers.py` | 27% | Anomaly detection flow, remediation branch |
+| `truth-enrichment/event_handlers.py` | 28% | Guardrail rejection path, partial enrichment |
+| `logistics-carrier-selection/event_handlers.py` | 37% | Rate comparison, multi-carrier fallback |
+| `logistics-eta-computation/event_handlers.py` | 37% | Delay computation, carrier API errors |
+| `logistics-returns-support/event_handlers.py` | 37% | Label generation, eligibility check |
+| `logistics-route-issue-detection/event_handlers.py` | 37% | Rerouting decision tree |
+| `crm-campaign-intelligence/event_handlers.py` | 38% | ROI prediction, channel selection |
+| `truth-export/event_handlers.py` | 41% | PIM writeback, schema transformation |
+| `crm-support-assistance/event_handlers.py` | 44% | Ticket classification, escalation path |
+| `ecommerce-product-detail-enrichment/event_handlers.py` | 44% | SEO enrichment, image processing |
+| `crm-segmentation-personalization/event_handlers.py` | 46% | Cohort creation, behavioral clustering |
+| `inventory-alerts-triggers/event_handlers.py` | 46% | Threshold alerting, notification dispatch |
+| `inventory-jit-replenishment/event_handlers.py` | 46% | Demand forecast, auto-reorder |
+| `product-management-acp-transformation/event_handlers.py` | 46% | ACP mapping, attribute extraction |
+| `product-management-normalization-classification/event_handlers.py` | 46% | Taxonomy mapping, normalization |
+| `crm-profile-aggregation/event_handlers.py` | 46% | Profile merge, deduplication |
+| `ecommerce-order-status/event_handlers.py` | 48% | Tracking enrichment, notification |
+| `ecommerce-cart-intelligence/event_handlers.py` | 48% | Cross-sell, abandonment detection |
+
+**Recommended Test Strategy:**
+1. Add `pytest-asyncio` integration tests that simulate Event Hub `EventData` payloads
+2. Test the full `process_event()` → adapter → memory → response path per handler
+3. Cover error branches: malformed events, adapter timeouts, duplicate events
+4. Use `conftest.py` Event Hub mocking fixtures from `apps/conftest.py`
+
+---
+
+## Priority 2: Agent Modules (19 files, avg 51.6%)
+
+Agent `agents.py` files contain the core intelligence logic — tool definitions, MCP registrations, and invocation handlers. Coverage gaps are in model invocation branches that require Foundry mock fixtures.
+
+| File | Coverage | Missing Path |
+|------|----------|--------------|
+| `product-management-assortment-optimization/agents.py` | 43% | Optimization scoring, batch analysis |
+| `product-management-consistency-validation/agents.py` | 44% | Cross-channel validation, quality scoring |
+| `truth-enrichment/agents.py` | 46% | Guardrail enforcement, confidence scoring |
+| `crm-profile-aggregation/agents.py` | 46% | 360° view assembly, data reconciliation |
+| `product-management-normalization-classification/agents.py` | 48% | Taxonomy resolution, attribute mapping |
+| `inventory-jit-replenishment/agents.py` | 49% | Demand prediction, reorder logic |
+| `product-management-acp-transformation/agents.py` | 49% | Canonical format mapping |
+| `crm-segmentation-personalization/agents.py` | 49% | Segment creation, behavioral analysis |
+| `crm-support-assistance/agents.py` | 50% | Ticket routing, resolution suggestion |
+| `inventory-reservation-validation/agents.py` | 50% | Conflict detection, hold management |
+| `logistics-route-issue-detection/agents.py` | 51% | Delay classification, rerouting |
+| `logistics-carrier-selection/agents.py` | 52% | Rate optimization, SLA matching |
+| `logistics-eta-computation/agents.py` | 52% | Multi-carrier ETA, delay modeling |
+| `logistics-returns-support/agents.py` | 52% | Eligibility rules, label workflow |
+| `inventory-alerts-triggers/agents.py` | 55% | Alert threshold logic, suppression |
+| `truth-hitl/agents.py` | 55% | Review decision tree, audit logging |
+| `inventory-health-check/agents.py` | 57% | Accuracy scoring, cycle scheduling |
+| `crm-campaign-intelligence/agents.py` | 69% | Channel ROI computation |
+| `truth-export/agents.py` | 72% | Format transformation, writeback |
+
+**Recommended Test Strategy:**
+1. Create a shared `foundry_mock` fixture that returns configurable `AgentResponse` objects
+2. Test each MCP tool function independently with direct invocation
+3. Test the `invoke()` method with SLM and LLM branch paths
+4. Cover tool-calling chains (agent A calls agent B's MCP tool)
+
+---
+
+## Priority 3: Adapters (19 files, avg 59.8%)
+
+Adapters handle external API calls and data transformation. Coverage gaps are in error paths and external API response handling.
+
+| File | Coverage | Gap Area |
+|------|----------|----------|
+| `lib/.../crud_adapter.py` | 38% | HTTP error paths, retry logic |
+| `crm-segmentation-personalization/adapters.py` | 42% | Segment API errors |
+| `lib/.../crm_adapter.py` | 46% | Profile merge conflicts |
+| `lib/.../mock_adapters.py` | 56% | Unused mock variants |
+| `lib/.../pricing_adapter.py` | 56% | Dynamic pricing paths |
+| `product-management-normalization-classification/adapters.py` | 57% | Taxonomy API |
+| `product-management-consistency-validation/adapters.py` | 60% | Validation rule engine |
+| `truth-enrichment/adapters.py` | 60% | Enrichment pipeline stages |
+| `crm-campaign-intelligence/adapters.py` | 61% | Channel optimization |
+| `crm-support-assistance/adapters.py` | 61% | Ticket system integration |
+| `product-management-assortment-optimization/adapters.py` | 61% | Assortment scoring |
+| `lib/.../inventory_adapter.py` | 61% | Stock check variants |
+| `inventory-alerts-triggers/adapters.py` | 62% | Notification dispatch |
+| `inventory-health-check/adapters.py` | 64% | Health scoring |
+| `inventory-reservation-validation/adapters.py` | 68% | Hold conflict resolution |
+| `logistics-eta-computation/adapters.py` | 69% | Carrier API integration |
+| `logistics-returns-support/adapters.py` | 69% | Return label generation |
+| `logistics-carrier-selection/adapters.py` | 72% | Rate comparison |
+| `lib/.../product_adapter.py` | 72% | Product CRUD calls |
+
+**Recommended Test Strategy:**
+1. Add `httpx.MockTransport` or `respx` fixtures for HTTP adapter tests
+2. Test each adapter method with success, error (4xx, 5xx), and timeout scenarios
+3. Cover retry/circuit-breaker behavior with controlled failure injection
+4. Stub CRUD endpoints using FastAPI test client
+
+---
+
+## Priority 4: Lib Core Gaps
+
+| File | Coverage | Issue |
+|------|----------|-------|
+| `lib/.../agents/memory/builder.py` | 31% | `gather_adapters()` parallel I/O paths |
+| `lib/tests/test_agents_builder.py` | 42% | Test file itself has dead branches |
+| `lib/.../utils/event_hub.py` | 50% | Consumer lifecycle, checkpoint logic |
+| `lib/.../agents/orchestration/evaluator.py` | 52% | Complexity evaluation branches |
+
+**Recommended Test Strategy:**
+1. `memory/builder.py`: Add tests for parallel `asyncio.gather` with Redis failure, Cosmos timeout, and partial success scenarios
+2. `event_hub.py`: Test consumer group lifecycle, offset management, and error recovery
+3. `evaluator.py`: Test all complexity classification thresholds
+
+---
+
+## Coverage by Domain (Heat Map)
+
+| Domain | Files | Avg Coverage | Critical Gaps |
+|--------|-------|-------------|---------------|
+| **eCommerce** | 25 | 83% | event_handlers (44-48%), adapters (60-72%) |
+| **CRM** | 20 | 78% | agents (46-69%), event_handlers (38-46%) |
+| **Inventory** | 20 | 76% | event_handlers (27-46%), agents (49-57%) |
+| **Logistics** | 20 | 77% | event_handlers (37%), agents (51-52%) |
+| **Product Mgmt** | 20 | 72% | event_handlers (24-46%), agents (43-49%) |
+| **Search** | 8 | 85% | ai_search.py (60%) |
+| **Truth Layer** | 16 | 74% | schemas_compat (17%), event_handlers (28-41%) |
+| **CRUD Service** | 25 | 82% | repositories (30-60%), consumers (45%) |
+| **Lib Core** | 53+ | 91% | memory/builder (31%), crud_adapter (38%) |
+
+---
+
+## Remediation Plan
+
+### Wave 1 — Lib Core (Week 1)
+- [ ] `memory/builder.py` → Add parallel I/O failure tests (target: 80%)
+- [ ] `crud_adapter.py` → Add HTTP error path tests (target: 80%)
+- [ ] `event_hub.py` → Add consumer lifecycle tests (target: 75%)
+- [ ] `evaluator.py` → Add complexity threshold tests (target: 75%)
+
+### Wave 2 — Event Handlers (Weeks 2-3)
+- [ ] Create shared Event Hub test fixtures in `apps/conftest.py`
+- [ ] Add integration tests for all 19 event handler files (target: 70%)
+- [ ] Cover: deserialization, happy path, error path, duplicate detection
+
+### Wave 3 — Agents (Weeks 3-4)
+- [ ] Create shared Foundry mock fixture
+- [ ] Add MCP tool unit tests for all 19 agent files (target: 70%)
+- [ ] Cover: SLM path, LLM escalation, tool chains
+
+### Wave 4 — Adapters (Week 4)
+- [ ] Add HTTP mock tests for all 19 adapter files (target: 75%)
+- [ ] Cover: success, 4xx, 5xx, timeout, retry
+
+**Expected outcome**: Overall coverage from 89.8% → 93%+, with 0 files below 60%.
+
+---
+
+## Related
+
+- [Governance Policy: 75% coverage floor](../governance/backend-governance.md)
+- [Lib README: Testing section](../../lib/README.md)
+- [CI/CD: Test workflow](../../.github/workflows/)

--- a/docs/backend_plan.md
+++ b/docs/backend_plan.md
@@ -1,8 +1,10 @@
 # Backend Implementation Plan
 
-**Version**: 1.0  
-**Date**: 2026-01-30  
-**Status**: Draft
+**Version**: 2.0  
+**Date**: 2026-01-30 (created) | 2026-04-12 (updated)  
+**Status**: Implemented
+
+> **Note**: This plan was the original design document for CRUD service capabilities. The implementation is now complete — see [crud-features-map.md](crud-features-map.md) for the live feature matrix and [apps/crud-service/README.md](../apps/crud-service/README.md) for the current service documentation.
 
 ## Executive Summary
 

--- a/docs/crud-features-map.md
+++ b/docs/crud-features-map.md
@@ -1,7 +1,7 @@
 # CRUD Service Features Map — Gap Analysis & Roadmap
 
-> **Generated**: 2026-02-28  
-> **Scope**: All 21 agent apps, shared lib schemas, 59 open issues  
+> **Generated**: 2026-02-28 | **Last Reviewed**: 2026-04-12  
+> **Scope**: All 27 agent/service apps, shared lib schemas  
 > **Purpose**: Document every capability gap between the CRUD service and the agent ecosystem, propose new Postgres models, adapter integrations, and issues for feature parity.
 
 ---

--- a/docs/demos/README.md
+++ b/docs/demos/README.md
@@ -1,13 +1,13 @@
 # Agent Demonstration Guide
 
-**Last Updated**: February 3, 2026  
-**Status**: Phase 1 Complete | Phases 2-4 In Progress
+**Last Updated**: April 12, 2026  
+**Status**: Phase 1 Complete | Phase 2 In Progress
 
 ---
 
 ## Overview
 
-This directory contains comprehensive demonstrations for all 21 agent services in Holiday Peak Hub. Each demo is designed to showcase agent capabilities through realistic retail scenarios, from quick API calls to complex multi-agent workflows.
+This directory contains comprehensive demonstrations for all 27 agent/service apps in Holiday Peak Hub. Each demo is designed to showcase agent capabilities through realistic retail scenarios, from quick API calls to complex multi-agent workflows.
 
 ### Live Operator Runbook
 

--- a/docs/demos/api-examples/README.md
+++ b/docs/demos/api-examples/README.md
@@ -6,7 +6,7 @@
 
 ## Overview
 
-This directory contains quick-start API examples for all 21 agent services, including curl scripts, PowerShell examples, and Postman collections.
+This directory contains quick-start API examples for the 26 agent services plus the CRUD service, including curl scripts, PowerShell examples, and Postman collections.
 
 ---
 

--- a/docs/governance/backend-governance.md
+++ b/docs/governance/backend-governance.md
@@ -1,7 +1,7 @@
 # Backend Development Governance and Compliance Guidelines
 
 **Version**: 2.0  
-**Last Updated**: 2026-03-11  
+**Last Updated**: 2026-04-12  
 **Owner**: Backend Team
 
 ## Scope

--- a/docs/governance/dependency-audit-wave0.md
+++ b/docs/governance/dependency-audit-wave0.md
@@ -2,7 +2,7 @@
 
 **Issue**: [#372](https://github.com/Azure-Samples/holiday-peak-hub/issues/372)  
 **Owner**: Platform Quality / Platform Engineering  
-**Last Updated**: 2026-03-19
+**Last Updated**: 2026-04-12
 
 ## Baseline Evidence
 

--- a/docs/governance/frontend-governance.md
+++ b/docs/governance/frontend-governance.md
@@ -1,7 +1,7 @@
 # Frontend Development Rules and Policies
 
 **Version**: 2.0  
-**Last Updated**: 2026-03-11  
+**Last Updated**: 2026-04-12  
 **Owner**: Frontend Team
 
 ## Scope

--- a/docs/governance/repository-hygiene-cleanup.md
+++ b/docs/governance/repository-hygiene-cleanup.md
@@ -1,7 +1,7 @@
 # Repository Hygiene Cleanup Runbook
 
 **Version**: 1.0  
-**Last Updated**: 2026-04-02  
+**Last Updated**: 2026-04-12  
 **Audience**: Repository maintainers and admins
 
 ## Purpose

--- a/docs/governance/security-exception-register.md
+++ b/docs/governance/security-exception-register.md
@@ -1,7 +1,7 @@
 # Security Exception Register
 
 **Owner**: Platform Engineering  
-**Last Updated**: 2026-04-02
+**Last Updated**: 2026-04-12
 
 This register is the time-boxed exception ledger for open high-severity security alerts that are not yet closed at merge time.
 

--- a/docs/governance/security-triage-weekly.md
+++ b/docs/governance/security-triage-weekly.md
@@ -2,7 +2,7 @@
 
 **Owner**: Platform Engineering  
 **Cadence**: Weekly (Monday)  
-**Last Updated**: 2026-04-02
+**Last Updated**: 2026-04-12
 
 ## Severity Burn-down
 

--- a/docs/implementation/README.md
+++ b/docs/implementation/README.md
@@ -117,7 +117,7 @@ The implementation plan includes a comprehensive C4 Component Diagram (Level 3) 
 - Frontend Layer (Next.js)
 - API Gateway (Azure API Management)
 - CRUD Service (FastAPI with event publishing and agent client)
-- 21 Agent Services (5 domains)
+- 26 Agent Services (7 domains: eCommerce, CRM, Inventory, Logistics, Product Mgmt, Search, Truth Layer)
 - Data Layer (PostgreSQL for CRUD, Cosmos DB for agent memory, Redis, Blob Storage, Event Hubs)
 - Platform Services (Azure Monitor, Key Vault)
 

--- a/docs/implementation/architecture-implementation-plan.md
+++ b/docs/implementation/architecture-implementation-plan.md
@@ -1,9 +1,11 @@
 # Architecture Implementation Plan
 
-**Date**: January 30, 2026  
-**Version**: 1.0  
-**Status**: Ready for Implementation  
-**Target Completion**: Q1 2026
+**Date**: January 30, 2026 (created) | April 12, 2026 (reviewed)  
+**Version**: 2.0  
+**Status**: Substantially Complete  
+**Original Target**: Q1 2026 (met)
+
+> **Note**: The compliance gaps identified in this plan have been addressed through v1.1.0, v2.0.0, and subsequent PRs through #802. MCP adapter layer, agent-to-agent communication, enterprise connectors, and infrastructure automation are all implemented. Remaining items tracked in [docs/roadmap/](../roadmap/) and GitHub issues.
 
 ---
 

--- a/docs/implementation/c4-component-diagram.md
+++ b/docs/implementation/c4-component-diagram.md
@@ -587,44 +587,55 @@ async def get_enrichment(product_id: str) -> dict:
 ```
 holiday-peak-hub (AKS cluster)
 │
-├── namespace: crud
+├── namespace: holiday-peak-crud
 │   ├── deployment: crud-service (3 replicas)
 │   ├── service: crud-service-svc
 │   └── hpa: crud-service-hpa (3-20 replicas)
 │
-├── namespace: agents-ecommerce
-│   ├── deployment: catalog-search (3 replicas)
-│   ├── deployment: product-enrichment (2 replicas)
-│   ├── deployment: cart-intelligence (2 replicas)
-│   ├── deployment: checkout-support (2 replicas)
-│   └── deployment: order-status (2 replicas)
-│
-├── namespace: agents-crm
-│   ├── deployment: profile-aggregation (2 replicas)
-│   ├── deployment: segmentation (2 replicas)
-│   ├── deployment: campaign-intelligence (2 replicas)
-│   └── deployment: support-assistance (2 replicas)
-│
-├── namespace: agents-inventory
-│   ├── deployment: health-check (2 replicas)
-│   ├── deployment: jit-replenishment (2 replicas)
-│   ├── deployment: reservation-validation (3 replicas)
-│   └── deployment: alerts-triggers (2 replicas)
-│
-├── namespace: agents-logistics
-│   ├── deployment: eta-computation (2 replicas)
-│   ├── deployment: carrier-selection (2 replicas)
-│   ├── deployment: returns-support (2 replicas)
-│   └── deployment: route-detection (2 replicas)
-│
-└── namespace: agents-product
-    ├── deployment: normalization (2 replicas)
-    ├── deployment: acp-transformation (2 replicas)
-    ├── deployment: consistency-validation (2 replicas)
-    └── deployment: assortment-optimization (2 replicas)
+└── namespace: holiday-peak-agents
+    │
+    ├── eCommerce Domain
+    │   ├── deployment: catalog-search (3 replicas)
+    │   ├── deployment: product-enrichment (2 replicas)
+    │   ├── deployment: cart-intelligence (2 replicas)
+    │   ├── deployment: checkout-support (2 replicas)
+    │   └── deployment: order-status (2 replicas)
+    │
+    ├── CRM Domain
+    │   ├── deployment: profile-aggregation (2 replicas)
+    │   ├── deployment: segmentation (2 replicas)
+    │   ├── deployment: campaign-intelligence (2 replicas)
+    │   └── deployment: support-assistance (2 replicas)
+    │
+    ├── Inventory Domain
+    │   ├── deployment: health-check (2 replicas)
+    │   ├── deployment: jit-replenishment (2 replicas)
+    │   ├── deployment: reservation-validation (3 replicas)
+    │   └── deployment: alerts-triggers (2 replicas)
+    │
+    ├── Logistics Domain
+    │   ├── deployment: eta-computation (2 replicas)
+    │   ├── deployment: carrier-selection (2 replicas)
+    │   ├── deployment: returns-support (2 replicas)
+    │   └── deployment: route-detection (2 replicas)
+    │
+    ├── Product Management Domain
+    │   ├── deployment: normalization (2 replicas)
+    │   ├── deployment: acp-transformation (2 replicas)
+    │   ├── deployment: consistency-validation (2 replicas)
+    │   └── deployment: assortment-optimization (2 replicas)
+    │
+    ├── Search Domain
+    │   └── deployment: search-enrichment-agent (2 replicas)
+    │
+    └── Truth Layer Domain
+        ├── deployment: truth-ingestion (2 replicas)
+        ├── deployment: truth-enrichment (2 replicas)
+        ├── deployment: truth-hitl (2 replicas)
+        └── deployment: truth-export (2 replicas)
 ```
 
-**Total Pods**: ~50 (CRUD: 3-20, Agents: 2-3 each × 21)
+**Total Pods**: ~55 (CRUD: 3-20, Agents: 2-3 each × 26)
 
 ---
 

--- a/docs/implementation/issues/ISSUE-001-remove-fake-catalog-seed-and-live-data.md
+++ b/docs/implementation/issues/ISSUE-001-remove-fake-catalog-seed-and-live-data.md
@@ -19,8 +19,8 @@ Live demo catalog contains unrealistic placeholder categories and products (for 
 
 ## Validation
 
-- Query `https://blue-meadow-00fcb8810.4.azurestaticapps.net/api/categories` and confirm absence of fake names.
-- Query `https://blue-meadow-00fcb8810.4.azurestaticapps.net/api/products?limit=300` and confirm no products belong to removed fake category IDs.
+- Query the deployed demo environment's `/api/categories` endpoint and confirm absence of fake names.
+- Query the deployed demo environment's `/api/products?limit=300` endpoint and confirm no products belong to removed fake category IDs.
 
 ## Implementation Notes
 

--- a/docs/implementation/issues/ISSUE-002-catalog-page-ux-alignment.md
+++ b/docs/implementation/issues/ISSUE-002-catalog-page-ux-alignment.md
@@ -16,4 +16,4 @@ Category/catalog pages diverge from homepage visual system and include broken/aw
 
 ## Validation
 - Manual UI verification in desktop and mobile breakpoints.
-- Live check on `https://blue-meadow-00fcb8810.4.azurestaticapps.net/category` and `/category/[slug]` pages.
+- Check deployed demo environment on `/category` and `/category/[slug]` pages.

--- a/docs/implementation/issues/ISSUE-003-dev-login-mock-role-priority.md
+++ b/docs/implementation/issues/ISSUE-003-dev-login-mock-role-priority.md
@@ -13,5 +13,5 @@ Live dev login appears Microsoft-first and does not reliably surface mock role a
 - [ ] Existing Microsoft auth path remains available.
 
 ## Validation
-- Open `https://blue-meadow-00fcb8810.4.azurestaticapps.net/auth/login` and verify role buttons appear first in dev mode.
+- Open the deployed dev environment's `/auth/login` page and verify role buttons appear first in dev mode.
 - Confirm sign-in via both mock role and Microsoft path remains functional.

--- a/docs/project-status.md
+++ b/docs/project-status.md
@@ -1,26 +1,47 @@
 # Project Status & Issue Prioritization
 
-> Generated: 2026-03-27 | Version: main (post PR #559) | Branch: `main`
+> Generated: 2026-04-12 | Version: main (post PR #802) | Branch: `main`
 
-## Current Main Snapshot (2026-03-27)
+## Current Main Snapshot (2026-04-12)
 
-### Recently Merged
-- Issue #558: enrichment/search orchestration hardening.
-- PR #559: hardening merge to main with protected-branch auto-merge.
+### Recently Merged (April 2026)
 
-### What Changed
-- Truth ingestion now emits `enrichment-jobs`.
-- Truth HITL approval now emits both `export-jobs` and `search-enrichment-jobs`.
-- Truth enrichment now uses human-gated lifecycle (`pending_review`) with no direct auto-approval write path.
-- Catalog search now returns/uses stage and session metadata and persists search history context.
-- UI search now uses baseline-first retrieval with background intelligent rerank refresh.
-- Agent API proxy now forwards correlation and user/session/IP context headers.
+| PR | Title | Impact |
+|----|-------|--------|
+| #802 | Replace FoundryInvoker with FoundryAgentInvoker (MAF runtime) | Fixes silent tool-dropping; upgrades `agent-framework` to 1.0.1 GA |
+| #800 | Parallelize memory reads/writes, add memory tools | Concurrent hot/warm/cold I/O via `asyncio.gather` |
+| #798 | Add start-dev-environment script | MCAPSGov nightly shutdown recovery automation |
+| #797 | Add fix-issues-pipeline prompt | End-to-end issue resolution workflow |
+| #796 | Parallelize catalog-search I/O | Eliminates duplicate keyword search, reduces p95 latency |
+| #794 | Fix CRUD_SERVICE_URL port 8000→80 | Resolves inter-service connectivity in AKS |
+| #793 | Scaffold MkDocs documentation site | Future docs-as-website in `mkdocs/` |
+| #792 | Flux Phase B — full GitOps reconciliation | Removes kubectl-apply fallback |
+| #789 | API Center governance + APIM MCP strategy | ADR-035 implementation |
+| #788 | Namespace isolation (ADR-034) | Separate CRUD and agent Kubernetes namespaces |
+| #785 | Flux CD migration (ADR-033) | Declarative manifest reconciliation |
+| #776 | Harden CRUD Entra auth rollout | Improved authentication contracts |
+| #771 | Complete self-healing epic | Incident lifecycle, remediation policy, audit trail |
+
+### What Changed (Since Last Snapshot)
+
+- **FoundryAgentInvoker** replaces legacy `FoundryInvoker`: agent tools are now properly forwarded through the Microsoft Agent Framework `FoundryAgent` runtime instead of being silently dropped.
+- `agent-framework` upgraded from unpinned to `>=1.0.1` GA across all 27 Python service packages; resolves `ContextProvider` vs `BaseContextProvider` import incompatibility.
+- Memory tier operations parallelized with `asyncio.gather` for reduced latency; new memory tools (`get_memory`, `set_memory`, `search_memory`) and `gather_adapters` helper available.
+- AKS deployments now reconcile through Flux CD GitOps (ADR-033); kubectl-apply path removed.
+- CRUD and agent services run in separate Kubernetes namespaces (ADR-034).
+- API Center governance and APIM MCP strategy implemented (ADR-035).
+- Self-healing runtime completed with incident lifecycle state machine, remediation policy, and audit trail.
+- Catalog-search I/O parallelized; duplicate keyword search eliminated.
 
 ### Validation
-- Full local test run on latest merged state: 1647 passed, 2 warnings.
+
+- Full local test run: **1796 passed** (1136 lib + 660 app), 0 failures.
+- CI gate: lint, test, CodeQL, pip-audit, contract-gate all passing on `main`.
+- 35 Architecture Decision Records (ADR-001 through ADR-035).
 
 ### Note
-- Historical sections below preserve earlier v1.1.0 planning/trackers for audit context and may include superseded planning entries.
+
+- Historical sections below preserve earlier v1.1.0 and v2.0.0 planning/trackers for audit context and may include superseded planning entries.
 
 ---
 

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -1,9 +1,21 @@
 # Roadmap & Known Issues
 
 **Created**: February 27, 2026  
-**Source**: Deployment validation audit (February 2026)
+**Last Updated**: April 12, 2026  
+**Source**: Deployment validation audit (February 2026) + ongoing issue tracking
 
 This folder tracks corrections, gaps, and planned enhancements discovered during architecture review and deployment validation.
+
+## Recent Resolutions (April 2026)
+
+| Resolution | PR | Impact |
+|-----------|-----|--------|
+| Silent tool-dropping in FoundryInvoker | #802 | Agent tools now forwarded correctly via MAF FoundryAgent |
+| Memory tier I/O latency | #800 | Parallel hot/warm/cold operations via asyncio.gather |
+| Catalog-search duplicate queries | #796 | Eliminated redundant keyword search execution |
+| CRUD_SERVICE_URL port mismatch | #794 | Agent inter-service connectivity restored |
+| Flux CD GitOps migration | #785, #792 | Declarative manifest reconciliation, kubectl-apply removed |
+| Namespace isolation | #788 | CRUD and agent services in separate namespaces |
 
 ## Issue Index
 

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,93 +1,468 @@
-# Holiday Peak Lib
+# `holiday-peak-lib` — Core Micro-Framework for Agentic Retail Services
 
-Core shared framework for retail agent services in this repository.
+![version](https://img.shields.io/badge/version-0.2.0-blue)
+![python](https://img.shields.io/badge/python-%3E%3D3.13-blue)
+![tests](https://img.shields.io/badge/tests-1136%20passed-brightgreen)
+![coverage](https://img.shields.io/badge/coverage-89%25-brightgreen)
 
-It provides:
+`holiday-peak-lib` is the shared micro-framework that powers every retail agent service in this repository. It provides a single, cohesive abstraction layer over Microsoft Agent Framework (MAF), Azure AI Foundry, three-tier memory, enterprise connectors, resilience patterns, and structured telemetry — enabling 26 domain-specific agent services to stay thin, consistent, and independently deployable while sharing battle-tested infrastructure code.
 
-- Agent foundations (`BaseRetailAgent`, `AgentBuilder`, MCP exposure)
-- Adapter contracts and domain adapters
-- Canonical schemas and truth-layer models
-- Shared app factory and configuration settings
-- Reliability/telemetry helpers (retry, circuit breaker, bulkhead, telemetry)
-- Structured `/invoke` outcome telemetry for success/degraded/error traceability in Azure Monitor/Application Insights
-- Autonomous self-healing runtime (incident lifecycle, remediation policy, audit trail)
-- Connectors and integration contracts for enterprise systems
+---
 
-## Location
+## Why Microsoft Agent Framework (MAF) Lives Here
 
-- Source package: `lib/src/holiday_peak_lib`
-- Package metadata: `lib/src/pyproject.toml`
-- Library tests: `lib/tests`
+[Microsoft Agent Framework](https://learn.microsoft.com/en-us/python/api/overview/azure/agent-framework) (`agent-framework>=1.0.1` GA) is the Python runtime that executes [Azure AI Foundry](https://learn.microsoft.com/en-us/azure/ai-studio/) agents. It handles the protocol-level details of agent invocation, tool forwarding, message streaming, and lifecycle management.
 
-## Setup
+Rather than having each of the 26 service apps depend on MAF directly, the lib **wraps MAF behind `FoundryAgentInvoker`** — a thin adapter that turns a Foundry Agent into a `ModelTarget` invoker consumed by `BaseRetailAgent`. This architectural choice delivers concrete benefits:
 
-From repository root:
+| Benefit | Detail |
+|---------|--------|
+| **Single point of upgrade** | When MAF releases a breaking change or a new GA version, **one `pyproject.toml` update** in `lib/src` propagates to all services. In PR #802 (migrating from `FoundryInvoker` to `FoundryAgentInvoker`), all 27 `pyproject.toml` files were updated in a single pass because the abstraction boundary held. |
+| **SDK-agnostic base class** | `BaseRetailAgent` extends MAF's `BaseAgent` but adds retail-specific concerns: SLM/LLM routing, three-tier memory, MCP tool exposure, guardrails, and structured telemetry. Agent services never need to understand MAF internals. |
+| **Consistent tool forwarding** | Tools registered via `AgentBuilder.with_tool()` are forwarded to the Foundry agent through a standardized interface, avoiding per-service wiring. |
+| **Centralized telemetry** | `FoundryTracer` wraps OpenTelemetry with Foundry-aware span attributes, ensuring every agent invocation emits consistent traces to Azure Monitor. |
+| **Import isolation** | Agent services import **only from `holiday_peak_lib`** — never directly from `agent_framework` or `agent_framework_foundry`. The lazy import in `base_agent.py` even provides a fallback shim when MAF is unavailable (CI resilience). |
 
-```bash
-uv sync --directory lib/src --extra dev --extra test --extra lint
+**Reference links:**
+- [Microsoft Agent Framework Python API](https://learn.microsoft.com/en-us/python/api/overview/azure/agent-framework)
+- [Azure AI Foundry documentation](https://learn.microsoft.com/en-us/azure/ai-studio/)
+
+---
+
+## Architecture Overview
+
+```mermaid
+%%{init: {'theme':'base', 'themeVariables': {'primaryColor':'#FFB3BA','primaryTextColor':'#000','primaryBorderColor':'#FF8B94','lineColor':'#BAE1FF','secondaryColor':'#BAE1FF','tertiaryColor':'#FFFFFF'}}}%%
+graph TD
+    subgraph "holiday_peak_lib"
+        AF["app_factory<br/>+ app_factory_components"]
+        AG["agents"]
+        AD["adapters"]
+        SC["schemas"]
+        CF["config"]
+        UT["utils"]
+        MC["mcp"]
+        EV["events"]
+        CN["connectors"]
+        IG["integrations"]
+        SH["self_healing"]
+        TR["truth"]
+        EL["evaluation"]
+
+        subgraph "agents/"
+            BA["BaseRetailAgent<br/>(base_agent)"]
+            BU["AgentBuilder<br/>(builder)"]
+            FO["FoundryAgentInvoker<br/>(foundry)"]
+            PL["prompt_loader"]
+            PP["provider_policy"]
+            SA["service_agent"]
+            FM["fastapi_mcp"]
+            subgraph "memory/"
+                HM["HotMemory<br/>(Redis)"]
+                WM["WarmMemory<br/>(Cosmos DB)"]
+                CM["ColdMemory<br/>(Blob)"]
+                MB["MemoryBuilder<br/>+ MemoryClient"]
+            end
+            subgraph "guardrails/"
+                EG["EnrichmentGuardrail"]
+                SV["SourceValidator"]
+                CA["ContentAttributor"]
+                GM["GuardrailMiddleware"]
+            end
+            subgraph "orchestration/"
+                RS["RoutingStrategy"]
+                EE["Evaluator"]
+            end
+        end
+    end
+
+    AF --> AG
+    AF --> MC
+    AF --> SH
+    AF --> CF
+    AF --> UT
+    AG --> AD
+    AG --> SC
+    AG --> UT
+    BU --> BA
+    BU --> FO
+    BU --> RS
+    BU --> MB
+    BA --> FO
+    MC --> AG
+    EV --> SC
+    CN --> CF
+    IG --> CN
+    TR --> EV
+    EL --> SC
 ```
 
-If you already have a virtual environment active and prefer pip:
+---
 
-```bash
-pip install -e lib/src[dev,test,lint]
+## Module Reference
+
+### `agents/` — Agent Runtime
+
+| File / Submodule | Key Exports | Purpose |
+|------------------|-------------|---------|
+| `base_agent.py` | `BaseRetailAgent`, `AgentDependencies`, `ModelTarget` | Abstract base extending MAF `BaseAgent` with SLM/LLM model selection, complexity heuristics, and retail-specific lifecycle hooks |
+| `builder.py` | `AgentBuilder` | Fluent builder composing agents with memory tiers, routing strategy, MCP server, tools, and model targets |
+| `foundry.py` | `FoundryAgentConfig`, `FoundryAgentInvoker`, `build_foundry_model_target`, `ensure_foundry_agent` | MAF integration: lazy-imports `agent_framework_foundry.FoundryAgent`, normalizes project endpoints, wraps invocation as `ModelTarget` |
+| `prompt_loader.py` | `load_service_prompt_instructions` | Loads structured prompt instruction files per service |
+| `provider_policy.py` | `sanitize_messages_for_provider`, `should_use_local_routing_prompt` | Provider-specific message sanitization and routing decision policies |
+| `service_agent.py` | `ServiceAgent` | Concrete agent implementation for standard service patterns |
+| `fastapi_mcp.py` | MCP-FastAPI bridge | Glue module for MCP tool registration within FastAPI request lifecycle |
+
+### `agents/memory/` — Three-Tier Memory
+
+| File | Key Exports | Purpose |
+|------|-------------|---------|
+| `hot.py` | `HotMemory` | Redis-backed short-lived context with fail-open degradation |
+| `warm.py` | `WarmMemory` | Cosmos DB-backed conversation thread and session state |
+| `cold.py` | `ColdMemory` | Azure Blob Storage-backed long-term archival state |
+| `builder.py` | `MemoryBuilder`, `MemoryClient`, `MemoryRules` | Unified client with cascading read/write rules, parallel I/O via `asyncio.gather`, and promotion policies |
+| `namespace.py` | `NamespaceContext`, `build_canonical_memory_key`, `resolve_namespace_context` | Canonical key construction and namespace isolation for multi-tenant memory |
+
+### `agents/guardrails/` — Enrichment Guardrails
+
+| File | Key Exports | Purpose |
+|------|-------------|---------|
+| `enrichment_guardrail.py` | `EnrichmentGuardrail`, `SourceValidator`, `ContentAttributor`, `GuardrailMiddleware`, `SourceRef`, `SourceValidationResult` | Validates AI-generated enrichments against source evidence, attributes content provenance, and enforces quality gates in enrichment pipelines |
+
+### `agents/orchestration/` — Routing and Evaluation
+
+| File | Key Exports | Purpose |
+|------|-------------|---------|
+| `router.py` | `RoutingStrategy` | SLM-first intent routing with complexity-based escalation to LLM; supports tiered handler registration |
+| `evaluator.py` | `Evaluator`, `EvaluationResult` | Collects latency and success metrics for agent invocations |
+
+### `adapters/` — Domain Adapters
+
+| File | Key Exports | Purpose |
+|------|-------------|---------|
+| `base.py` | `BaseAdapter`, `BaseConnector`, `AdapterError` | Abstract adapter and connector contracts |
+| `crud_adapter.py` | `BaseCRUDAdapter` | Base adapter for CRUD service interactions |
+| `crm_adapter.py` | CRM domain adapter | Customer relationship management operations |
+| `inventory_adapter.py` | Inventory domain adapter | Stock levels, warehouse lookups |
+| `logistics_adapter.py` | Logistics domain adapter | Shipment tracking, carrier operations |
+| `pricing_adapter.py` | Pricing domain adapter | Price retrieval, dynamic pricing |
+| `product_adapter.py` | Product domain adapter | Product catalog operations |
+| `acp_mapper.py` | `AcpCatalogMapper` | Akeneo Connector Protocol (ACP) mapping |
+| `ucp_mapper.py` | `UcpProtocolMapper` | Unified Commerce Protocol (UCP) mapping |
+| `protocol_mapper.py` | `ProtocolMapper` | Generic protocol mapping contract |
+| `mcp_adapter.py` | `BaseMCPAdapter` | Adapter for agent-to-agent MCP communication |
+| `external_api_adapter.py` | `BaseExternalAPIAdapter` | Adapter for external REST API integrations |
+| `dam_image_analysis.py` | `DAMImageAnalysisAdapter` | Digital asset management image analysis |
+| `truth_store.py` | Truth store adapter | Adapter interface for truth layer persistence |
+| `mock_adapters.py` | `MockCRMAdapter`, `MockInventoryAdapter`, `MockLogisticsAdapter`, `MockPricingAdapter`, `MockProductAdapter`, `MockFunnelAdapter` | Test doubles for all domain adapters |
+
+### `app_factory.py` + `app_factory_components/` — Service Assembly
+
+| File | Key Exports | Purpose |
+|------|-------------|---------|
+| `app_factory.py` | `create_standard_app`, `build_service_app` | FastAPI app assembly with Foundry lifecycle, memory, MCP, self-healing, and event subscriptions |
+| `app_factory_components/endpoints.py` | `register_standard_endpoints` | Registers `/invoke`, `/health`, `/ready` and self-healing routes |
+| `app_factory_components/foundry_lifecycle.py` | `FoundryLifecycleManager`, `FoundryReadinessSnapshot` | Manages Foundry agent provisioning and readiness checks on startup |
+| `app_factory_components/middleware.py` | `register_correlation_middleware` | Correlation ID propagation middleware for distributed tracing |
+
+### `config/` — Configuration
+
+| File | Key Exports | Purpose |
+|------|-------------|---------|
+| `settings.py` | `MemorySettings`, `ServiceSettings` | Pydantic `BaseSettings` models for memory tiers, AI Search, Event Hub, and Azure Monitor |
+| `tenant_config.py` | Tenant configuration | Per-tenant configuration resolution |
+
+### `connectors/` — Enterprise Connector Registry
+
+| File / Submodule | Key Exports | Purpose |
+|------------------|-------------|---------|
+| `registry.py` | `ConnectorRegistry` | Tenant-aware connector resolution with KeyVault secret integration |
+| `tenant_resolver.py` | Tenant resolver | Resolves connector instances per tenant context |
+| `tenant_config.py` | Tenant configuration | Connector-level tenant configuration |
+| `common/` | Shared connector utilities | Cross-connector helpers |
+| `pim/` | PIM connectors | Product Information Management connectors (Akeneo, Salsify) |
+| `dam/` | DAM connectors | Digital Asset Management connectors (Cloudinary) |
+| `crm_loyalty/` | CRM/Loyalty connectors | CRM and loyalty program connectors |
+| `inventory_scm/` | Inventory/SCM connectors | Inventory and supply chain connectors |
+
+### `evaluation/` — Quality Evaluation
+
+| File | Key Exports | Purpose |
+|------|-------------|---------|
+| `enrichment_evaluator.py` | Enrichment evaluator | Evaluates AI enrichment quality against ground truth |
+| `search_evaluator.py` | Search evaluator | Evaluates search relevance and ranking quality |
+| `eval_runner.py` | Evaluation runner | Orchestrates evaluation runs across multiple evaluators |
+
+### `events/` — Event Contracts
+
+| File | Key Exports | Purpose |
+|------|-------------|---------|
+| `connector_events.py` | `ConnectorEvent`, `ProductChanged`, `InventoryUpdated`, `CustomerUpdated`, `OrderStatusChanged`, `PriceUpdated` | Typed event models for connector integrations |
+| `retail_events.py` | `RetailEvent`, `OrderEventEnvelope`, `InventoryEventEnvelope`, `ShipmentEventEnvelope`, `PaymentEventEnvelope`, `ProductEventEnvelope`, `UserEventEnvelope`, `ReturnEventEnvelope` | Domain event envelopes with topic routing |
+| `versioning.py` | `SchemaCompatibilityPolicy`, `CURRENT_EVENT_SCHEMA_VERSION` | Event schema versioning and compatibility enforcement |
+
+### `integrations/` — Enterprise System Contracts
+
+| File | Key Exports | Purpose |
+|------|-------------|---------|
+| `contracts.py` | `PIMConnectorBase`, `DAMConnectorBase`, `CRMConnectorBase`, `CommerceConnectorBase`, `InventoryConnectorBase`, `AnalyticsConnectorBase`, `IdentityConnectorBase`, `WorkforceConnectorBase` | Abstract base classes for all enterprise system integrations |
+| `pim_generic_rest.py` | `GenericRestPIMConnector`, `PIMConnectionConfig` | Generic REST-based PIM connector for any PIM system |
+| `pim_writeback.py` | `PIMWritebackManager`, `WritebackResult`, `WritebackStatus` | Manages product data writeback to PIM systems with circuit breaking |
+| `dam_generic.py` | `GenericDAMConnector`, `DAMConnectionConfig` | Generic DAM connector for asset management systems |
+
+### `mcp/` — Model Context Protocol
+
+| File | Key Exports | Purpose |
+|------|-------------|---------|
+| `server.py` | `FastAPIMCPServer`, `MCPToolSchemaRef` | MCP tool server integrated with FastAPI for agent-to-agent tool exposure |
+| `ai_search_indexing.py` | `AISearchIndexingClient`, `register_ai_search_indexing_tools` | AI Search indexing operations exposed as MCP tools |
+
+### `schemas/` — Pydantic v2 Models
+
+| Submodule | Coverage |
+|-----------|----------|
+| `core.py` | `Product`, `UserContext`, `RecommendationRequest`, `RecommendationResponse` |
+| `crm.py` | `CRMAccount`, `CRMContact`, `CRMContext`, `CRMInteraction` |
+| `product.py` | `CanonicalProduct`, `CatalogProduct`, `ProductContext` |
+| `inventory.py` | `InventoryContext`, `InventoryItem`, `WarehouseStock` |
+| `pricing.py` | `PriceContext`, `PriceEntry` |
+| `logistics.py` | `LogisticsContext`, `Shipment`, `ShipmentEvent` |
+| `search.py` | `IntentClassification`, `SearchEnrichedProduct` |
+| `funnel.py` | `FunnelContext`, `FunnelMetric` |
+| `truth.py` | `TruthAttribute`, `ProductEnrichmentProposal`, `ProposedAttribute`, `Provenance`, `AuditEvent`, `ExportJob`, `GapReport`, `ProductStyle`, `ProductVariant` |
+| `acp.py` | `AcpProduct`, `AcpPartnerProfile` |
+| `ucp.py` | `UcpProduct`, `UcpPricing`, `UcpImage`, `UcpMetadata`, `UcpCompliance` |
+| `canonical/` | Canonical category and field definitions |
+| `categories/` | Category taxonomy schemas |
+| `mappings/` | Field mapping definitions (Salsify, Akeneo) |
+| `protocols/` | Protocol-specific schema extensions |
+
+### `self_healing/` — Autonomous Self-Healing Runtime
+
+| File | Key Exports | Purpose |
+|------|-------------|---------|
+| `kernel.py` | `SelfHealingKernel` | Incident lifecycle state machine: detect → classify → remediate → verify → escalate/closed |
+| `manifest.py` | `ServiceSurfaceManifest`, `SurfaceEdgeReference` | Declares service surfaces (`api`, `apim`, `aks_ingress`, `mcp`, `messaging`) covered by healing |
+| `models.py` | `Incident`, `IncidentState`, `IncidentClass`, `FailureSignal`, `RemediationActionResult`, `SurfaceType` | Domain models for the incident lifecycle |
+
+Feature flags: `SELF_HEALING_ENABLED`, `SELF_HEALING_DETECT_ONLY`, `SELF_HEALING_SURFACE_MANIFEST_JSON`, `SELF_HEALING_RECONCILE_ON_MESSAGING_ERROR`.
+
+Operational routes: `GET /self-healing/status`, `GET /self-healing/incidents`, `POST /self-healing/reconcile`.
+
+### `truth/` — Truth Layer
+
+| File | Key Exports | Purpose |
+|------|-------------|---------|
+| `models.py` | Truth layer domain models | Core truth layer entity models |
+| `schemas.py` | Truth layer schemas | Pydantic schemas for truth layer API contracts |
+| `evidence.py` | `EvidenceExtractor`, `EvidenceConfig`, `EnrichmentEvidence` | Extracts and structures evidence for enrichment proposals |
+| `store.py` | `TruthStore` | Persistence layer for truth layer entities |
+| `event_hub.py` | Truth Event Hub helpers | Event Hub integration for truth layer change events |
+
+### `utils/` — Reliability and Observability
+
+| File | Key Exports | Purpose |
+|------|-------------|---------|
+| `circuit_breaker.py` | `CircuitBreaker`, `CircuitBreakerOpenError`, `CircuitState` | Async circuit breaker with CLOSED → OPEN → HALF_OPEN recovery |
+| `bulkhead.py` | `Bulkhead`, `BulkheadFullError` | Per-workload concurrency isolation via semaphores |
+| `rate_limiter.py` | `RateLimiter`, `RateLimitExceededError` | Sliding-window per-tenant rate limiting |
+| `retry.py` | `async_retry` | Decorator-based async retry with configurable attempts and delay |
+| `compensation.py` | `CompensationAction`, `CompensationResult`, `execute_compensation` | Saga-style compensating transaction framework |
+| `event_hub.py` | `EventHubSubscriber`, `EventHubSubscription`, `create_eventhub_lifespan` | Azure Event Hub consumer lifecycle management |
+| `correlation.py` | `get_correlation_id`, `set_correlation_id`, `CORRELATION_HEADER` | Distributed correlation ID propagation |
+| `telemetry.py` | `FoundryTracer`, `get_foundry_tracer`, `get_tracer`, `get_meter`, `record_metric` | OpenTelemetry wrapper with Foundry-aware span attributes and Azure Monitor integration |
+| `logging.py` | `configure_logging`, `log_async_operation` | Structured logging with async operation instrumentation |
+| `truth_event_hub.py` | Truth-specific Event Hub helpers | Event Hub utilities for truth layer pipelines |
+
+---
+
+## Agent Lifecycle
+
+The following sequence shows how an agent service boots when `create_standard_app()` is called in each app's `main.py`:
+
+```mermaid
+%%{init: {'theme':'base', 'themeVariables': {'primaryColor':'#FFB3BA','primaryTextColor':'#000','primaryBorderColor':'#FF8B94','lineColor':'#BAE1FF','secondaryColor':'#BAE1FF','tertiaryColor':'#FFFFFF'}}}%%
+sequenceDiagram
+    participant Main as main.py
+    participant AF as app_factory
+    participant FC as FoundryAgentConfig
+    participant AB as AgentBuilder
+    participant FI as FoundryAgentInvoker
+    participant App as FastAPI App
+
+    Main->>AF: create_standard_app(service_name, AgentClass)
+    AF->>AF: Load MemorySettings from env vars
+    AF->>AF: Initialize HotMemory, WarmMemory, ColdMemory
+    AF->>AF: Initialize SelfHealingKernel from env
+    AF->>FC: Load FoundryAgentConfig from env vars<br/>(PROJECT_ENDPOINT, FOUNDRY_AGENT_ID_FAST, etc.)
+    AF->>AB: AgentBuilder()<br/>.with_agent(AgentClass)<br/>.with_router(RoutingStrategy)<br/>.with_memory(hot, warm, cold)<br/>.with_mcp(FastAPIMCPServer)
+    AB->>FI: build_foundry_model_target(config)<br/>wraps MAF FoundryAgent as ModelTarget
+    AB->>AB: .with_models(slm=target, llm=target)
+    AB->>AB: .build() → BaseRetailAgent instance
+    AF->>App: Register /invoke, /health, /ready
+    AF->>App: Register /self-healing/* routes
+    AF->>App: Register MCP tool endpoints
+    AF->>App: Register correlation middleware
+    AF-->>Main: Return FastAPI app
 ```
 
-## Module Map
+**Step-by-step:**
 
-```text
-holiday_peak_lib/
-├── adapters/      # Domain adapters + protocol mappers + truth store adapter
-├── agents/        # Base agent, builder, Foundry integration, MCP server, guardrails
-├── app_factory.py # Standard FastAPI app assembly for services
-├── config/        # Pydantic settings and tenant config
-├── connectors/    # Connector registry + tenant-aware connector resolution
-├── evaluation/    # Enrichment/search evaluation runners
-├── events/        # Shared connector event contracts
-├── integrations/  # PIM/DAM and integration contracts
-├── mcp/           # MCP tools (including AI Search indexing support)
-├── schemas/       # Canonical/domain/truth schemas (Pydantic v2)
-├── self_healing/  # Incident lifecycle kernel, manifest contract, remediation policy
-├── truth/         # Truth-layer models, storage, evidence, and Event Hub helpers
-└── utils/         # Retry, rate limiter, bulkhead, circuit breaker, telemetry, logging
+1. **`create_standard_app()`** is called in each app's `main.py` with the service name and agent class.
+2. **`FoundryAgentConfig`** is loaded from environment variables (`PROJECT_ENDPOINT`, `FOUNDRY_AGENT_ID_FAST`, `MODEL_DEPLOYMENT_NAME_FAST`, `FOUNDRY_AGENT_ID_RICH`, `MODEL_DEPLOYMENT_NAME_RICH`).
+3. **`AgentBuilder`** composes the agent with tools, memory tiers, routing strategy, guardrails, and MCP server.
+4. **`FoundryAgentInvoker`** wraps MAF's `FoundryAgent` as a `ModelTarget` — the agent never touches MAF directly.
+5. **FastAPI app** is returned with `/invoke`, `/health`, `/ready`, self-healing routes, and MCP tool endpoints registered.
+
+---
+
+## Three-Tier Memory Architecture
+
+```mermaid
+%%{init: {'theme':'base', 'themeVariables': {'primaryColor':'#FFB3BA','primaryTextColor':'#000','primaryBorderColor':'#FF8B94','lineColor':'#BAE1FF','secondaryColor':'#BAE1FF','tertiaryColor':'#FFFFFF'}}}%%
+graph LR
+    R["Read Request"] --> MC["MemoryClient"]
+    MC -->|"parallel asyncio.gather"| HOT["Hot<br/>Redis"]
+    MC -->|"parallel asyncio.gather"| WARM["Warm<br/>Cosmos DB"]
+    MC -->|"sequential fallback"| COLD["Cold<br/>Blob Storage"]
+
+    HOT -->|"hit"| RES["Return Value"]
+    WARM -->|"hit + promote"| HOT
+    WARM -->|"hit"| RES
+    COLD -->|"hit + promote"| HOT
+    COLD -->|"hit + promote"| WARM
+    COLD -->|"hit"| RES
 ```
 
-## Quick Usage
+| Tier | Backing Store | Latency | TTL | Use Case |
+|------|--------------|---------|-----|----------|
+| **Hot** | Azure Cache for Redis | Sub-millisecond | 300s (configurable) | Active conversation context, recent lookups |
+| **Warm** | Azure Cosmos DB | Single-digit ms | Configurable | Session history, user profiles, conversation threads |
+| **Cold** | Azure Blob Storage | Tens of ms | Indefinite | Long-term archival, audit trails, bulk state snapshots |
+
+**Behavior:**
+- **Reads** issue Hot + Warm lookups in **parallel** via `asyncio.gather`. Cold is a sequential fallback for archival data.
+- **Cascading promotion**: A warm-only hit promotes the value to hot. A cold-only hit promotes to both hot and warm.
+- **Writes** are write-through by default: hot + warm updated in parallel; cold is opt-in via `MemoryRules.write_cold`.
+- **Fail-open**: Hot memory degrades gracefully on Redis connection failures — agents continue operating with warm/cold tiers.
+
+### Configuration Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `REDIS_URL` | Full Redis connection URL (e.g., `rediss://:password@host:6380/0`) |
+| `REDIS_HOST` | Azure Redis hostname (auto-suffixed with `.redis.cache.windows.net`) |
+| `REDIS_PASSWORD` | Redis authentication password |
+| `KEY_VAULT_URI` | Azure Key Vault URI for secret resolution (Redis password) |
+| `COSMOS_ACCOUNT_URI` | Azure Cosmos DB account endpoint |
+| `COSMOS_DATABASE` | Cosmos DB database name |
+| `COSMOS_CONTAINER` | Cosmos DB container name |
+| `BLOB_ACCOUNT_URL` | Azure Blob Storage account URL |
+| `BLOB_CONTAINER` | Blob Storage container name |
+
+---
+
+## Resilience Patterns
+
+### Circuit Breaker
+
+Prevents cascading failures by short-circuiting calls to degraded downstream services. Transitions through CLOSED → OPEN → HALF_OPEN states based on consecutive failure counts and recovery timeouts.
 
 ```python
-from holiday_peak_lib.app_factory import build_service_app
+from holiday_peak_lib.utils import CircuitBreaker
 
-app = build_service_app(
-    service_name="my-service",
-    slm_config=slm_config,
-    llm_config=llm_config,
-)
+breaker = CircuitBreaker(name="catalog-api", failure_threshold=5, recovery_timeout=30.0)
+
+result = await breaker.call(fetch_catalog, product_id="SKU-001")
 ```
 
-## Self-Healing Runtime
+### Bulkhead
 
-Every service assembled through `build_service_app` inherits a shared self-healing kernel with:
+Isolates concurrent workloads with per-pipeline semaphores, preventing one slow pipeline from consuming all available threads.
 
-- Incident lifecycle state machine: detect -> classify -> remediate -> verify -> escalate/closed
-- Surface coverage: `api`, `apim`, `aks_ingress`, `mcp`, and `messaging`
-- Recoverable classification policy for infrastructure misconfiguration (`4xx` and selected `5xx`)
-- Allowlisted remediation actions with audit records
-- Guardrail that forbids image restore/redeploy remediation actions
+```python
+from holiday_peak_lib.utils import Bulkhead
 
-Feature flags:
+enrichment_bulkhead = Bulkhead(name="enrichment", concurrency_limit=10, queue_timeout=5.0)
 
-- `SELF_HEALING_ENABLED` (`false` by default)
-- `SELF_HEALING_DETECT_ONLY` (`false` by default)
-- `SELF_HEALING_SURFACE_MANIFEST_JSON` (optional JSON contract override)
-- `SELF_HEALING_RECONCILE_ON_MESSAGING_ERROR` (optional, default `false`)
+result = await enrichment_bulkhead.execute(enrich_product, product_id="SKU-001")
+```
 
-Operational routes exposed on every service:
+### Rate Limiter
 
-- `GET /self-healing/status`
-- `GET /self-healing/incidents`
-- `POST /self-healing/reconcile`
+Sliding-window per-tenant rate limiting to protect shared resources from noisy neighbors.
+
+```python
+from holiday_peak_lib.utils import RateLimiter
+
+limiter = RateLimiter(limit=100, window_seconds=60.0)
+
+await limiter.check(tenant_id="tenant-123")  # raises RateLimitExceededError if over limit
+```
+
+### Async Retry
+
+Decorator-based retry with configurable attempts and backoff delay for transient failures.
+
+```python
+from holiday_peak_lib.utils import async_retry
+
+@async_retry(times=3, delay_seconds=0.5)
+async def fetch_inventory(sku: str) -> dict:
+    ...
+```
+
+### Compensation (Saga Rollback)
+
+Saga-style compensating transaction framework for multi-step operations that need rollback on partial failure.
+
+```python
+from holiday_peak_lib.utils import CompensationAction, execute_compensation
+
+actions = [
+    CompensationAction(name="release-reservation", execute=release_reservation),
+    CompensationAction(name="refund-payment", execute=refund_payment),
+]
+result = await execute_compensation(actions, continue_on_error=False)
+```
+
+---
+
+## Dependencies
+
+| Package | Version Constraint | Purpose |
+|---------|--------------------|---------|
+| `agent-framework` | `>=1.0.1` | Microsoft Agent Framework (MAF) GA — Foundry agent execution runtime |
+| `azure-ai-projects` | `>=2.0.0b4` | Azure AI Foundry project client for agent provisioning and invocation |
+| `fastapi` | latest | Web framework for service endpoints and MCP tool exposition |
+| `fastapi-mcp` | latest | FastAPI integration for Model Context Protocol server |
+| `uvicorn` | latest | ASGI server for FastAPI services |
+| `pydantic` | `>=2` | Data validation and schema modeling (v2) |
+| `pydantic-settings` | `>=2` | Environment-based configuration management |
+| `httpx` | latest | Async HTTP client for inter-service communication |
+| `azure-identity` | latest | Azure credential management (DefaultAzureCredential) |
+| `azure-keyvault-secrets` | latest | Key Vault secret resolution for connector credentials |
+| `azure-search-documents` | latest | Azure AI Search indexing and querying |
+| `azure-cosmos` | latest | Azure Cosmos DB SDK for warm memory tier |
+| `azure-storage-blob` | latest | Azure Blob Storage SDK for cold memory tier |
+| `azure-eventhub` | latest | Azure Event Hub producer/consumer for event-driven pipelines |
+| `azure-monitor-opentelemetry` | `>=1.7.0` | Azure Monitor OpenTelemetry exporter |
+| `opentelemetry-api` | `>=1.27.0` | OpenTelemetry tracing and metrics API |
+| `opentelemetry-sdk` | `>=1.27.0` | OpenTelemetry SDK implementation |
+| `redis` | latest | Redis async client for hot memory tier |
+| `asyncpg` | latest | Async PostgreSQL driver |
+| `aiohttp` | latest | Async HTTP utilities |
+| `pyyaml` | latest | YAML configuration parsing |
+| `typing-extensions` | latest | Backported typing features |
+| `python-dotenv` | latest | `.env` file loading for local development |
+
+---
 
 ## Testing
+
+The lib test suite contains **1,136 tests** with **89% code coverage**, run via `pytest` with `pytest-asyncio` for async test support.
+
+### Running Tests
 
 From repository root:
 
@@ -95,14 +470,104 @@ From repository root:
 python -m pytest lib/tests
 ```
 
-Or from the `lib/src` package directory (uses local pytest config):
+Or from the `lib/src` package directory:
 
 ```bash
 cd lib/src
 python -m pytest
 ```
 
-## Notes
+### Test Module Mapping
 
-- This README intentionally reflects the current workspace structure and avoids static test-count snapshots.
-- For platform architecture context, see the repository docs in `docs/architecture`.
+| Test File | Module Covered |
+|-----------|---------------|
+| `test_agents_base.py` | `agents/base_agent.py` — BaseRetailAgent, ModelTarget, AgentDependencies |
+| `test_agents_builder.py` | `agents/builder.py` — AgentBuilder composition |
+| `test_foundry.py` | `agents/foundry.py` — FoundryAgentInvoker, endpoint normalization |
+| `test_prompt_loader.py` | `agents/prompt_loader.py` — Prompt instruction loading |
+| `test_provider_policy.py` | `agents/provider_policy.py` — Provider message sanitization |
+| `test_service_agent.py` | `agents/service_agent.py` — ServiceAgent implementation |
+| `test_memory.py` | `agents/memory/hot.py`, `warm.py`, `cold.py` — Individual memory tiers |
+| `test_memory_builder.py` | `agents/memory/builder.py` — MemoryClient cascading logic |
+| `test_memory_namespace.py` | `agents/memory/namespace.py` — Canonical key construction |
+| `test_guardrails.py` | `agents/guardrails/` — EnrichmentGuardrail, SourceValidator |
+| `test_router.py` | `agents/orchestration/router.py` — RoutingStrategy, SLM-first escalation |
+| `test_adapters.py` | `adapters/` — BaseAdapter, domain adapter contracts |
+| `test_acp_mapper.py` | `adapters/acp_mapper.py` — ACP protocol mapping |
+| `test_protocol_mappers.py` | `adapters/protocol_mapper.py`, `ucp_mapper.py` — Protocol mappers |
+| `test_app_factory.py` | `app_factory.py` — Service assembly |
+| `test_app_factory_endpoints.py` | `app_factory_components/endpoints.py` — Standard endpoints |
+| `test_app_factory_foundry_lifecycle.py` | `app_factory_components/foundry_lifecycle.py` — Foundry lifecycle |
+| `test_app_factory_middleware.py` | `app_factory_components/middleware.py` — Correlation middleware |
+| `test_config.py` | `config/settings.py` — MemorySettings, ServiceSettings |
+| `test_tenant_config.py` | `config/tenant_config.py` — Tenant configuration |
+| `test_connectors/` | `connectors/` — ConnectorRegistry, tenant resolver |
+| `test_tenant_resolver.py` | `connectors/tenant_resolver.py` — Tenant-aware connector resolution |
+| `test_connector_events.py` | `events/connector_events.py` — Connector event models |
+| `test_retail_events.py` | `events/retail_events.py` — Retail event envelopes |
+| `test_schema_registry_guard.py` | `events/versioning.py` — Schema compatibility policy |
+| `test_evaluation_metrics.py` | `evaluation/` — Enrichment and search evaluators |
+| `test_pim_generic_rest.py` | `integrations/pim_generic_rest.py` — Generic REST PIM connector |
+| `test_pim_writeback.py` | `integrations/pim_writeback.py` — PIM writeback manager |
+| `test_dam_generic.py` | `integrations/dam_generic.py` — Generic DAM connector |
+| `test_akeneo_connector.py` | `connectors/pim/` — Akeneo PIM connector |
+| `test_cloudinary_connector.py` | `connectors/dam/` — Cloudinary DAM connector |
+| `test_salsify_mappings.py` | `schemas/mappings/` — Salsify field mappings |
+| `test_mcp_server.py` | `mcp/server.py` — FastAPIMCPServer |
+| `test_ai_search_indexing_mcp.py` | `mcp/ai_search_indexing.py` — AI Search indexing tools |
+| `test_schemas.py` | `schemas/` — Core and domain Pydantic models |
+| `test_canonical_schemas.py` | `schemas/canonical/` — Canonical category schemas |
+| `test_search_schemas.py` | `schemas/search.py` — Search-specific schemas |
+| `test_truth_schemas.py` | `truth/schemas.py` — Truth layer schemas |
+| `test_truth_evidence.py` | `truth/evidence.py` — Evidence extraction |
+| `test_truth_event_hub.py` | `truth/event_hub.py` — Truth Event Hub integration |
+| `test_ucp_schema.py` | `schemas/ucp.py` — UCP schema validation |
+| `test_self_healing_core.py` | `self_healing/kernel.py`, `models.py` — Core incident lifecycle |
+| `test_self_healing_aks_strategy.py` | `self_healing/` — AKS-specific healing strategies |
+| `test_self_healing_apim_strategy.py` | `self_healing/` — APIM-specific healing strategies |
+| `test_self_healing_messaging_strategy.py` | `self_healing/` — Messaging healing strategies |
+| `test_self_healing_verification_escalation.py` | `self_healing/` — Verification and escalation flows |
+| `test_circuit_breaker.py` | `utils/circuit_breaker.py` — Circuit breaker states and recovery |
+| `test_bulkhead.py` | `utils/bulkhead.py` — Bulkhead concurrency isolation |
+| `test_rate_limiter.py` | `utils/rate_limiter.py` — Sliding-window rate limiting |
+| `test_retry.py` | `utils/retry.py` — Async retry decorator |
+| `test_compensation.py` | `utils/compensation.py` — Saga compensation framework |
+| `test_event_hub.py` | `utils/event_hub.py` — Event Hub subscriber lifecycle |
+| `test_telemetry.py` | `utils/telemetry.py` — FoundryTracer, metrics, spans |
+| `test_utils.py` | `utils/` — General utility helpers |
+
+---
+
+## Installation
+
+From the repository root:
+
+```bash
+uv pip install -e "lib/src[dev,test]"
+```
+
+Or with all optional groups:
+
+```bash
+uv sync --directory lib/src --extra dev --extra test --extra lint
+```
+
+For pip-based environments:
+
+```bash
+pip install -e "lib/src[dev,test,lint]"
+```
+
+---
+
+## Related Documentation
+
+| Resource | Link |
+|----------|------|
+| Agent architecture (lib) | [docs/architecture/components/libs/agents.md](../docs/architecture/components/libs/agents.md) |
+| Memory architecture (lib) | [docs/architecture/components/libs/memory.md](../docs/architecture/components/libs/memory.md) |
+| Microsoft Agent Framework | [learn.microsoft.com — Agent Framework Python API](https://learn.microsoft.com/en-us/python/api/overview/azure/agent-framework) |
+| Azure AI Foundry | [learn.microsoft.com — Azure AI Studio](https://learn.microsoft.com/en-us/azure/ai-studio/) |
+| Azure Cosmos DB | [learn.microsoft.com — Azure Cosmos DB](https://learn.microsoft.com/en-us/azure/cosmos-db/) |
+| Azure AI Search | [learn.microsoft.com — Azure AI Search](https://learn.microsoft.com/en-us/azure/search/) |
+| Platform architecture | [docs/architecture/](../docs/architecture/) |


### PR DESCRIPTION
## Summary

Fixes documentation that incorrectly referenced per-domain Kubernetes namespaces (`agents-ecommerce`, `agents-crm`, etc.) rejected by [ADR-034](docs/architecture/adrs/adr-034-namespace-isolation-strategy.md). The ADR decided on exactly **two namespaces**: `holiday-peak-crud` + `holiday-peak-agents`.

## Root Cause

Session 3 documentation overhaul misinterpreted ADR-034 and introduced per-domain namespace references in 32+ files. Infrastructure code (render-helm.sh, rendered manifests, deploy-azd.yml) was always correct.

## Changes

### Namespace Fixes (bug fix)
- **26 app READMEs**: `K8S_NAMESPACE` changed from per-domain values to `holiday-peak-agents`
- **6 architecture docs**: Mermaid diagrams, namespace tables, kubectl/helm commands corrected
- **9 broken ADR links fixed** to match actual ADR filenames

### Documentation Overhaul (previously uncommitted)
- **lib/README.md**: Comprehensive rewrite with module reference tables, MAF explanation, architecture diagrams
- **5 new docs created**: agentic-microservices-reference, maf-integration-rationale, solution-architecture-diagrams, standalone-deployment-guide, test-coverage-gap-analysis
- **3 new sequence diagrams**: Foundry invocation, memory parallel I/O, Flux GitOps deployment
- **30+ existing docs updated**: Agent counts, ADR index, component docs, governance

## Verification

- [x] All 26 agent app READMEs use `K8S_NAMESPACE="holiday-peak-agents"`
- [x] Zero remaining references to rejected per-domain namespaces
- [x] Markdown link checker passes
- [x] Pre-push lint gates pass: isort, black, pylint (no E/F), mypy
- [x] Consistent with render-helm.sh, rendered manifests, and deploy-azd.yml

Closes #803
