### PR TITLE
fix(ui): repair pagesRender smoke tests and re-enable in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Run UI type-check
         run: yarn type-check
       - name: Run UI unit tests
-        run: yarn test --ci --coverage --forceExit --testPathIgnorePatterns=tests/unit/pagesRender.test.tsx
+        run: yarn test --ci --coverage --forceExit
       - name: Install Playwright browser
         run: yarn playwright install --with-deps chromium
       - name: Run UI E2E smoke tests

--- a/apps/ui/tests/unit/pagesRender.test.tsx
+++ b/apps/ui/tests/unit/pagesRender.test.tsx
@@ -486,6 +486,29 @@ jest.mock('../../lib/hooks/useTruth', () => ({
   useReviewAction: () => ({ mutate: jest.fn(), isPending: false }),
 }));
 
+jest.mock('../../lib/hooks/useAgentMonitor', () => ({
+  useAgentMonitorDashboard: () => ({
+    data: null,
+    isLoading: false,
+    isError: false,
+    error: null,
+    isFetching: false,
+  }),
+  useAgentHealth: () => ({
+    data: null,
+    isLoading: false,
+    isError: false,
+  }),
+  useRecentTraces: () => ({
+    data: null,
+    isLoading: false,
+    isError: false,
+  }),
+  DEFAULT_AGENT_MONITOR_RANGE: '1h',
+  AGENT_MONITOR_RANGE_OPTIONS: [{ value: '1h', label: 'Last 1 hour' }],
+  isTracingUnavailableError: () => false,
+}));
+
 jest.mock('../../components/organisms/ProductGraphCanvas', () => ({
   ProductGraphCanvas: () => <div data-testid="product-graph" />,
 }));
@@ -596,7 +619,7 @@ describe('Page rendering smoke tests', () => {
 
   it('renders dashboard page', () => {
     render(<DashboardPage />);
-    expect(screen.getByText('My Dashboard')).toBeInTheDocument();
+    expect(screen.getByText('Dashboard')).toBeInTheDocument();
     expect(screen.getByText('Total Orders')).toBeInTheDocument();
     expect(screen.getAllByText('Unavailable').length).toBeGreaterThan(0);
     expect(screen.getByText('Rewards data is not available in the current API contract.')).toBeInTheDocument();


### PR DESCRIPTION
## Summary

Fixes #808

Repairs 2 failing tests in `pagesRender.test.tsx` and removes the `--testPathIgnorePatterns` exclusion so all 35 UI test suites run in CI.

### Changes

1. **`apps/ui/tests/unit/pagesRender.test.tsx`**:
   - Fix stale assertion: `'My Dashboard'` -> `'Dashboard'` (component heading changed)
   - Add `jest.mock` for `useAgentMonitor` hooks (`AdminPortalPage` uses `useAgentMonitorDashboard` which calls `useQuery` — was throwing `No QueryClient set`)

2. **`.github/workflows/test.yml`**:
   - Remove `--testPathIgnorePatterns=tests/unit/pagesRender.test.tsx` from the `Run UI unit tests` step

### Verification

| Check | Result |
|-------|--------|
| `pagesRender.test.tsx` | 21/21 pass |
| Full UI suite | 35 suites, 178 tests, 0 failures |
| Python tests | 1808 passed |
| Pre-push hooks | All pass (pylint 9.91/10) |