### PR TITLE
fix: add defense-in-depth timeout handling across agent invocation chain

### DIFF
--- a/apps/ui/app/agent-api/[...path]/route.ts
+++ b/apps/ui/app/agent-api/[...path]/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 
 import { resolveAgentApiBaseUrl, validateProxyBaseUrlPolicy } from '../../api/_shared/base-url-resolver';
 
+const AGENT_PROXY_TIMEOUT_MS = Number(process.env.AGENT_PROXY_TIMEOUT_MS ?? '120000');
+
 type TargetResolution = {
   targetUrl: string | null;
   baseUrl: string | null;
@@ -264,6 +266,9 @@ async function proxyRequest(
 
   let upstream: Response;
 
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), AGENT_PROXY_TIMEOUT_MS);
+
   try {
     upstream = await fetch(targetUrl, {
       method,
@@ -271,8 +276,35 @@ async function proxyRequest(
       body,
       redirect: 'manual',
       cache: 'no-store',
+      signal: controller.signal,
     });
   } catch (error) {
+    clearTimeout(timeoutId);
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      console.error('Agent API proxy upstream request timed out', {
+        attemptedPath: upstreamPath,
+        sourceKey,
+        timeoutMs: AGENT_PROXY_TIMEOUT_MS,
+      });
+      return NextResponse.json(
+        buildProxyErrorPayload({
+          failureKind: 'network',
+          sourceKey,
+          baseUrl,
+          attemptedPath: upstreamPath,
+          method,
+          upstreamError: `Request timed out after ${AGENT_PROXY_TIMEOUT_MS}ms`,
+        }),
+        {
+          status: 504,
+          headers: {
+            'x-holiday-peak-proxy': 'next-app-agent-api',
+            'x-holiday-peak-proxy-source': sourceKey ?? '',
+            'x-holiday-peak-proxy-failure-kind': 'timeout',
+          },
+        },
+      );
+    }
     if (error instanceof Error) {
       console.error('Agent API proxy upstream fetch failed', {
         attemptedPath: upstreamPath,
@@ -299,6 +331,8 @@ async function proxyRequest(
       },
     );
   }
+
+  clearTimeout(timeoutId);
 
   if (upstream.status === 502) {
     const upstreamError = await readUpstreamErrorPayload(upstream);

--- a/lib/src/holiday_peak_lib/agents/base_agent.py
+++ b/lib/src/holiday_peak_lib/agents/base_agent.py
@@ -1,6 +1,7 @@
 """Base agent abstraction with model selection and SDK integration points."""
 
 import asyncio
+import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from time import perf_counter
@@ -35,6 +36,9 @@ from .provider_policy import (
 ModelInvoker = Callable[..., Awaitable[dict[str, Any]]]
 
 UPGRADE_TOKEN = "upgrade"
+
+_DEFAULT_AGENT_INVOKE_TIMEOUT = float(os.getenv("AGENT_INVOKE_TIMEOUT_SECONDS", "90"))
+_DEFAULT_ROUTING_EVAL_TIMEOUT = float(os.getenv("AGENT_ROUTING_EVAL_TIMEOUT_SECONDS", "15"))
 
 
 @dataclass
@@ -384,6 +388,10 @@ class BaseRetailAgent(BaseAgent, ABC):
         error_text: str | None = None
         try:
             result = await target.invoker(**payload)
+        except asyncio.TimeoutError:
+            outcome = "timeout"
+            error_text = "Model invocation timed out"
+            raise
         except Exception as exc:
             outcome = "error"
             error_text = str(exc)
@@ -481,10 +489,31 @@ class BaseRetailAgent(BaseAgent, ABC):
             },
         )
 
-        if self.slm and self.llm:
-            return await self._evaluate_with_slm_routing(request, messages, payload_tools, **kwargs)
+        try:
+            if self.slm and self.llm:
+                return await asyncio.wait_for(
+                    self._evaluate_with_slm_routing(request, messages, payload_tools, **kwargs),
+                    timeout=_DEFAULT_AGENT_INVOKE_TIMEOUT,
+                )
 
-        return await self._direct_model_selection(request, messages, payload_tools, **kwargs)
+            return await asyncio.wait_for(
+                self._direct_model_selection(request, messages, payload_tools, **kwargs),
+                timeout=_DEFAULT_AGENT_INVOKE_TIMEOUT,
+            )
+        except asyncio.TimeoutError:
+            self._trace_decision(
+                decision="invoke_model",
+                outcome="timeout",
+                metadata={"timeout_seconds": _DEFAULT_AGENT_INVOKE_TIMEOUT},
+            )
+            return {
+                "error": "timeout",
+                "message": "The agent could not complete the request within the allowed time.",
+                "_telemetry": {
+                    "outcome": "timeout",
+                    "timeout_seconds": _DEFAULT_AGENT_INVOKE_TIMEOUT,
+                },
+            }
 
     async def _evaluate_with_slm_routing(
         self,
@@ -523,9 +552,18 @@ class BaseRetailAgent(BaseAgent, ABC):
             "different sources to be understood and processed, return a single word 'upgrade'.\n\n"
             f"Request: {request}"
         )
-        evaluation_result = await self.__invoke_target(
-            self.slm, evaluation_prompt, payload_tools, **kwargs
-        )
+        try:
+            evaluation_result = await asyncio.wait_for(
+                self.__invoke_target(self.slm, evaluation_prompt, payload_tools, **kwargs),
+                timeout=_DEFAULT_ROUTING_EVAL_TIMEOUT,
+            )
+        except asyncio.TimeoutError:
+            self._trace_decision(
+                decision="routing_evaluation",
+                outcome="timeout_fallback_slm",
+                metadata={"timeout_seconds": _DEFAULT_ROUTING_EVAL_TIMEOUT},
+            )
+            return await self.__invoke_target(self.slm, messages, payload_tools, **kwargs)
         evaluation_text = ""
         if isinstance(evaluation_result, dict):
             evaluation_text = str(

--- a/lib/src/holiday_peak_lib/agents/foundry.py
+++ b/lib/src/holiday_peak_lib/agents/foundry.py
@@ -7,6 +7,7 @@ Agent into a ``ModelTarget`` invoker for ``BaseRetailAgent``.
 
 from __future__ import annotations
 
+import asyncio
 import inspect
 import os
 from dataclasses import dataclass
@@ -21,6 +22,8 @@ from azure.identity.aio import DefaultAzureCredential
 from .base_agent import ModelTarget
 
 _FOUNDRY_PROJECT_HOST_SUFFIX = ".services.ai.azure.com"
+
+_DEFAULT_FOUNDRY_INVOKE_TIMEOUT = float(os.getenv("AGENT_FOUNDRY_INVOKE_TIMEOUT_SECONDS", "55"))
 
 
 # Lazy imports for MAF FoundryAgent (Phase 1)
@@ -605,10 +608,11 @@ class FoundryAgentInvoker:
     middleware, telemetry, and tool execution loop.
     """
 
-    def __init__(self, config: FoundryAgentConfig) -> None:
+    def __init__(self, config: FoundryAgentConfig, *, timeout: float | None = None) -> None:
         self.config = config
         self._agent: Any = None
         self._credential: Any = None
+        self._timeout = timeout if timeout is not None else _DEFAULT_FOUNDRY_INVOKE_TIMEOUT
 
     def _ensure_agent(self) -> Any:
         """Create or return the cached FoundryAgent instance."""
@@ -655,12 +659,51 @@ class FoundryAgentInvoker:
 
         agent = self._ensure_agent()
 
-        # Call through full MAF pipeline
-        response = await agent.run(
-            maf_messages,
-            stream=stream,
-            tools=tool_callables,
-        )
+        # Call through full MAF pipeline with explicit timeout
+        try:
+            response = await asyncio.wait_for(
+                agent.run(
+                    maf_messages,
+                    stream=stream,
+                    tools=tool_callables,
+                ),
+                timeout=self._timeout,
+            )
+        except asyncio.TimeoutError:
+            elapsed_ms = (perf_counter() - started) * 1000
+            reference_name = self.config.agent_name or self.config.agent_id
+            return {
+                "messages": [
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "output_text",
+                                "text": (
+                                    "The request could not be completed within"
+                                    " the allowed time. Please try a simpler"
+                                    " query or retry shortly."
+                                ),
+                            }
+                        ],
+                    }
+                ],
+                "stream": stream,
+                "error": "timeout",
+                "telemetry": {
+                    "endpoint": self.config.endpoint,
+                    "agent_name": reference_name,
+                    "deployment_name": self.config.deployment_name or reference_name,
+                    "stream": stream,
+                    "messages_sent": len(normalized),
+                    "duration_ms": elapsed_ms,
+                    "api_version": "responses",
+                    "runtime": "maf",
+                    "timeout_seconds": self._timeout,
+                    "outcome": "timeout",
+                },
+            }
 
         # Convert AgentResponse to expected dict format
         assistant_text = response.text if hasattr(response, "text") else str(response)

--- a/lib/src/holiday_peak_lib/app_factory_components/endpoints.py
+++ b/lib/src/holiday_peak_lib/app_factory_components/endpoints.py
@@ -1,5 +1,7 @@
 """Endpoint registration helpers for service apps."""
 
+import asyncio
+import os
 from collections.abc import Awaitable, Callable
 from typing import Any
 
@@ -9,6 +11,8 @@ from holiday_peak_lib.connectors.registry import ConnectorRegistry
 from holiday_peak_lib.self_healing import FailureSignal, SelfHealingKernel, SurfaceType
 from holiday_peak_lib.utils import get_tracer
 from holiday_peak_lib.utils.logging import log_async_operation
+
+_DEFAULT_ENDPOINT_TIMEOUT = float(os.getenv("AGENT_ENDPOINT_TIMEOUT_SECONDS", "120"))
 
 
 def register_standard_endpoints(
@@ -347,17 +351,42 @@ def register_standard_endpoints(
                         )
                     return await router.route(intent, request_payload)
 
-            response_payload = await log_async_operation(
-                logger,
-                name="service.invoke",
-                intent=intent,
-                func=_route_with_span,
-                token_count=None,
-                metadata={
-                    "payload_size": len(str(request_payload)),
-                    "service": service_name,
-                },
-            )
+            try:
+                response_payload = await asyncio.wait_for(
+                    log_async_operation(
+                        logger,
+                        name="service.invoke",
+                        intent=intent,
+                        func=_route_with_span,
+                        token_count=None,
+                        metadata={
+                            "payload_size": len(str(request_payload)),
+                            "service": service_name,
+                        },
+                    ),
+                    timeout=_DEFAULT_ENDPOINT_TIMEOUT,
+                )
+            except asyncio.TimeoutError:
+                _log_info(
+                    "invoke_endpoint_timeout",
+                    extra={
+                        "service": service_name,
+                        "intent": intent,
+                        "timeout_seconds": _DEFAULT_ENDPOINT_TIMEOUT,
+                    },
+                )
+                _emit_invoke_outcome_telemetry(
+                    intent=intent,
+                    request_payload=request_payload,
+                    error=TimeoutError(f"Invoke timed out after {_DEFAULT_ENDPOINT_TIMEOUT}s"),
+                )
+                raise HTTPException(
+                    status_code=504,
+                    detail=(
+                        f"Agent invocation timed out after {_DEFAULT_ENDPOINT_TIMEOUT:.0f}s. "
+                        "Please retry with a simpler query."
+                    ),
+                )
             _emit_invoke_outcome_telemetry(
                 intent=intent,
                 request_payload=request_payload,


### PR DESCRIPTION
## Summary

Add configurable timeouts at every layer of the agent invocation path to prevent unhandled 60s timeouts from the MAF SDK propagating as silent failures with 'No response payload was returned'.

## Root Cause

The entire invocation chain from UI proxy → \/invoke\ endpoint → \BaseRetailAgent.invoke_model()\ → \FoundryAgentInvoker.__call__()\ → \gent.run()\ had **zero timeout handling**. The 60-second timeout from the \gent_framework\ SDK's internal default on \FoundryAgent.run()\ caused \AsyncTimeoutError\ to propagate unhandled, resulting in evaluation failures (Process: 5/100, Output: 15/100, Intent: 20/100).

Additionally, the SLM routing pattern makes **two sequential model calls** (evaluation + execution), compounding timeout risk.

## Changes

| Layer | File | Fix | Default |
|-------|------|-----|---------|
| **Innermost** — Foundry SDK | \lib/.../agents/foundry.py\ | \syncio.wait_for()\ around \gent.run()\, returns structured timeout response | 55s |
| **Agent** — SLM routing eval | \lib/.../agents/base_agent.py\ | 15s budget for routing eval; on timeout, falls through to direct SLM | 15s |
| **Agent** — invoke_model | \lib/.../agents/base_agent.py\ | Outer \syncio.wait_for()\ wrapping entire routing + execution chain | 90s |
| **Endpoint** — /invoke | \lib/.../app_factory_components/endpoints.py\ | \syncio.wait_for()\ around \log_async_operation()\, returns HTTP 504 | 120s |
| **Outermost** — UI proxy | \pps/ui/app/agent-api/[...path]/route.ts\ | \AbortController\ with timeout on \etch()\, returns HTTP 504 | 120s |

## Configuration (all env vars)

| Variable | Default | Scope |
|----------|---------|-------|
| \AGENT_FOUNDRY_INVOKE_TIMEOUT_SECONDS\ | 55 | Per Foundry SDK call |
| \AGENT_ROUTING_EVAL_TIMEOUT_SECONDS\ | 15 | SLM routing evaluation budget |
| \AGENT_INVOKE_TIMEOUT_SECONDS\ | 90 | Entire \invoke_model()\ chain |
| \AGENT_ENDPOINT_TIMEOUT_SECONDS\ | 120 | \/invoke\ HTTP endpoint |
| \AGENT_PROXY_TIMEOUT_MS\ | 120000 | UI BFF proxy fetch |

## Testing

- 1808 Python tests pass (1136 lib + 12 e2e + 660 apps)
- 178 UI tests pass (35 suites)
- TypeScript compiles cleanly (\	sc --noEmit\ — zero errors)
- All pre-push lint gates pass (isort, black, markdown links, event schema contracts)

Fixes #810