### PR TITLE
fix(ui): bump axios to ^1.15.0 — resolve critical SSRF and header injection CVEs

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -44,7 +44,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.0.2",
     "@types/react-star-ratings": "^2.3.3",
-    "axios": "^1.13.5",
+    "axios": "^1.15.0",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "next": "^16.2.0",

--- a/apps/ui/yarn.lock
+++ b/apps/ui/yarn.lock
@@ -2374,14 +2374,14 @@ axe-core@^4.10.0:
   resolved "https://registry.npmjs.org/axe-core/-/axe-core-4.11.1.tgz"
   integrity sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==
 
-axios@^1.13.5:
-  version "1.13.6"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.13.6.tgz#c3f92da917dc209a15dd29936d20d5089b6b6c98"
-  integrity sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==
+axios@^1.15.0:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.15.0.tgz#0fcee91ef03d386514474904b27863b2c683bf4f"
+  integrity sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==
   dependencies:
     follow-redirects "^1.15.11"
     form-data "^4.0.5"
-    proxy-from-env "^1.1.0"
+    proxy-from-env "^2.1.0"
 
 axobject-query@^4.1.0:
   version "4.1.0"
@@ -6146,10 +6146,10 @@ prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
     object-assign "^4.1.1"
     react-is "^16.13.1"
 
-proxy-from-env@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz"
-  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+proxy-from-env@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-2.1.0.tgz#a7487568adad577cfaaa7e88c49cab3ab3081aba"
+  integrity sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==
 
 psl@^1.1.33:
   version "1.15.0"


### PR DESCRIPTION
## Summary

Fixes #805

Bumps `axios` from `1.13.6` to `1.15.0` in `apps/ui` to resolve **2 critical vulnerabilities** that were blocking the `test/ui-quality` CI job.

### Critical CVEs resolved

| Advisory | Severity | Description |
|----------|----------|-------------|
| [GHSA-3p68-rc4w-qgx5](https://github.com/advisories/GHSA-3p68-rc4w-qgx5) | **Critical** | NO_PROXY Hostname Normalization Bypass → SSRF |
| [GHSA-fvcv-3m26-pcqx](https://github.com/advisories/GHSA-fvcv-3m26-pcqx) | **Critical** | Cloud Metadata Exfiltration via Header Injection |

### Changes

- `apps/ui/package.json`: `axios` `^1.13.5` → `^1.15.0`
- `apps/ui/yarn.lock`: regenerated (axios resolves to `1.15.0`)

### Verification

| Check | Result |
|-------|--------|
| `yarn audit` critical count | **0** (was 2) |
| `yarn lint` | Pass |
| `yarn type-check` | Pass |
| `yarn test` (34 suites, 157 tests) | Pass |
| Pre-push hooks (isort, black, pylint, mypy, 660 app tests) | Pass |

### Notes

77 high-severity advisories remain (minimatch, picomatch, flatted, lodash, next — all transitive). These do **not** block CI (the audit gate only fails on `critical > 0`). They can be addressed in a follow-up dependency sweep.