### PR TITLE
fix(deploy): force CRUD_CHANGED=true when crud-service is in serviceFilter

### DIFF
--- a/.github/workflows/deploy-azd.yml
+++ b/.github/workflows/deploy-azd.yml
@@ -291,6 +291,8 @@ jobs:
             done
             if [ "$CRUD_IN_FILTER" = false ]; then
               CRUD_CHANGED=false
+            else
+              CRUD_CHANGED=true
             fi
             UI_CHANGED=false
             echo "Service filter applied: ${CHANGED_AGENTS[*]:-none}"


### PR DESCRIPTION
## Problem

When \serviceFilter\ includes \crud-service\, the \detect-changes\ job correctly avoids resetting \CRUD_CHANGED\ to \alse\ — but it never sets it to \	rue\ either. If no actual file changes were detected (e.g., during a manual redeploy or when only workflow files changed), \CRUD_CHANGED\ remains \alse\ and the \deploy-crud\ job is skipped.

This means \serviceFilter\ effectively works for agent services but not for CRUD, defeating the purpose of a manual service-targeted deploy.

## Fix

In the \serviceFilter\ block, when \crud-service\ IS in the filter list, explicitly set \CRUD_CHANGED=true\ (the \lse\ branch of the existing \CRUD_IN_FILTER\ check).

## Impact

- Manual deploys with \serviceFilter\ containing \crud-service\ will now correctly trigger \deploy-crud\
- No change to auto-triggered deploys (which don't use \serviceFilter\)