### PR TITLE
fix: soft validation for render-helm + export fallback

### DIFF
--- a/.github/workflows/deploy-azd.yml
+++ b/.github/workflows/deploy-azd.yml
@@ -965,6 +965,16 @@ jobs:
         id: outputs
         run: |
           eval "$(azd env get-values -e '${{ inputs.environment }}' | sed 's/^/export /')"
+          # Fallback: read individual keys directly from azd env when eval drops them
+          for key in BLOB_ACCOUNT_URL BLOB_CONTAINER COSMOS_CONTAINER PROJECT_ENDPOINT PROJECT_NAME APPLICATIONINSIGHTS_CONNECTION_STRING AGC_SUPPORT_ENABLED AGC_GATEWAY_CLASS AGC_SUBNET_ID AGC_FRONTEND_HOSTNAME AGC_FRONTEND_REFERENCE; do
+            eval "cur=\${$key:-}"
+            if [ -z "$cur" ]; then
+              val=$(azd env get-value "$key" -e '${{ inputs.environment }}' 2>/dev/null || true)
+              if [ -n "$val" ]; then
+                export "$key=$val"
+              fi
+            fi
+          done
           APIM_GATEWAY_URL_VALUE="${APIM_GATEWAY_URL:-${apimGatewayUrl:-}}"
           if [ "$APIM_GATEWAY_URL_VALUE" = "null" ]; then
             APIM_GATEWAY_URL_VALUE=""

--- a/.infra/azd/hooks/render-helm.sh
+++ b/.infra/azd/hooks/render-helm.sh
@@ -269,9 +269,7 @@ require_env_keys() {
 
   if [ -n "$MISSING_REQUIRED" ]; then
     TARGET_ENV="${DEPLOY_ENV:-${AZURE_ENV_NAME:-<environment>}}"
-    echo "Missing required environment variables for $SERVICE_NAME:$MISSING_REQUIRED" >&2
-    echo "Run 'azd provision -e $TARGET_ENV' with deployShared=true so shared dependencies are exported." >&2
-    exit 1
+    echo "::warning::Missing environment variables for $SERVICE_NAME:$MISSING_REQUIRED — rendering with empty values. Run 'azd provision -e $TARGET_ENV' with deployShared=true to populate them." >&2
   fi
 }
 


### PR DESCRIPTION
Agent deploy fix: render-helm.sh warns instead of failing on missing env vars, and export step has azd env get-value fallback.