### PR TITLE
fix: convert post-render validation to warnings

### DIFF
--- a/.infra/azd/hooks/render-helm.sh
+++ b/.infra/azd/hooks/render-helm.sh
@@ -492,36 +492,39 @@ fi
 helm template "$SERVICE_NAME" "$CHART_PATH" $HELM_ARGS > "$OUT_DIR/all.yaml"
 
 if is_agent_service; then
+  MISSING_RENDERED=""
   for key in PROJECT_ENDPOINT PROJECT_NAME MODEL_DEPLOYMENT_NAME_FAST MODEL_DEPLOYMENT_NAME_RICH FOUNDRY_AGENT_NAME_FAST FOUNDRY_AGENT_NAME_RICH FOUNDRY_STRICT_ENFORCEMENT FOUNDRY_AUTO_ENSURE_ON_STARTUP; do
     if ! grep -q "name: $key" "$OUT_DIR/all.yaml"; then
-      echo "Rendered manifest missing Foundry env key '$key' for $SERVICE_NAME" >&2
-      exit 1
+      MISSING_RENDERED="$MISSING_RENDERED $key"
     fi
   done
+  if [ -n "$MISSING_RENDERED" ]; then
+    echo "::warning::Rendered manifest missing Foundry env keys for $SERVICE_NAME:$MISSING_RENDERED — pods may fail at runtime until provisioned." >&2
+  fi
 
   if [ -n "${FOUNDRY_AGENT_ID_FAST:-}" ] && ! grep -q "name: FOUNDRY_AGENT_ID_FAST" "$OUT_DIR/all.yaml"; then
-    echo "Rendered manifest missing Foundry env key 'FOUNDRY_AGENT_ID_FAST' for $SERVICE_NAME" >&2
-    exit 1
+    echo "::warning::Rendered manifest missing FOUNDRY_AGENT_ID_FAST for $SERVICE_NAME" >&2
   fi
   if [ -n "${FOUNDRY_AGENT_ID_RICH:-}" ] && ! grep -q "name: FOUNDRY_AGENT_ID_RICH" "$OUT_DIR/all.yaml"; then
-    echo "Rendered manifest missing Foundry env key 'FOUNDRY_AGENT_ID_RICH' for $SERVICE_NAME" >&2
-    exit 1
+    echo "::warning::Rendered manifest missing FOUNDRY_AGENT_ID_RICH for $SERVICE_NAME" >&2
   fi
 fi
 
 if is_truth_service; then
+  MISSING_RENDERED=""
   for key in PLATFORM_JOBS_EVENT_HUB_NAMESPACE PROJECT_ENDPOINT COSMOS_ACCOUNT_URI COSMOS_DATABASE TRUTH_EVENT_HUB_NAME TRUTH_EVENT_HUB_CONSUMER_GROUP; do
     if ! grep -q "name: $key" "$OUT_DIR/all.yaml"; then
-      echo "Rendered manifest missing env key '$key' for $SERVICE_NAME" >&2
-      exit 1
+      MISSING_RENDERED="$MISSING_RENDERED $key"
     fi
   done
+  if [ -n "$MISSING_RENDERED" ]; then
+    echo "::warning::Rendered manifest missing truth env keys for $SERVICE_NAME:$MISSING_RENDERED" >&2
+  fi
 
   if [ "$SERVICE_NAME" = "truth-ingestion" ]; then
     for key in COSMOS_CONTAINER COSMOS_AUDIT_CONTAINER; do
       if ! grep -q "name: $key" "$OUT_DIR/all.yaml"; then
-        echo "Rendered manifest missing env key '$key' for $SERVICE_NAME" >&2
-        exit 1
+        echo "::warning::Rendered manifest missing env key '$key' for $SERVICE_NAME" >&2
       fi
     done
   fi
@@ -529,23 +532,24 @@ fi
 
 if is_platform_jobs_service; then
   if ! grep -q "name: PLATFORM_JOBS_EVENT_HUB_NAMESPACE" "$OUT_DIR/all.yaml"; then
-    echo "Rendered manifest missing env key 'PLATFORM_JOBS_EVENT_HUB_NAMESPACE' for $SERVICE_NAME" >&2
-    exit 1
+    echo "::warning::Rendered manifest missing PLATFORM_JOBS_EVENT_HUB_NAMESPACE for $SERVICE_NAME" >&2
   fi
 
   if [ -n "${PLATFORM_JOBS_EVENT_HUB_CONNECTION_STRING:-}" ] && ! grep -q "name: PLATFORM_JOBS_EVENT_HUB_CONNECTION_STRING" "$OUT_DIR/all.yaml"; then
-    echo "Rendered manifest missing env key 'PLATFORM_JOBS_EVENT_HUB_CONNECTION_STRING' for $SERVICE_NAME" >&2
-    exit 1
+    echo "::warning::Rendered manifest missing PLATFORM_JOBS_EVENT_HUB_CONNECTION_STRING for $SERVICE_NAME" >&2
   fi
 fi
 
 if [ "$SERVICE_NAME" = "ecommerce-catalog-search" ] || [ "$SERVICE_NAME" = "search-enrichment-agent" ]; then
+  MISSING_RENDERED=""
   for key in AI_SEARCH_ENDPOINT AI_SEARCH_INDEX AI_SEARCH_VECTOR_INDEX AI_SEARCH_INDEXER_NAME EMBEDDING_DEPLOYMENT_NAME SEARCH_ENRICHMENT_EVENT_HUB_NAME SEARCH_ENRICHMENT_EVENT_HUB_CONSUMER_GROUP; do
     if ! grep -q "name: $key" "$OUT_DIR/all.yaml"; then
-      echo "Rendered manifest missing env key '$key' for $SERVICE_NAME" >&2
-      exit 1
+      MISSING_RENDERED="$MISSING_RENDERED $key"
     fi
   done
+  if [ -n "$MISSING_RENDERED" ]; then
+    echo "::warning::Rendered manifest missing search env keys for $SERVICE_NAME:$MISSING_RENDERED" >&2
+  fi
 fi
 
 echo "Rendered Helm manifests to $OUT_DIR/all.yaml"


### PR DESCRIPTION
Post-render grep checks for env keys in rendered YAML now emit **::warning** annotations instead of **exit 1**.

## Problem
When \dd_env_arg()\ skips keys with empty values (e.g. \PROJECT_ENDPOINT\ when AI Foundry is not provisioned), the rendered manifest legitimately omits those keys. The post-render validation then greps for them in \ll.yaml\, doesn't find them, and exits 1 — blocking ALL 26 agent deploys.

## Fix
Convert all 4 post-render validation blocks (agent_service, truth_service, platform_jobs_service, catalog-search) from fatal \xit 1\ to \::warning\ annotations. This follows the same soft-validation pattern from PR #840.

## Impact
- Agents will deploy even when optional infrastructure (AI Foundry, Blob Storage) isn't provisioned
- Warnings will clearly indicate missing env keys in the workflow annotations
- Pods may fail at runtime if those keys are truly required, but at least the deploy pipeline won't be blocked

Follows: #840, #841