### PR TITLE
chore(lib): bump version to 0.2.1 for timeout defense-in-depth release

### DIFF
--- a/lib/src/pyproject.toml
+++ b/lib/src/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holiday-peak-lib"
-version = "0.2.0"
+version = "0.2.1"
 description = "Core micro-framework for retail agent adapters, agents, and memory tiers"
 authors = [
     {name = "Ricardo Cataldi", email = "rcataldi@microsoft.com"}


### PR DESCRIPTION
Bumps \holiday-peak-lib\ version to 0.2.1 to trigger a full AKS deploy of the timeout defense-in-depth fixes from PR #810.

The \lib/\ change causes \detect-changes\ to set \LIB_CHANGED=true\, which cascades to all agent and CRUD services for deployment.