### PR TITLE
fix(deploy): refresh azd env outputs when skipProvision=true

### DIFF
--- a/.github/workflows/deploy-azd.yml
+++ b/.github/workflows/deploy-azd.yml
@@ -787,6 +787,15 @@ jobs:
               --scope "$KEY_VAULT_ID"
           fi
 
+      - name: Refresh azd environment from deployed infrastructure
+        if: ${{ inputs.skipProvision }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "skipProvision=true: refreshing azd environment outputs from the last successful deployment."
+          azd env refresh -e '${{ inputs.environment }}' --no-prompt
+          echo "azd env refresh completed."
+
       - name: Export provisioned outputs
         id: outputs
         run: |


### PR DESCRIPTION
## Problem
When \skipProvision=true\, \zd provision\ is skipped so infrastructure outputs (POSTGRES_HOST, COSMOS_ACCOUNT_URI, etc.) are never written to the local azd environment on the CI runner. This causes \Validate PostgreSQL auth contract\ to fail with empty values.

**Error**: \Missing PostgreSQL deployment outputs required for auth validation.\
**Run**: 24337965550

## Fix
Add an \zd env refresh\ step that queries the last successful deployment outputs from Azure and repopulates the local environment **before** the export step. This only runs when \skipProvision=true\.

## Testing
- Only modifies workflow YAML (no app code changes)
- \zd env refresh\ is a read-only operation against the last ARM deployment