### PR TITLE
fix(infra): make ApiCenter conditional on region availability

### DIFF
--- a/.infra/modules/shared-infrastructure/shared-infrastructure.bicep
+++ b/.infra/modules/shared-infrastructure/shared-infrastructure.bicep
@@ -1346,7 +1346,21 @@ module apim 'br/public:avm/res/api-management/service:0.14.1' = {
 }
 
 // API Center — centralized API governance and discovery
-resource apiCenter 'Microsoft.ApiCenter/services@2024-03-01' = {
+// ApiCenter is only available in select regions; skip provisioning when the
+// deployment location is not in the supported list to avoid validation errors.
+var apicSupportedRegions = [
+  'eastus'
+  'westeurope'
+  'uksouth'
+  'centralindia'
+  'australiaeast'
+  'francecentral'
+  'swedencentral'
+  'canadacentral'
+]
+var apicEnabled = contains(apicSupportedRegions, toLower(location))
+
+resource apiCenter 'Microsoft.ApiCenter/services@2024-03-01' = if (apicEnabled) {
   name: apicName
   location: location
   identity: {
@@ -1686,7 +1700,7 @@ output keyVaultName string = keyVault.outputs.name
 output keyVaultUri string = keyVault.outputs.uri
 output apimName string = apim.outputs.name
 output apimGatewayUrl string = 'https://${apimName}.azure-api.net'
-output apicName string = apiCenter.name
+output apicName string = apicEnabled ? apiCenter.name : ''
 output aiServicesName string = aiFoundry.outputs.aiServicesName
 output aiProjectName string = aiFoundry.outputs.aiProjectName
 output aiSearchName string = aiSearchName


### PR DESCRIPTION
## Problem
azd provision fails with LocationNotAvailableForResourceType because Microsoft.ApiCenter/services is not available in centralus. This blocks ALL provision-dependent deploy paths.

## Fix
Make the ApiCenter Bicep resource conditional: deploy only when the target region is in the supported region list (eastus, westeurope, uksouth, centralindia, australiaeast, francecentral, swedencentral, canadacentral).

## Impact
- centralus (dev environment): ApiCenter skipped, provision succeeds
- Supported regions: ApiCenter deploys as before
- Output apicName returns empty string when ApiCenter is not deployed