### PR TITLE
fix(ci): refresh azd outputs after RoleAssignmentExists fallback

### DIFF
--- a/.github/workflows/deploy-azd.yml
+++ b/.github/workflows/deploy-azd.yml
@@ -715,7 +715,10 @@ jobs:
           if [ "${{ inputs.environment }}" != "prod" ] && [ "${{ inputs.environment }}" != "production" ] \
             && grep -q "RoleAssignmentExists" "$PROVISION_LOG" \
             && ! grep -q "BadRequest:" "$PROVISION_LOG"; then
-            echo "Non-prod provision hit an idempotent RoleAssignmentExists conflict; continuing." >&2
+            echo "Non-prod provision hit an idempotent RoleAssignmentExists conflict." >&2
+            echo "Infrastructure was deployed but azd did not save outputs. Running azd env refresh to populate them." >&2
+            azd env refresh -e '${{ inputs.environment }}' --no-prompt
+            echo "azd env refresh completed after RoleAssignmentExists fallback."
             exit 0
           fi
 

--- a/docs/governance/infrastructure-governance.md
+++ b/docs/governance/infrastructure-governance.md
@@ -100,6 +100,8 @@ Infrastructure provisioning, deployment orchestration, identity, security contro
 - Optional UI-only deployment path constrained by SWA token flow and health checks.
 - ACR runner-IP allowlist exceptions may be applied/removed automatically when enabled.
 - If the environment ACR public endpoint is disabled, the tested-image build guard must temporarily enable public access with `defaultAction=Deny`, reuse the runner-IP allowlist flow, and restore the prior `publicNetworkAccess` and `networkRuleSet.defaultAction` after the build phase completes.
+- When restoring ACR access state, `defaultAction` validation must be skipped if `publicNetworkAccess` is being set to `Disabled` — Azure may report any `defaultAction` value when public access is off and the value is semantically irrelevant.
+- When `azd provision` fails with `RoleAssignmentExists` in a non-prod environment, the infrastructure is typically deployed successfully but azd does not write outputs. The workflow must run `azd env refresh` after this fallback to populate outputs (POSTGRES_HOST, COSMOS_ACCOUNT_URI, etc.) from the deployed resources.
 
 ## Data Connectivity Guardrails
 

