### PR TITLE
fix(deploy): break azure.yaml parser loop after target service found

### DIFF
--- a/.github/workflows/deploy-azd.yml
+++ b/.github/workflows/deploy-azd.yml
@@ -1122,6 +1122,8 @@ jobs:
 
               service_match = re.match(r"^  ([a-z0-9\-]+):\s*$", line)
               if service_match:
+                  if current_service == service_name:
+                      break
                   current_service = service_match.group(1)
                   project_path = None
                   docker_path = None


### PR DESCRIPTION
## Problem

The inline Python parser in the \uild-aks-images\ workflow step resets \project_path\ to \None\ every time it encounters a new service definition in \zure.yaml\. This means after parsing the target service's properties, the parser continues iterating and resets the collected values when it hits the next service block.

**Result**: All 28+ \uild-aks-images\ matrix jobs fail with:
\\\
Could not resolve azure.yaml project metadata for service '<name>'.
\\\

## Fix

Add an early \reak\ when the parser has already been processing the target service and encounters the start of a new service definition. This preserves \project_path\, \docker_path\, and \docker_context\ as they were found.

## Verified

Tested locally against all 27 AKS services — all resolve correctly after the fix.