### PR TITLE
fix(ci): reduce workflow_dispatch inputs to 10-input limit (#811)

### DIFF
--- a/.github/workflows/deploy-azd-dev.yml
+++ b/.github/workflows/deploy-azd-dev.yml
@@ -49,29 +49,15 @@ on:
         required: true
         type: boolean
         default: false
-      apiBaseUrl:
-        description: Optional API base URL for UI build override
-        required: false
-        default: ''
       forceApimSync:
         description: Force APIM sync and smoke checks even when no changed services are detected
         required: true
         type: boolean
         default: true
-      autoAllowAcrRunnerIp:
-        description: Temporarily allow GitHub runner egress IP in ACR firewall during deploy and remove it afterward
-        required: true
-        type: boolean
-        default: true
-      skipApiSmokeChecks:
-        description: Skip API smoke checks (use only for urgent UI-only rollouts)
-        required: true
-        type: boolean
-        default: false
 
 permissions:
   id-token: write
-  contents: read
+  contents: write
 
 jobs:
   deploy:
@@ -81,7 +67,7 @@ jobs:
        github.event.workflow_run.event == 'push')
     permissions:
       id-token: write
-      contents: read
+      contents: write
       issues: write
     uses: ./.github/workflows/deploy-azd.yml
     with:
@@ -93,13 +79,13 @@ jobs:
       sourceRef: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceRef || (github.event_name == 'workflow_run' && format('refs/heads/{0}', github.event.workflow_run.head_branch) || '') }}
       deployStatic: ${{ github.event_name != 'workflow_dispatch' || inputs.deployStatic }}
       uiOnly: ${{ github.event_name == 'workflow_dispatch' && inputs.uiOnly }}
-      apiBaseUrl: ${{ github.event_name == 'workflow_dispatch' && inputs.apiBaseUrl || '' }}
+      apiBaseUrl: ''
       deployChangedOnly: true
       skipProvision: ${{ github.event_name != 'workflow_dispatch' || inputs.skipProvision }}
       serviceFilter: ${{ github.event_name == 'workflow_dispatch' && inputs.serviceFilter || '' }}
       forceApimSync: ${{ github.event_name == 'workflow_dispatch' && inputs.forceApimSync }}
-      autoAllowAcrRunnerIp: ${{ github.event_name != 'workflow_dispatch' || inputs.autoAllowAcrRunnerIp }}
-      skipApiSmokeChecks: ${{ github.event_name == 'workflow_dispatch' && inputs.skipApiSmokeChecks }}
+      autoAllowAcrRunnerIp: true
+      skipApiSmokeChecks: false
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}


### PR DESCRIPTION
## Summary

Fixes the deploy-azd-dev workflow `startup_failure` that has blocked all dev environment deployments since April 11.

Closes #811

## Root Cause

`deploy-azd-dev.yml` had **13 `workflow_dispatch` inputs** but GitHub Actions enforces a [maximum of 10](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#providing-inputs). This was exceeded incrementally across PRs #767, #785, and #789.

## Changes

1. **Removed 3 rarely-used dispatch inputs**, hardcoding their defaults in the `with:` block:
   - `autoAllowAcrRunnerIp` -> hardcoded `true` (always needed for private ACR)
   - `skipApiSmokeChecks` -> hardcoded `false` (redundant with `uiOnly`)
   - `apiBaseUrl` -> hardcoded `''` (auto-detected by the workflow)
2. **Updated permissions** from `contents: read` to `contents: write` at both workflow and job level (required for the Flux `commit-rendered-manifests` job added in PR #785)

## Verification

- `actionlint` reports **0 errors** on the fixed workflow
- All pre-push lint gates pass (isort, black, pylint 9.91/10, mypy, link checks, event schema contracts)
- Default deployment behavior is unchanged (all removed inputs were hardcoded to their previous defaults)
