### PR TITLE
fix: replace unreliable agents_changed boolean with changed_agent_services_csv

### DIFF
--- a/.github/workflows/deploy-azd.yml
+++ b/.github/workflows/deploy-azd.yml
@@ -2233,7 +2233,9 @@ jobs:
 
   deploy-agents:
     runs-on: ubuntu-latest
-    if: ${{ !inputs.uiOnly && needs.detect-changes.outputs.agents_changed == 'true' && (needs.deploy-crud.result == 'success' || needs.deploy-crud.result == 'skipped') && (needs.deploy-foundry-models.result == 'success' || needs.deploy-foundry-models.result == 'skipped') }}
+    # Use changed_agent_services_csv (same reliability as build-aks-images uses changed_aks_services_csv)
+    # because agents_changed output can silently remain 'false' due to GitHub Actions output evaluation timing
+    if: ${{ !inputs.uiOnly && needs.detect-changes.outputs.changed_agent_services_csv != '' && (needs.deploy-crud.result == 'success' || needs.deploy-crud.result == 'skipped') && (needs.deploy-foundry-models.result == 'success' || needs.deploy-foundry-models.result == 'skipped') }}
     needs:
       - provision
       - deploy-crud
@@ -2486,7 +2488,7 @@ jobs:
           fi
 
       - name: Wait for agent rollouts