--- a/docs/roadmap/014-deploy-pipeline-hardening.md
+++ b/docs/roadmap/014-deploy-pipeline-hardening.md
@@ -1,0 +1,61 @@
+# 014 — Deploy Pipeline Hardening (April 2026)
+
+**Status**: Resolved  
+**PRs**: #813, #814, #827, #828, #829, #830, #831, #832, #833  
+**Category**: CI/CD, Infrastructure  
+**Created**: April 13, 2026
+
+## Summary
+
+A series of cascading blockers were discovered and fixed when deploying the
+full AKS backend (28 services) for the first time after the agent timeout
+defense-in-depth changes (PR #810). Nine PRs addressed issues spanning the
+build matrix parser, change detection, Bicep provisioning, and ACR network
+access restoration.
+
+## Issues Fixed
+
+| PR | Issue | Root Cause | Fix |
+|----|-------|-----------|-----|
+| #813 | Image builds targeted wrong service | Python parser in `build-aks-images` reset `project_path` after iterating past the target service | Early `break` after finding the matching service |
+| #814 | `LIB_CHANGED` not triggered | `holiday-peak-lib` version unchanged across deploys | Bumped to 0.2.1 to trigger full rebuild |
+| #827 | CRUD service skipped in deploy | `serviceFilter` didn't force `CRUD_CHANGED=true` when crud-service was in filter | Set `CRUD_CHANGED=true` when `crud-service` appears in filter |
+| #828 | Empty infra outputs with `skipProvision` | `azd env refresh` not called when skipping provision | Added `azd env refresh` step for `skipProvision=true` |
+| #829 | Bicep provision failure in centralus | `Microsoft.ApiCenter/services` unavailable in region | Made ApiCenter conditional on region support |
+| #830 | ACR export policy blocked public access | `exportPolicy: disabled` prevents `publicNetworkAccess` toggle on Premium ACR | Enable export policy before toggling network access |
+| #831 | ACR data-plane auth failure | `defaultAction: Deny` caused `CONNECTIVITY_REFRESH_TOKEN_ERROR` during builds | Use `defaultAction: Allow` during build window + readiness loop |
+| #832 | ACR restore validation false positive | Validating `defaultAction` after disabling `publicNetworkAccess` — Azure reports `Deny` | Skip `defaultAction` validation when public access is `Disabled` |
+| #833 | Empty POSTGRES_HOST after provision | `azd provision` exited non-zero due to `RoleAssignmentExists`, outputs not saved | Run `azd env refresh` after the RoleAssignmentExists fallback |
+
+## Key Lessons
+
+1. **azd provision failure modes**: When `azd provision` fails, it does not
+   write outputs to the environment — even if all infrastructure resources
+   were successfully deployed. The `RoleAssignmentExists` error is a trailing
+   conflict that doesn't affect actual resource creation.
+
+2. **ACR Premium network access**: Premium ACR with export policy disabled
+   and public access disabled requires a specific sequence to enable network
+   access for builds: enable export policy first, then toggle public access,
+   then set `defaultAction: Allow`, then wait for data-plane readiness.
+
+3. **Bicep role assignment idempotency**: Azure rejects role assignments for
+   the same principal+role+scope if a different assignment name (guid) is
+   used. AVM modules generate their own GUIDs — changing module versions or
+   inputs can cause `RoleAssignmentExists` conflicts. The workflow fallback
+   handles this for non-prod environments.
+
+4. **Change detection with filters**: When using `serviceFilter` to target
+   specific services, dependent services (like CRUD for agent services) must
+   be explicitly included in the change cascade.
+
+## Architecture Impact
+
+- The deploy workflow now has defense-in-depth for infrastructure output
+  propagation: outputs flow from Bicep → azd environment → workflow outputs
+  → downstream jobs, with `azd env refresh` as a fallback when provision
+  partially fails.
+
+- ACR network access management follows a save/restore pattern with
+  validation gates that account for Azure's eventual consistency in network
+  rule reporting.

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -10,6 +10,7 @@ This folder tracks corrections, gaps, and planned enhancements discovered during
 
 | Resolution | PR | Impact |
 |-----------|-----|--------|
+| Deploy pipeline hardening (9 fixes) | #813-#833 | Full AKS deploy unblocked: parser, change detection, ACR access, provision outputs |
 | Silent tool-dropping in FoundryInvoker | #802 | Agent tools now forwarded correctly via MAF FoundryAgent |
 | Memory tier I/O latency | #800 | Parallel hot/warm/cold operations via asyncio.gather |
 | Catalog-search duplicate queries | #796 | Eliminated redundant keyword search execution |
@@ -31,6 +32,7 @@ This folder tracks corrections, gaps, and planned enhancements discovered during
 | 8 | [AI Search not provisioned](008-ai-search-not-provisioned.md) | Medium | Infrastructure | [#32](https://github.com/Azure-Samples/holiday-peak-hub/issues/32) |
 | 9 | [Route protection middleware implemented (resolved)](009-missing-middleware-ts.md) | Medium | Frontend | [#33](https://github.com/Azure-Samples/holiday-peak-hub/issues/33) |
 | 13 | [AGC edge migration plan](013-agc-edge-migration.md) | High | Infrastructure | [#282](https://github.com/Azure-Samples/holiday-peak-hub/issues/282) - [#287](https://github.com/Azure-Samples/holiday-peak-hub/issues/287) |
+| 14 | [Deploy pipeline hardening (resolved)](014-deploy-pipeline-hardening.md) | Critical | CI/CD | #813-#833 |
 
 ### Feature Requests
 


### PR DESCRIPTION
## Problem

\deploy-crud\ fails at \Validate PostgreSQL auth contract\ with:
\\\
Missing PostgreSQL deployment outputs required for auth validation.
\\\

\POSTGRES_HOST\ is empty because \zd provision\ exited non-zero due to two \RoleAssignmentExists\ conflicts:
\\\
RoleAssignmentExists: The role assignment already exists. ID: 1970ad0e66bf586ca4e742858010d189
RoleAssignmentExists: The role assignment already exists. ID: 7adf53f75bda50d982b0c3bc361a339d
\\\

The non-prod fallback handler correctly caught this and exited 0, but since azd didn't save outputs (it treats the deployment as failed), all infrastructure outputs (POSTGRES_HOST, COSMOS_ACCOUNT_URI, REDIS_HOST, etc.) remained empty.

## Fix

After the \RoleAssignmentExists\ fallback succeeds, run \zd env refresh\ to populate outputs from the deployed infrastructure resources. This is the same technique used in the \skipProvision=true\ path.

## Context

- Run 24352997643: all 28 images built, restore-acr-build-access passed (PR #832 fix verified), but deploy-crud failed on empty POSTGRES_HOST.
- The infrastructure was actually deployed successfully — PostgreSQL, Cosmos, Redis, AKS, etc. all show as \Done\. Only the trailing role assignment was a conflict.