### PR TITLE
fix: set POSTGRES_AUTH_MODE=password for dev (Entra requires admin)

### DIFF
--- a/.github/workflows/deploy-azd.yml
+++ b/.github/workflows/deploy-azd.yml
@@ -416,9 +416,10 @@ jobs:
           azd env set K8S_CRUD_NAMESPACE holiday-peak-crud -e "${{ inputs.environment }}"
           azd env set K8S_AGENTS_NAMESPACE holiday-peak-agents -e "${{ inputs.environment }}"
           azd env set KEDA_ENABLED true -e "${{ inputs.environment }}"
-          if [ "${{ inputs.environment }}" = "dev" ]; then
-            azd env set POSTGRES_AUTH_MODE entra -e "${{ inputs.environment }}"
-          fi
+          # PostgreSQL auth: use password for dev until Entra AD admin is configured
+          # in Bicep (administrators param on AVM PostgreSQL module). Enabling
+          # activeDirectoryAuth without an admin has no effect — see ADR-033 follow-up.
+          azd env set POSTGRES_AUTH_MODE password -e "${{ inputs.environment }}"
 
       - name: Install kubelogin
         run: |


### PR DESCRIPTION
## Problem

Deploy run [24371722408](https://github.com/Azure-Samples/holiday-peak-hub/actions/runs/24371722408) failed at **deploy-crud → Validate PostgreSQL auth contract** (step 12):

\\\
Configured POSTGRES_AUTH_MODE=entra
Live PostgreSQL auth config: passwordAuth=Enabled, activeDirectoryAuth=Disabled
Configured Entra auth, but live PostgreSQL server does not have activeDirectoryAuth enabled.
\\\

## Root Cause

The workflow (line 420) explicitly set \POSTGRES_AUTH_MODE=entra\ for dev, but enabling \ctiveDirectoryAuth\ on Azure PostgreSQL Flexible Server **requires an Entra AD administrator** to be configured first ([docs](https://learn.microsoft.com/en-us/azure/postgresql/security/security-entra-configure)).

The AVM module (\r/public:avm/res/db-for-postgre-sql/flexible-server:0.15.2\) has no \dministrators\ parameter configured in our Bicep. Without an Entra admin, Azure silently ignores the \ctiveDirectoryAuth: 'Enabled'\ setting — the server stays on password auth.

## Fix

Set \POSTGRES_AUTH_MODE=password\ until the Bicep is updated with the \dministrators\ parameter and a managed identity Entra admin (P2 follow-up).

## Follow-up (P2)

To enable Entra auth in the future:
1. Add \dministrators\ param to AVM PostgreSQL module with the CRUD workload identity as Entra admin
2. Add SQL role provisioning step (\pgaadauth_create_principal_with_oid\) in schema migration workflow
3. Switch \POSTGRES_AUTH_MODE=entra\ once prerequisites are met

## Validation

- The provision recovery step (PR #835) confirmed POSTGRES_HOST is correctly recovered
- This fix aligns the configured auth mode with the live server state
- The \Validate PostgreSQL auth contract\ step will now pass