-        if: ${{ needs.detect-changes.outputs.agents_changed == 'true' }}
+        if: ${{ needs.detect-changes.outputs.changed_agent_services_csv != '' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -2524,7 +2526,7 @@ jobs:
 
   validate-agc-readiness:
     runs-on: ubuntu-latest
-    if: ${{ !inputs.uiOnly && (inputs.forceApimSync || needs.detect-changes.outputs.agents_changed == 'true' || needs.detect-changes.outputs.crud_changed == 'true' || needs.detect-changes.outputs.ui_changed == 'true') && (needs.deploy-crud.result == 'success' || needs.deploy-crud.result == 'skipped') && (needs.deploy-agents.result == 'success' || needs.deploy-agents.result == 'skipped') }}
+    if: ${{ !inputs.uiOnly && (inputs.forceApimSync || needs.detect-changes.outputs.changed_agent_services_csv != '' || needs.detect-changes.outputs.crud_changed == 'true' || needs.detect-changes.outputs.ui_changed == 'true') && (needs.deploy-crud.result == 'success' || needs.deploy-crud.result == 'skipped') && (needs.deploy-agents.result == 'success' || needs.deploy-agents.result == 'skipped') }}
     needs:
       - provision
       - deploy-crud
@@ -2650,7 +2652,7 @@ jobs:
 
   sync-apim:
     runs-on: ubuntu-latest
-    if: ${{ !inputs.uiOnly && (inputs.forceApimSync || needs.detect-changes.outputs.agents_changed == 'true' || needs.detect-changes.outputs.crud_changed == 'true' || needs.detect-changes.outputs.ui_changed == 'true') && (needs.deploy-crud.result == 'success' || needs.deploy-crud.result == 'skipped') && (needs.deploy-agents.result == 'success' || needs.deploy-agents.result == 'skipped') && needs.validate-agc-readiness.result == 'success' }}
+    if: ${{ !inputs.uiOnly && (inputs.forceApimSync || needs.detect-changes.outputs.changed_agent_services_csv != '' || needs.detect-changes.outputs.crud_changed == 'true' || needs.detect-changes.outputs.ui_changed == 'true') && (needs.deploy-crud.result == 'success' || needs.deploy-crud.result == 'skipped') && (needs.deploy-agents.result == 'success' || needs.deploy-agents.result == 'skipped') && needs.validate-agc-readiness.result == 'success' }}
     needs:
       - deploy-crud
       - deploy-agents
@@ -2710,7 +2712,7 @@ jobs:
 
   sync-apic:
     runs-on: ubuntu-latest
-    if: ${{ !inputs.uiOnly && (inputs.forceApimSync || needs.detect-changes.outputs.agents_changed == 'true' || needs.detect-changes.outputs.crud_changed == 'true') && (needs.sync-apim.result == 'success' || needs.sync-apim.result == 'skipped') }}
+    if: ${{ !inputs.uiOnly && (inputs.forceApimSync || needs.detect-changes.outputs.changed_agent_services_csv != '' || needs.detect-changes.outputs.crud_changed == 'true') && (needs.sync-apim.result == 'success' || needs.sync-apim.result == 'skipped') }}
     needs:
       - detect-changes
       - sync-apim
@@ -2739,7 +2741,7 @@ jobs:
 
   smoke-apim:
     runs-on: ubuntu-latest
-    if: ${{ !inputs.uiOnly && (inputs.forceApimSync || needs.detect-changes.outputs.agents_changed == 'true' || needs.detect-changes.outputs.crud_changed == 'true' || needs.detect-changes.outputs.ui_changed == 'true') && needs.validate-agc-readiness.result == 'success' && (needs.sync-apim.result == 'success' || needs.sync-apim.result == 'skipped') && (needs.ensure-foundry-agents.result == 'success' || needs.ensure-foundry-agents.result == 'skipped') }}
+    if: ${{ !inputs.uiOnly && (inputs.forceApimSync || needs.detect-changes.outputs.changed_agent_services_csv != '' || needs.detect-changes.outputs.crud_changed == 'true' || needs.detect-changes.outputs.ui_changed == 'true') && needs.validate-agc-readiness.result == 'success' && (needs.sync-apim.result == 'success' || needs.sync-apim.result == 'skipped') && (needs.ensure-foundry-agents.result == 'success' || needs.ensure-foundry-agents.result == 'skipped') }}
     needs:
       - detect-changes
       - sync-apim
@@ -2975,7 +2977,7 @@ jobs:
 
   ensure-foundry-agents:
     runs-on: ubuntu-latest
-    if: ${{ !inputs.uiOnly && needs.detect-changes.outputs.agents_changed == 'true' && (needs.deploy-agents.result == 'success' || needs.deploy-agents.result == 'skipped') }}
+    if: ${{ !inputs.uiOnly && needs.detect-changes.outputs.changed_agent_services_csv != '' && (needs.deploy-agents.result == 'success' || needs.deploy-agents.result == 'skipped') }}
     needs:
       - deploy-agents
       - detect-changes


### PR DESCRIPTION
## Problem

\deploy-agents\ and all downstream jobs (commit-rendered-manifests, sync-apim, smoke-apim, ensure-foundry-agents, etc.) were **skipped** even when all 27 service builds succeeded.

**Root cause**: The \gents_changed\ boolean output from \detect-changes\ was not reliably propagating as \'true'\ to downstream job conditions — despite the detect-changes step logging that it was set.

## Fix

Replaced \gents_changed == 'true'\ with \changed_agent_services_csv != ''\ across **7 job/step conditions**. This mirrors the pattern already working for \uild-aks-images\ (which uses \changed_aks_services_csv != ''\).

### Changed conditions:
| Job/Step | Before | After |
|---|---|---|
| \deploy-agents\ | \gents_changed == 'true'\ | \changed_agent_services_csv != ''\ |
| \commit-rendered-manifests\ → Wait for agent rollouts | Same | Same |
| \alidate-agc-readiness\ | Same (in OR) | Same |
| \sync-apim\ | Same (in OR) | Same |
| \sync-apic\ | Same (in OR) | Same |
| \smoke-apim\ | Same (in OR) | Same |
| \nsure-foundry-agents\ | Same | Same |

## Evidence

Run 24374545691: All 27 builds succeeded, deploy-crud succeeded, but deploy-agents was SKIPPED. Detect-changes logs confirmed service filter applied and outputs were set, but the boolean didn't propagate.