### PR TITLE
Add app-scoped deployment workflows

### DIFF
--- a/.github/workflows/deploy-azd-crm-campaign-intelligence.yml
+++ b/.github/workflows/deploy-azd-crm-campaign-intelligence.yml
@@ -1,0 +1,87 @@
+name: deploy-azd-crm-campaign-intelligence (entrypoint)
+
+on:
+  push:
+    branches:
+      - '**'
+    paths:
+      - apps/crm-campaign-intelligence/**
+      - lib/**
+      - azure.yaml
+      - .infra/**
+      - .kubernetes/**
+      - .github/workflows/deploy-azd.yml
+      - .github/workflows/deploy-azd-service.yml
+      - .github/workflows/deploy-azd-crm-campaign-intelligence.yml
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Target deployment environment
+        required: true
+        default: dev
+      location:
+        description: Azure location
+        required: true
+        default: centralus
+      projectName:
+        description: Project prefix used by naming convention
+        required: true
+        default: holidaypeakhub405
+      imageTag:
+        description: Image tag to deploy
+        required: true
+        default: latest
+      testedSourceSha:
+        description: Optional tested source commit SHA to deploy
+        required: false
+        default: ''
+      testedSourceRef:
+        description: Optional tested source ref to deploy when testedSourceSha is empty
+        required: false
+        default: ''
+      skipProvision:
+        description: Skip azd provision and reuse the current environment infrastructure
+        required: true
+        type: boolean
+        default: true
+      forceApimSync:
+        description: Force APIM sync and smoke checks even when no changed services are detected
+        required: true
+        type: boolean
+        default: true
+      autoAllowAcrRunnerIp:
+        description: Temporarily allow GitHub runner egress IP in ACR firewall during deploy
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: deploy-azd-${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}-crm-campaign-intelligence
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    permissions:
+      id-token: write
+      contents: read
+      issues: write
+    uses: ./.github/workflows/deploy-azd-service.yml
+    with:
+      serviceName: crm-campaign-intelligence
+      environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}
+      location: ${{ github.event_name == 'workflow_dispatch' && inputs.location || 'centralus' }}
+      projectName: ${{ github.event_name == 'workflow_dispatch' && inputs.projectName || 'holidaypeakhub405' }}
+      imageTag: ${{ github.event_name == 'workflow_dispatch' && inputs.imageTag || github.sha }}
+      testedSourceSha: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceSha || github.sha }}
+      testedSourceRef: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceRef || github.ref }}
+      skipProvision: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.skipProvision) || 'true') }}
+      forceApimSync: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.forceApimSync) || 'true') }}
+      autoAllowAcrRunnerIp: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.autoAllowAcrRunnerIp) || 'true') }}
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/deploy-azd-crm-profile-aggregation.yml
+++ b/.github/workflows/deploy-azd-crm-profile-aggregation.yml
@@ -1,0 +1,87 @@
+name: deploy-azd-crm-profile-aggregation (entrypoint)
+
+on:
+  push:
+    branches:
+      - '**'
+    paths:
+      - apps/crm-profile-aggregation/**
+      - lib/**
+      - azure.yaml
+      - .infra/**
+      - .kubernetes/**
+      - .github/workflows/deploy-azd.yml
+      - .github/workflows/deploy-azd-service.yml
+      - .github/workflows/deploy-azd-crm-profile-aggregation.yml
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Target deployment environment
+        required: true
+        default: dev
+      location:
+        description: Azure location
+        required: true
+        default: centralus
+      projectName:
+        description: Project prefix used by naming convention
+        required: true
+        default: holidaypeakhub405
+      imageTag:
+        description: Image tag to deploy
+        required: true
+        default: latest
+      testedSourceSha:
+        description: Optional tested source commit SHA to deploy
+        required: false
+        default: ''
+      testedSourceRef:
+        description: Optional tested source ref to deploy when testedSourceSha is empty
+        required: false
+        default: ''
+      skipProvision:
+        description: Skip azd provision and reuse the current environment infrastructure
+        required: true
+        type: boolean
+        default: true
+      forceApimSync:
+        description: Force APIM sync and smoke checks even when no changed services are detected
+        required: true
+        type: boolean
+        default: true
+      autoAllowAcrRunnerIp:
+        description: Temporarily allow GitHub runner egress IP in ACR firewall during deploy
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: deploy-azd-${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}-crm-profile-aggregation
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    permissions:
+      id-token: write
+      contents: read
+      issues: write
+    uses: ./.github/workflows/deploy-azd-service.yml
+    with:
+      serviceName: crm-profile-aggregation
+      environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}
+      location: ${{ github.event_name == 'workflow_dispatch' && inputs.location || 'centralus' }}
+      projectName: ${{ github.event_name == 'workflow_dispatch' && inputs.projectName || 'holidaypeakhub405' }}
+      imageTag: ${{ github.event_name == 'workflow_dispatch' && inputs.imageTag || github.sha }}
+      testedSourceSha: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceSha || github.sha }}
+      testedSourceRef: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceRef || github.ref }}
+      skipProvision: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.skipProvision) || 'true') }}
+      forceApimSync: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.forceApimSync) || 'true') }}
+      autoAllowAcrRunnerIp: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.autoAllowAcrRunnerIp) || 'true') }}
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/deploy-azd-crm-segmentation-personalization.yml
+++ b/.github/workflows/deploy-azd-crm-segmentation-personalization.yml
@@ -1,0 +1,87 @@
+name: deploy-azd-crm-segmentation-personalization (entrypoint)
+
+on:
+  push:
+    branches:
+      - '**'
+    paths:
+      - apps/crm-segmentation-personalization/**
+      - lib/**
+      - azure.yaml
+      - .infra/**
+      - .kubernetes/**
+      - .github/workflows/deploy-azd.yml
+      - .github/workflows/deploy-azd-service.yml
+      - .github/workflows/deploy-azd-crm-segmentation-personalization.yml
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Target deployment environment
+        required: true
+        default: dev
+      location:
+        description: Azure location
+        required: true
+        default: centralus
+      projectName:
+        description: Project prefix used by naming convention
+        required: true
+        default: holidaypeakhub405
+      imageTag:
+        description: Image tag to deploy
+        required: true
+        default: latest
+      testedSourceSha:
+        description: Optional tested source commit SHA to deploy
+        required: false
+        default: ''
+      testedSourceRef:
+        description: Optional tested source ref to deploy when testedSourceSha is empty
+        required: false
+        default: ''
+      skipProvision:
+        description: Skip azd provision and reuse the current environment infrastructure
+        required: true
+        type: boolean
+        default: true
+      forceApimSync:
+        description: Force APIM sync and smoke checks even when no changed services are detected
+        required: true
+        type: boolean
+        default: true
+      autoAllowAcrRunnerIp:
+        description: Temporarily allow GitHub runner egress IP in ACR firewall during deploy
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: deploy-azd-${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}-crm-segmentation-personalization
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    permissions:
+      id-token: write
+      contents: read
+      issues: write
+    uses: ./.github/workflows/deploy-azd-service.yml
+    with:
+      serviceName: crm-segmentation-personalization
+      environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}
+      location: ${{ github.event_name == 'workflow_dispatch' && inputs.location || 'centralus' }}
+      projectName: ${{ github.event_name == 'workflow_dispatch' && inputs.projectName || 'holidaypeakhub405' }}
+      imageTag: ${{ github.event_name == 'workflow_dispatch' && inputs.imageTag || github.sha }}
+      testedSourceSha: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceSha || github.sha }}
+      testedSourceRef: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceRef || github.ref }}
+      skipProvision: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.skipProvision) || 'true') }}
+      forceApimSync: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.forceApimSync) || 'true') }}
+      autoAllowAcrRunnerIp: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.autoAllowAcrRunnerIp) || 'true') }}
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/deploy-azd-crm-support-assistance.yml
+++ b/.github/workflows/deploy-azd-crm-support-assistance.yml
@@ -1,0 +1,87 @@
+name: deploy-azd-crm-support-assistance (entrypoint)
+
+on:
+  push:
+    branches:
+      - '**'
+    paths:
+      - apps/crm-support-assistance/**
+      - lib/**
+      - azure.yaml
+      - .infra/**
+      - .kubernetes/**
+      - .github/workflows/deploy-azd.yml
+      - .github/workflows/deploy-azd-service.yml
+      - .github/workflows/deploy-azd-crm-support-assistance.yml
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Target deployment environment
+        required: true
+        default: dev
+      location:
+        description: Azure location
+        required: true
+        default: centralus
+      projectName:
+        description: Project prefix used by naming convention
+        required: true
+        default: holidaypeakhub405
+      imageTag:
+        description: Image tag to deploy
+        required: true
+        default: latest
+      testedSourceSha:
+        description: Optional tested source commit SHA to deploy
+        required: false
+        default: ''
+      testedSourceRef:
+        description: Optional tested source ref to deploy when testedSourceSha is empty
+        required: false
+        default: ''
+      skipProvision:
+        description: Skip azd provision and reuse the current environment infrastructure
+        required: true
+        type: boolean
+        default: true
+      forceApimSync:
+        description: Force APIM sync and smoke checks even when no changed services are detected
+        required: true
+        type: boolean
+        default: true
+      autoAllowAcrRunnerIp:
+        description: Temporarily allow GitHub runner egress IP in ACR firewall during deploy
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: deploy-azd-${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}-crm-support-assistance
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    permissions:
+      id-token: write
+      contents: read
+      issues: write
+    uses: ./.github/workflows/deploy-azd-service.yml
+    with:
+      serviceName: crm-support-assistance
+      environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}
+      location: ${{ github.event_name == 'workflow_dispatch' && inputs.location || 'centralus' }}
+      projectName: ${{ github.event_name == 'workflow_dispatch' && inputs.projectName || 'holidaypeakhub405' }}
+      imageTag: ${{ github.event_name == 'workflow_dispatch' && inputs.imageTag || github.sha }}
+      testedSourceSha: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceSha || github.sha }}
+      testedSourceRef: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceRef || github.ref }}
+      skipProvision: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.skipProvision) || 'true') }}
+      forceApimSync: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.forceApimSync) || 'true') }}
+      autoAllowAcrRunnerIp: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.autoAllowAcrRunnerIp) || 'true') }}
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/deploy-azd-crud-service.yml
+++ b/.github/workflows/deploy-azd-crud-service.yml
@@ -1,0 +1,87 @@
+name: deploy-azd-crud-service (entrypoint)
+
+on:
+  push:
+    branches:
+      - '**'
+    paths:
+      - apps/crud-service/**
+      - lib/**
+      - azure.yaml
+      - .infra/**
+      - .kubernetes/**
+      - .github/workflows/deploy-azd.yml
+      - .github/workflows/deploy-azd-service.yml
+      - .github/workflows/deploy-azd-crud-service.yml
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Target deployment environment
+        required: true
+        default: dev
+      location:
+        description: Azure location
+        required: true
+        default: centralus
+      projectName:
+        description: Project prefix used by naming convention
+        required: true
+        default: holidaypeakhub405
+      imageTag:
+        description: Image tag to deploy
+        required: true
+        default: latest
+      testedSourceSha:
+        description: Optional tested source commit SHA to deploy
+        required: false
+        default: ''
+      testedSourceRef:
+        description: Optional tested source ref to deploy when testedSourceSha is empty
+        required: false
+        default: ''
+      skipProvision:
+        description: Skip azd provision and reuse the current environment infrastructure
+        required: true
+        type: boolean
+        default: true
+      forceApimSync:
+        description: Force APIM sync and smoke checks even when no changed services are detected
+        required: true
+        type: boolean
+        default: true
+      autoAllowAcrRunnerIp:
+        description: Temporarily allow GitHub runner egress IP in ACR firewall during deploy
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: deploy-azd-${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}-crud-service
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    permissions:
+      id-token: write
+      contents: read
+      issues: write
+    uses: ./.github/workflows/deploy-azd-service.yml
+    with:
+      serviceName: crud-service
+      environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}
+      location: ${{ github.event_name == 'workflow_dispatch' && inputs.location || 'centralus' }}
+      projectName: ${{ github.event_name == 'workflow_dispatch' && inputs.projectName || 'holidaypeakhub405' }}
+      imageTag: ${{ github.event_name == 'workflow_dispatch' && inputs.imageTag || github.sha }}
+      testedSourceSha: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceSha || github.sha }}
+      testedSourceRef: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceRef || github.ref }}
+      skipProvision: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.skipProvision) || 'true') }}
+      forceApimSync: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.forceApimSync) || 'true') }}
+      autoAllowAcrRunnerIp: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.autoAllowAcrRunnerIp) || 'true') }}
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/deploy-azd-dev.yml
+++ b/.github/workflows/deploy-azd-dev.yml
@@ -72,6 +72,7 @@ jobs:
     uses: ./.github/workflows/deploy-azd.yml
     with:
       environment: dev
+      githubEnvironment: dev
       location: ${{ github.event_name == 'workflow_dispatch' && inputs.location || 'centralus' }}
       projectName: ${{ github.event_name == 'workflow_dispatch' && inputs.projectName || 'holidaypeakhub405' }}
       imageTag: ${{ github.event_name == 'workflow_dispatch' && inputs.imageTag || github.event.workflow_run.head_sha }}

--- a/.github/workflows/deploy-azd-ecommerce-cart-intelligence.yml
+++ b/.github/workflows/deploy-azd-ecommerce-cart-intelligence.yml
@@ -1,0 +1,87 @@
+name: deploy-azd-ecommerce-cart-intelligence (entrypoint)
+
+on:
+  push:
+    branches:
+      - '**'
+    paths:
+      - apps/ecommerce-cart-intelligence/**
+      - lib/**
+      - azure.yaml
+      - .infra/**
+      - .kubernetes/**
+      - .github/workflows/deploy-azd.yml
+      - .github/workflows/deploy-azd-service.yml
+      - .github/workflows/deploy-azd-ecommerce-cart-intelligence.yml
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Target deployment environment
+        required: true
+        default: dev
+      location:
+        description: Azure location
+        required: true
+        default: centralus
+      projectName:
+        description: Project prefix used by naming convention
+        required: true
+        default: holidaypeakhub405
+      imageTag:
+        description: Image tag to deploy
+        required: true
+        default: latest
+      testedSourceSha:
+        description: Optional tested source commit SHA to deploy
+        required: false
+        default: ''
+      testedSourceRef:
+        description: Optional tested source ref to deploy when testedSourceSha is empty
+        required: false
+        default: ''
+      skipProvision:
+        description: Skip azd provision and reuse the current environment infrastructure
+        required: true
+        type: boolean
+        default: true
+      forceApimSync:
+        description: Force APIM sync and smoke checks even when no changed services are detected
+        required: true
+        type: boolean
+        default: true
+      autoAllowAcrRunnerIp:
+        description: Temporarily allow GitHub runner egress IP in ACR firewall during deploy
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: deploy-azd-${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}-ecommerce-cart-intelligence
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    permissions:
+      id-token: write
+      contents: read
+      issues: write
+    uses: ./.github/workflows/deploy-azd-service.yml
+    with:
+      serviceName: ecommerce-cart-intelligence
+      environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}
+      location: ${{ github.event_name == 'workflow_dispatch' && inputs.location || 'centralus' }}
+      projectName: ${{ github.event_name == 'workflow_dispatch' && inputs.projectName || 'holidaypeakhub405' }}
+      imageTag: ${{ github.event_name == 'workflow_dispatch' && inputs.imageTag || github.sha }}
+      testedSourceSha: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceSha || github.sha }}
+      testedSourceRef: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceRef || github.ref }}
+      skipProvision: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.skipProvision) || 'true') }}
+      forceApimSync: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.forceApimSync) || 'true') }}
+      autoAllowAcrRunnerIp: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.autoAllowAcrRunnerIp) || 'true') }}
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/deploy-azd-ecommerce-catalog-search.yml
+++ b/.github/workflows/deploy-azd-ecommerce-catalog-search.yml
@@ -1,0 +1,87 @@
+name: deploy-azd-ecommerce-catalog-search (entrypoint)
+
+on:
+  push:
+    branches:
+      - '**'
+    paths:
+      - apps/ecommerce-catalog-search/**
+      - lib/**
+      - azure.yaml
+      - .infra/**
+      - .kubernetes/**
+      - .github/workflows/deploy-azd.yml
+      - .github/workflows/deploy-azd-service.yml
+      - .github/workflows/deploy-azd-ecommerce-catalog-search.yml
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Target deployment environment
+        required: true
+        default: dev
+      location:
+        description: Azure location
+        required: true
+        default: centralus
+      projectName:
+        description: Project prefix used by naming convention
+        required: true
+        default: holidaypeakhub405
+      imageTag:
+        description: Image tag to deploy
+        required: true
+        default: latest
+      testedSourceSha:
+        description: Optional tested source commit SHA to deploy
+        required: false
+        default: ''
+      testedSourceRef:
+        description: Optional tested source ref to deploy when testedSourceSha is empty
+        required: false
+        default: ''
+      skipProvision:
+        description: Skip azd provision and reuse the current environment infrastructure
+        required: true
+        type: boolean
+        default: true
+      forceApimSync:
+        description: Force APIM sync and smoke checks even when no changed services are detected
+        required: true
+        type: boolean
+        default: true
+      autoAllowAcrRunnerIp:
+        description: Temporarily allow GitHub runner egress IP in ACR firewall during deploy
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: deploy-azd-${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}-ecommerce-catalog-search
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    permissions:
+      id-token: write
+      contents: read
+      issues: write
+    uses: ./.github/workflows/deploy-azd-service.yml
+    with:
+      serviceName: ecommerce-catalog-search
+      environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}
+      location: ${{ github.event_name == 'workflow_dispatch' && inputs.location || 'centralus' }}
+      projectName: ${{ github.event_name == 'workflow_dispatch' && inputs.projectName || 'holidaypeakhub405' }}
+      imageTag: ${{ github.event_name == 'workflow_dispatch' && inputs.imageTag || github.sha }}
+      testedSourceSha: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceSha || github.sha }}
+      testedSourceRef: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceRef || github.ref }}
+      skipProvision: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.skipProvision) || 'true') }}
+      forceApimSync: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.forceApimSync) || 'true') }}
+      autoAllowAcrRunnerIp: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.autoAllowAcrRunnerIp) || 'true') }}
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/deploy-azd-ecommerce-checkout-support.yml
+++ b/.github/workflows/deploy-azd-ecommerce-checkout-support.yml
@@ -1,0 +1,87 @@
+name: deploy-azd-ecommerce-checkout-support (entrypoint)
+
+on:
+  push:
+    branches:
+      - '**'
+    paths:
+      - apps/ecommerce-checkout-support/**
+      - lib/**
+      - azure.yaml
+      - .infra/**
+      - .kubernetes/**
+      - .github/workflows/deploy-azd.yml
+      - .github/workflows/deploy-azd-service.yml
+      - .github/workflows/deploy-azd-ecommerce-checkout-support.yml
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Target deployment environment
+        required: true
+        default: dev
+      location:
+        description: Azure location
+        required: true
+        default: centralus
+      projectName:
+        description: Project prefix used by naming convention
+        required: true
+        default: holidaypeakhub405
+      imageTag:
+        description: Image tag to deploy
+        required: true
+        default: latest
+      testedSourceSha:
+        description: Optional tested source commit SHA to deploy
+        required: false
+        default: ''
+      testedSourceRef:
+        description: Optional tested source ref to deploy when testedSourceSha is empty
+        required: false
+        default: ''
+      skipProvision:
+        description: Skip azd provision and reuse the current environment infrastructure
+        required: true
+        type: boolean
+        default: true
+      forceApimSync:
+        description: Force APIM sync and smoke checks even when no changed services are detected
+        required: true
+        type: boolean
+        default: true
+      autoAllowAcrRunnerIp:
+        description: Temporarily allow GitHub runner egress IP in ACR firewall during deploy
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: deploy-azd-${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}-ecommerce-checkout-support
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    permissions:
+      id-token: write
+      contents: read
+      issues: write
+    uses: ./.github/workflows/deploy-azd-service.yml
+    with:
+      serviceName: ecommerce-checkout-support
+      environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}
+      location: ${{ github.event_name == 'workflow_dispatch' && inputs.location || 'centralus' }}
+      projectName: ${{ github.event_name == 'workflow_dispatch' && inputs.projectName || 'holidaypeakhub405' }}
+      imageTag: ${{ github.event_name == 'workflow_dispatch' && inputs.imageTag || github.sha }}
+      testedSourceSha: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceSha || github.sha }}
+      testedSourceRef: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceRef || github.ref }}
+      skipProvision: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.skipProvision) || 'true') }}
+      forceApimSync: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.forceApimSync) || 'true') }}
+      autoAllowAcrRunnerIp: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.autoAllowAcrRunnerIp) || 'true') }}
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/deploy-azd-ecommerce-order-status.yml
+++ b/.github/workflows/deploy-azd-ecommerce-order-status.yml
@@ -1,0 +1,87 @@
+name: deploy-azd-ecommerce-order-status (entrypoint)
+
+on:
+  push:
+    branches:
+      - '**'
+    paths:
+      - apps/ecommerce-order-status/**
+      - lib/**
+      - azure.yaml
+      - .infra/**
+      - .kubernetes/**
+      - .github/workflows/deploy-azd.yml
+      - .github/workflows/deploy-azd-service.yml
+      - .github/workflows/deploy-azd-ecommerce-order-status.yml
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Target deployment environment
+        required: true
+        default: dev
+      location:
+        description: Azure location
+        required: true
+        default: centralus
+      projectName:
+        description: Project prefix used by naming convention
+        required: true
+        default: holidaypeakhub405
+      imageTag:
+        description: Image tag to deploy
+        required: true
+        default: latest
+      testedSourceSha:
+        description: Optional tested source commit SHA to deploy
+        required: false
+        default: ''
+      testedSourceRef:
+        description: Optional tested source ref to deploy when testedSourceSha is empty
+        required: false
+        default: ''
+      skipProvision:
+        description: Skip azd provision and reuse the current environment infrastructure
+        required: true
+        type: boolean
+        default: true
+      forceApimSync:
+        description: Force APIM sync and smoke checks even when no changed services are detected
+        required: true
+        type: boolean
+        default: true
+      autoAllowAcrRunnerIp:
+        description: Temporarily allow GitHub runner egress IP in ACR firewall during deploy
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: deploy-azd-${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}-ecommerce-order-status
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    permissions:
+      id-token: write
+      contents: read
+      issues: write
+    uses: ./.github/workflows/deploy-azd-service.yml
+    with:
+      serviceName: ecommerce-order-status
+      environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}
+      location: ${{ github.event_name == 'workflow_dispatch' && inputs.location || 'centralus' }}
+      projectName: ${{ github.event_name == 'workflow_dispatch' && inputs.projectName || 'holidaypeakhub405' }}
+      imageTag: ${{ github.event_name == 'workflow_dispatch' && inputs.imageTag || github.sha }}
+      testedSourceSha: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceSha || github.sha }}
+      testedSourceRef: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceRef || github.ref }}
+      skipProvision: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.skipProvision) || 'true') }}
+      forceApimSync: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.forceApimSync) || 'true') }}
+      autoAllowAcrRunnerIp: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.autoAllowAcrRunnerIp) || 'true') }}
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/deploy-azd-ecommerce-product-detail-enrichment.yml
+++ b/.github/workflows/deploy-azd-ecommerce-product-detail-enrichment.yml
@@ -1,0 +1,87 @@
+name: deploy-azd-ecommerce-product-detail-enrichment (entrypoint)
+
+on:
+  push:
+    branches:
+      - '**'
+    paths:
+      - apps/ecommerce-product-detail-enrichment/**
+      - lib/**
+      - azure.yaml
+      - .infra/**
+      - .kubernetes/**
+      - .github/workflows/deploy-azd.yml
+      - .github/workflows/deploy-azd-service.yml
+      - .github/workflows/deploy-azd-ecommerce-product-detail-enrichment.yml
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Target deployment environment
+        required: true
+        default: dev
+      location:
+        description: Azure location
+        required: true
+        default: centralus
+      projectName:
+        description: Project prefix used by naming convention
+        required: true
+        default: holidaypeakhub405
+      imageTag:
+        description: Image tag to deploy
+        required: true
+        default: latest
+      testedSourceSha:
+        description: Optional tested source commit SHA to deploy
+        required: false
+        default: ''
+      testedSourceRef:
+        description: Optional tested source ref to deploy when testedSourceSha is empty
+        required: false
+        default: ''
+      skipProvision:
+        description: Skip azd provision and reuse the current environment infrastructure
+        required: true
+        type: boolean
+        default: true
+      forceApimSync:
+        description: Force APIM sync and smoke checks even when no changed services are detected
+        required: true
+        type: boolean
+        default: true
+      autoAllowAcrRunnerIp:
+        description: Temporarily allow GitHub runner egress IP in ACR firewall during deploy
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: deploy-azd-${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}-ecommerce-product-detail-enrichment
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    permissions:
+      id-token: write
+      contents: read
+      issues: write
+    uses: ./.github/workflows/deploy-azd-service.yml
+    with:
+      serviceName: ecommerce-product-detail-enrichment
+      environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}
+      location: ${{ github.event_name == 'workflow_dispatch' && inputs.location || 'centralus' }}
+      projectName: ${{ github.event_name == 'workflow_dispatch' && inputs.projectName || 'holidaypeakhub405' }}
+      imageTag: ${{ github.event_name == 'workflow_dispatch' && inputs.imageTag || github.sha }}
+      testedSourceSha: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceSha || github.sha }}
+      testedSourceRef: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceRef || github.ref }}
+      skipProvision: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.skipProvision) || 'true') }}
+      forceApimSync: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.forceApimSync) || 'true') }}
+      autoAllowAcrRunnerIp: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.autoAllowAcrRunnerIp) || 'true') }}
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/deploy-azd-inventory-alerts-triggers.yml
+++ b/.github/workflows/deploy-azd-inventory-alerts-triggers.yml
@@ -1,0 +1,87 @@
+name: deploy-azd-inventory-alerts-triggers (entrypoint)
+
+on:
+  push:
+    branches:
+      - '**'
+    paths:
+      - apps/inventory-alerts-triggers/**
+      - lib/**
+      - azure.yaml
+      - .infra/**
+      - .kubernetes/**
+      - .github/workflows/deploy-azd.yml
+      - .github/workflows/deploy-azd-service.yml
+      - .github/workflows/deploy-azd-inventory-alerts-triggers.yml
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Target deployment environment
+        required: true
+        default: dev
+      location:
+        description: Azure location
+        required: true
+        default: centralus
+      projectName:
+        description: Project prefix used by naming convention
+        required: true
+        default: holidaypeakhub405
+      imageTag:
+        description: Image tag to deploy
+        required: true
+        default: latest
+      testedSourceSha:
+        description: Optional tested source commit SHA to deploy
+        required: false
+        default: ''
+      testedSourceRef:
+        description: Optional tested source ref to deploy when testedSourceSha is empty
+        required: false
+        default: ''
+      skipProvision:
+        description: Skip azd provision and reuse the current environment infrastructure
+        required: true
+        type: boolean
+        default: true
+      forceApimSync:
+        description: Force APIM sync and smoke checks even when no changed services are detected
+        required: true
+        type: boolean
+        default: true
+      autoAllowAcrRunnerIp:
+        description: Temporarily allow GitHub runner egress IP in ACR firewall during deploy
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: deploy-azd-${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}-inventory-alerts-triggers
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    permissions:
+      id-token: write
+      contents: read
+      issues: write
+    uses: ./.github/workflows/deploy-azd-service.yml
+    with:
+      serviceName: inventory-alerts-triggers
+      environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}
+      location: ${{ github.event_name == 'workflow_dispatch' && inputs.location || 'centralus' }}
+      projectName: ${{ github.event_name == 'workflow_dispatch' && inputs.projectName || 'holidaypeakhub405' }}
+      imageTag: ${{ github.event_name == 'workflow_dispatch' && inputs.imageTag || github.sha }}
+      testedSourceSha: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceSha || github.sha }}
+      testedSourceRef: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceRef || github.ref }}
+      skipProvision: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.skipProvision) || 'true') }}
+      forceApimSync: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.forceApimSync) || 'true') }}
+      autoAllowAcrRunnerIp: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.autoAllowAcrRunnerIp) || 'true') }}
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/deploy-azd-inventory-health-check.yml
+++ b/.github/workflows/deploy-azd-inventory-health-check.yml
@@ -1,0 +1,87 @@
+name: deploy-azd-inventory-health-check (entrypoint)
+
+on:
+  push:
+    branches:
+      - '**'
+    paths:
+      - apps/inventory-health-check/**
+      - lib/**
+      - azure.yaml
+      - .infra/**
+      - .kubernetes/**
+      - .github/workflows/deploy-azd.yml
+      - .github/workflows/deploy-azd-service.yml
+      - .github/workflows/deploy-azd-inventory-health-check.yml
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Target deployment environment
+        required: true
+        default: dev
+      location:
+        description: Azure location
+        required: true
+        default: centralus
+      projectName:
+        description: Project prefix used by naming convention
+        required: true
+        default: holidaypeakhub405
+      imageTag:
+        description: Image tag to deploy
+        required: true
+        default: latest
+      testedSourceSha:
+        description: Optional tested source commit SHA to deploy
+        required: false
+        default: ''
+      testedSourceRef:
+        description: Optional tested source ref to deploy when testedSourceSha is empty
+        required: false
+        default: ''
+      skipProvision:
+        description: Skip azd provision and reuse the current environment infrastructure
+        required: true
+        type: boolean
+        default: true
+      forceApimSync:
+        description: Force APIM sync and smoke checks even when no changed services are detected
+        required: true
+        type: boolean
+        default: true
+      autoAllowAcrRunnerIp:
+        description: Temporarily allow GitHub runner egress IP in ACR firewall during deploy
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: deploy-azd-${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}-inventory-health-check
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    permissions:
+      id-token: write
+      contents: read
+      issues: write
+    uses: ./.github/workflows/deploy-azd-service.yml
+    with:
+      serviceName: inventory-health-check
+      environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}
+      location: ${{ github.event_name == 'workflow_dispatch' && inputs.location || 'centralus' }}
+      projectName: ${{ github.event_name == 'workflow_dispatch' && inputs.projectName || 'holidaypeakhub405' }}
+      imageTag: ${{ github.event_name == 'workflow_dispatch' && inputs.imageTag || github.sha }}
+      testedSourceSha: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceSha || github.sha }}
+      testedSourceRef: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceRef || github.ref }}
+      skipProvision: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.skipProvision) || 'true') }}
+      forceApimSync: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.forceApimSync) || 'true') }}
+      autoAllowAcrRunnerIp: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.autoAllowAcrRunnerIp) || 'true') }}
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/deploy-azd-inventory-jit-replenishment.yml
+++ b/.github/workflows/deploy-azd-inventory-jit-replenishment.yml
@@ -1,0 +1,87 @@
+name: deploy-azd-inventory-jit-replenishment (entrypoint)
+
+on:
+  push:
+    branches:
+      - '**'
+    paths:
+      - apps/inventory-jit-replenishment/**
+      - lib/**
+      - azure.yaml
+      - .infra/**
+      - .kubernetes/**
+      - .github/workflows/deploy-azd.yml
+      - .github/workflows/deploy-azd-service.yml
+      - .github/workflows/deploy-azd-inventory-jit-replenishment.yml
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Target deployment environment
+        required: true
+        default: dev
+      location:
+        description: Azure location
+        required: true
+        default: centralus
+      projectName:
+        description: Project prefix used by naming convention
+        required: true
+        default: holidaypeakhub405
+      imageTag:
+        description: Image tag to deploy
+        required: true
+        default: latest
+      testedSourceSha:
+        description: Optional tested source commit SHA to deploy
+        required: false
+        default: ''
+      testedSourceRef:
+        description: Optional tested source ref to deploy when testedSourceSha is empty
+        required: false
+        default: ''
+      skipProvision:
+        description: Skip azd provision and reuse the current environment infrastructure
+        required: true
+        type: boolean
+        default: true
+      forceApimSync:
+        description: Force APIM sync and smoke checks even when no changed services are detected
+        required: true
+        type: boolean
+        default: true
+      autoAllowAcrRunnerIp:
+        description: Temporarily allow GitHub runner egress IP in ACR firewall during deploy
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: deploy-azd-${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}-inventory-jit-replenishment
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    permissions:
+      id-token: write
+      contents: read
+      issues: write
+    uses: ./.github/workflows/deploy-azd-service.yml
+    with:
+      serviceName: inventory-jit-replenishment
+      environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}
+      location: ${{ github.event_name == 'workflow_dispatch' && inputs.location || 'centralus' }}
+      projectName: ${{ github.event_name == 'workflow_dispatch' && inputs.projectName || 'holidaypeakhub405' }}
+      imageTag: ${{ github.event_name == 'workflow_dispatch' && inputs.imageTag || github.sha }}
+      testedSourceSha: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceSha || github.sha }}
+      testedSourceRef: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceRef || github.ref }}
+      skipProvision: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.skipProvision) || 'true') }}
+      forceApimSync: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.forceApimSync) || 'true') }}
+      autoAllowAcrRunnerIp: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.autoAllowAcrRunnerIp) || 'true') }}
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/deploy-azd-inventory-reservation-validation.yml
+++ b/.github/workflows/deploy-azd-inventory-reservation-validation.yml
@@ -1,0 +1,87 @@
+name: deploy-azd-inventory-reservation-validation (entrypoint)
+
+on:
+  push:
+    branches:
+      - '**'
+    paths:
+      - apps/inventory-reservation-validation/**
+      - lib/**
+      - azure.yaml
+      - .infra/**
+      - .kubernetes/**
+      - .github/workflows/deploy-azd.yml
+      - .github/workflows/deploy-azd-service.yml
+      - .github/workflows/deploy-azd-inventory-reservation-validation.yml
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Target deployment environment
+        required: true
+        default: dev
+      location:
+        description: Azure location
+        required: true
+        default: centralus
+      projectName:
+        description: Project prefix used by naming convention
+        required: true
+        default: holidaypeakhub405
+      imageTag:
+        description: Image tag to deploy
+        required: true
+        default: latest
+      testedSourceSha:
+        description: Optional tested source commit SHA to deploy
+        required: false
+        default: ''
+      testedSourceRef:
+        description: Optional tested source ref to deploy when testedSourceSha is empty
+        required: false
+        default: ''
+      skipProvision:
+        description: Skip azd provision and reuse the current environment infrastructure
+        required: true
+        type: boolean
+        default: true
+      forceApimSync:
+        description: Force APIM sync and smoke checks even when no changed services are detected
+        required: true
+        type: boolean
+        default: true
+      autoAllowAcrRunnerIp:
+        description: Temporarily allow GitHub runner egress IP in ACR firewall during deploy
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: deploy-azd-${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}-inventory-reservation-validation
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    permissions:
+      id-token: write
+      contents: read
+      issues: write
+    uses: ./.github/workflows/deploy-azd-service.yml
+    with:
+      serviceName: inventory-reservation-validation
+      environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}
+      location: ${{ github.event_name == 'workflow_dispatch' && inputs.location || 'centralus' }}
+      projectName: ${{ github.event_name == 'workflow_dispatch' && inputs.projectName || 'holidaypeakhub405' }}
+      imageTag: ${{ github.event_name == 'workflow_dispatch' && inputs.imageTag || github.sha }}
+      testedSourceSha: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceSha || github.sha }}
+      testedSourceRef: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceRef || github.ref }}
+      skipProvision: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.skipProvision) || 'true') }}
+      forceApimSync: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.forceApimSync) || 'true') }}
+      autoAllowAcrRunnerIp: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.autoAllowAcrRunnerIp) || 'true') }}
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/deploy-azd-logistics-carrier-selection.yml
+++ b/.github/workflows/deploy-azd-logistics-carrier-selection.yml
@@ -1,0 +1,87 @@
+name: deploy-azd-logistics-carrier-selection (entrypoint)
+
+on:
+  push:
+    branches:
+      - '**'
+    paths:
+      - apps/logistics-carrier-selection/**
+      - lib/**
+      - azure.yaml
+      - .infra/**
+      - .kubernetes/**
+      - .github/workflows/deploy-azd.yml
+      - .github/workflows/deploy-azd-service.yml
+      - .github/workflows/deploy-azd-logistics-carrier-selection.yml
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Target deployment environment
+        required: true
+        default: dev
+      location:
+        description: Azure location
+        required: true
+        default: centralus
+      projectName:
+        description: Project prefix used by naming convention
+        required: true
+        default: holidaypeakhub405
+      imageTag:
+        description: Image tag to deploy
+        required: true
+        default: latest
+      testedSourceSha:
+        description: Optional tested source commit SHA to deploy
+        required: false
+        default: ''
+      testedSourceRef:
+        description: Optional tested source ref to deploy when testedSourceSha is empty
+        required: false
+        default: ''
+      skipProvision:
+        description: Skip azd provision and reuse the current environment infrastructure
+        required: true
+        type: boolean
+        default: true
+      forceApimSync:
+        description: Force APIM sync and smoke checks even when no changed services are detected
+        required: true
+        type: boolean
+        default: true
+      autoAllowAcrRunnerIp:
+        description: Temporarily allow GitHub runner egress IP in ACR firewall during deploy
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: deploy-azd-${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}-logistics-carrier-selection
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    permissions:
+      id-token: write
+      contents: read
+      issues: write
+    uses: ./.github/workflows/deploy-azd-service.yml
+    with:
+      serviceName: logistics-carrier-selection
+      environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}
+      location: ${{ github.event_name == 'workflow_dispatch' && inputs.location || 'centralus' }}
+      projectName: ${{ github.event_name == 'workflow_dispatch' && inputs.projectName || 'holidaypeakhub405' }}
+      imageTag: ${{ github.event_name == 'workflow_dispatch' && inputs.imageTag || github.sha }}
+      testedSourceSha: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceSha || github.sha }}
+      testedSourceRef: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceRef || github.ref }}
+      skipProvision: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.skipProvision) || 'true') }}
+      forceApimSync: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.forceApimSync) || 'true') }}
+      autoAllowAcrRunnerIp: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.autoAllowAcrRunnerIp) || 'true') }}
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/deploy-azd-logistics-eta-computation.yml
+++ b/.github/workflows/deploy-azd-logistics-eta-computation.yml
@@ -1,0 +1,87 @@
+name: deploy-azd-logistics-eta-computation (entrypoint)
+
+on:
+  push:
+    branches:
+      - '**'
+    paths:
+      - apps/logistics-eta-computation/**
+      - lib/**
+      - azure.yaml
+      - .infra/**
+      - .kubernetes/**
+      - .github/workflows/deploy-azd.yml
+      - .github/workflows/deploy-azd-service.yml
+      - .github/workflows/deploy-azd-logistics-eta-computation.yml
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Target deployment environment
+        required: true
+        default: dev
+      location:
+        description: Azure location
+        required: true
+        default: centralus
+      projectName:
+        description: Project prefix used by naming convention
+        required: true
+        default: holidaypeakhub405
+      imageTag:
+        description: Image tag to deploy
+        required: true
+        default: latest
+      testedSourceSha:
+        description: Optional tested source commit SHA to deploy
+        required: false
+        default: ''
+      testedSourceRef:
+        description: Optional tested source ref to deploy when testedSourceSha is empty
+        required: false
+        default: ''
+      skipProvision:
+        description: Skip azd provision and reuse the current environment infrastructure
+        required: true
+        type: boolean
+        default: true
+      forceApimSync:
+        description: Force APIM sync and smoke checks even when no changed services are detected
+        required: true
+        type: boolean
+        default: true
+      autoAllowAcrRunnerIp:
+        description: Temporarily allow GitHub runner egress IP in ACR firewall during deploy
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: deploy-azd-${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}-logistics-eta-computation
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    permissions:
+      id-token: write
+      contents: read
+      issues: write
+    uses: ./.github/workflows/deploy-azd-service.yml
+    with:
+      serviceName: logistics-eta-computation
+      environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}
+      location: ${{ github.event_name == 'workflow_dispatch' && inputs.location || 'centralus' }}
+      projectName: ${{ github.event_name == 'workflow_dispatch' && inputs.projectName || 'holidaypeakhub405' }}
+      imageTag: ${{ github.event_name == 'workflow_dispatch' && inputs.imageTag || github.sha }}
+      testedSourceSha: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceSha || github.sha }}
+      testedSourceRef: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceRef || github.ref }}
+      skipProvision: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.skipProvision) || 'true') }}
+      forceApimSync: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.forceApimSync) || 'true') }}
+      autoAllowAcrRunnerIp: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.autoAllowAcrRunnerIp) || 'true') }}
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/deploy-azd-logistics-returns-support.yml
+++ b/.github/workflows/deploy-azd-logistics-returns-support.yml
@@ -1,0 +1,87 @@
+name: deploy-azd-logistics-returns-support (entrypoint)
+
+on:
+  push:
+    branches:
+      - '**'
+    paths:
+      - apps/logistics-returns-support/**
+      - lib/**
+      - azure.yaml
+      - .infra/**
+      - .kubernetes/**
+      - .github/workflows/deploy-azd.yml
+      - .github/workflows/deploy-azd-service.yml
+      - .github/workflows/deploy-azd-logistics-returns-support.yml
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Target deployment environment
+        required: true
+        default: dev
+      location:
+        description: Azure location
+        required: true
+        default: centralus
+      projectName:
+        description: Project prefix used by naming convention
+        required: true
+        default: holidaypeakhub405
+      imageTag:
+        description: Image tag to deploy
+        required: true
+        default: latest
+      testedSourceSha:
+        description: Optional tested source commit SHA to deploy
+        required: false
+        default: ''
+      testedSourceRef:
+        description: Optional tested source ref to deploy when testedSourceSha is empty
+        required: false
+        default: ''
+      skipProvision:
+        description: Skip azd provision and reuse the current environment infrastructure
+        required: true
+        type: boolean
+        default: true
+      forceApimSync:
+        description: Force APIM sync and smoke checks even when no changed services are detected
+        required: true
+        type: boolean
+        default: true
+      autoAllowAcrRunnerIp:
+        description: Temporarily allow GitHub runner egress IP in ACR firewall during deploy
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: deploy-azd-${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}-logistics-returns-support
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    permissions:
+      id-token: write
+      contents: read
+      issues: write
+    uses: ./.github/workflows/deploy-azd-service.yml
+    with:
+      serviceName: logistics-returns-support
+      environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}
+      location: ${{ github.event_name == 'workflow_dispatch' && inputs.location || 'centralus' }}
+      projectName: ${{ github.event_name == 'workflow_dispatch' && inputs.projectName || 'holidaypeakhub405' }}
+      imageTag: ${{ github.event_name == 'workflow_dispatch' && inputs.imageTag || github.sha }}
+      testedSourceSha: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceSha || github.sha }}
+      testedSourceRef: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceRef || github.ref }}
+      skipProvision: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.skipProvision) || 'true') }}
+      forceApimSync: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.forceApimSync) || 'true') }}
+      autoAllowAcrRunnerIp: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.autoAllowAcrRunnerIp) || 'true') }}
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/deploy-azd-logistics-route-issue-detection.yml
+++ b/.github/workflows/deploy-azd-logistics-route-issue-detection.yml
@@ -1,0 +1,87 @@
+name: deploy-azd-logistics-route-issue-detection (entrypoint)
+
+on:
+  push:
+    branches:
+      - '**'
+    paths:
+      - apps/logistics-route-issue-detection/**
+      - lib/**
+      - azure.yaml
+      - .infra/**
+      - .kubernetes/**
+      - .github/workflows/deploy-azd.yml
+      - .github/workflows/deploy-azd-service.yml
+      - .github/workflows/deploy-azd-logistics-route-issue-detection.yml
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Target deployment environment
+        required: true
+        default: dev
+      location:
+        description: Azure location
+        required: true
+        default: centralus
+      projectName:
+        description: Project prefix used by naming convention
+        required: true
+        default: holidaypeakhub405
+      imageTag:
+        description: Image tag to deploy
+        required: true
+        default: latest
+      testedSourceSha:
+        description: Optional tested source commit SHA to deploy
+        required: false
+        default: ''
+      testedSourceRef:
+        description: Optional tested source ref to deploy when testedSourceSha is empty
+        required: false
+        default: ''
+      skipProvision:
+        description: Skip azd provision and reuse the current environment infrastructure
+        required: true
+        type: boolean
+        default: true
+      forceApimSync:
+        description: Force APIM sync and smoke checks even when no changed services are detected
+        required: true
+        type: boolean
+        default: true
+      autoAllowAcrRunnerIp:
+        description: Temporarily allow GitHub runner egress IP in ACR firewall during deploy
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: deploy-azd-${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}-logistics-route-issue-detection
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    permissions:
+      id-token: write
+      contents: read
+      issues: write
+    uses: ./.github/workflows/deploy-azd-service.yml
+    with:
+      serviceName: logistics-route-issue-detection
+      environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}
+      location: ${{ github.event_name == 'workflow_dispatch' && inputs.location || 'centralus' }}
+      projectName: ${{ github.event_name == 'workflow_dispatch' && inputs.projectName || 'holidaypeakhub405' }}
+      imageTag: ${{ github.event_name == 'workflow_dispatch' && inputs.imageTag || github.sha }}
+      testedSourceSha: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceSha || github.sha }}
+      testedSourceRef: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceRef || github.ref }}
+      skipProvision: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.skipProvision) || 'true') }}
+      forceApimSync: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.forceApimSync) || 'true') }}
+      autoAllowAcrRunnerIp: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.autoAllowAcrRunnerIp) || 'true') }}
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/deploy-azd-prod.yml
+++ b/.github/workflows/deploy-azd-prod.yml
@@ -57,6 +57,7 @@ jobs:
     uses: ./.github/workflows/deploy-azd.yml
     with:
       environment: prod
+      githubEnvironment: prod
       location: centralus
       projectName: holidaypeakhub405
       imageTag: ${{ github.ref_name }}

--- a/.github/workflows/deploy-azd-product-management-acp-transformation.yml
+++ b/.github/workflows/deploy-azd-product-management-acp-transformation.yml
@@ -1,0 +1,87 @@
+name: deploy-azd-product-management-acp-transformation (entrypoint)
+
+on:
+  push:
+    branches:
+      - '**'
+    paths:
+      - apps/product-management-acp-transformation/**
+      - lib/**
+      - azure.yaml
+      - .infra/**
+      - .kubernetes/**
+      - .github/workflows/deploy-azd.yml
+      - .github/workflows/deploy-azd-service.yml
+      - .github/workflows/deploy-azd-product-management-acp-transformation.yml
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Target deployment environment
+        required: true
+        default: dev
+      location:
+        description: Azure location
+        required: true
+        default: centralus
+      projectName:
+        description: Project prefix used by naming convention
+        required: true
+        default: holidaypeakhub405
+      imageTag:
+        description: Image tag to deploy
+        required: true
+        default: latest
+      testedSourceSha:
+        description: Optional tested source commit SHA to deploy
+        required: false
+        default: ''
+      testedSourceRef:
+        description: Optional tested source ref to deploy when testedSourceSha is empty
+        required: false
+        default: ''
+      skipProvision:
+        description: Skip azd provision and reuse the current environment infrastructure
+        required: true
+        type: boolean
+        default: true
+      forceApimSync:
+        description: Force APIM sync and smoke checks even when no changed services are detected
+        required: true
+        type: boolean
+        default: true
+      autoAllowAcrRunnerIp:
+        description: Temporarily allow GitHub runner egress IP in ACR firewall during deploy
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: deploy-azd-${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}-product-management-acp-transformation
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    permissions:
+      id-token: write
+      contents: read
+      issues: write
+    uses: ./.github/workflows/deploy-azd-service.yml
+    with:
+      serviceName: product-management-acp-transformation
+      environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}
+      location: ${{ github.event_name == 'workflow_dispatch' && inputs.location || 'centralus' }}
+      projectName: ${{ github.event_name == 'workflow_dispatch' && inputs.projectName || 'holidaypeakhub405' }}
+      imageTag: ${{ github.event_name == 'workflow_dispatch' && inputs.imageTag || github.sha }}
+      testedSourceSha: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceSha || github.sha }}
+      testedSourceRef: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceRef || github.ref }}
+      skipProvision: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.skipProvision) || 'true') }}
+      forceApimSync: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.forceApimSync) || 'true') }}
+      autoAllowAcrRunnerIp: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.autoAllowAcrRunnerIp) || 'true') }}
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/deploy-azd-product-management-assortment-optimization.yml
+++ b/.github/workflows/deploy-azd-product-management-assortment-optimization.yml
@@ -1,0 +1,87 @@
+name: deploy-azd-product-management-assortment-optimization (entrypoint)
+
+on:
+  push:
+    branches:
+      - '**'
+    paths:
+      - apps/product-management-assortment-optimization/**
+      - lib/**
+      - azure.yaml
+      - .infra/**
+      - .kubernetes/**
+      - .github/workflows/deploy-azd.yml
+      - .github/workflows/deploy-azd-service.yml
+      - .github/workflows/deploy-azd-product-management-assortment-optimization.yml
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Target deployment environment
+        required: true
+        default: dev
+      location:
+        description: Azure location
+        required: true
+        default: centralus
+      projectName:
+        description: Project prefix used by naming convention
+        required: true
+        default: holidaypeakhub405
+      imageTag:
+        description: Image tag to deploy
+        required: true
+        default: latest
+      testedSourceSha:
+        description: Optional tested source commit SHA to deploy
+        required: false
+        default: ''
+      testedSourceRef:
+        description: Optional tested source ref to deploy when testedSourceSha is empty
+        required: false
+        default: ''
+      skipProvision:
+        description: Skip azd provision and reuse the current environment infrastructure
+        required: true
+        type: boolean
+        default: true
+      forceApimSync:
+        description: Force APIM sync and smoke checks even when no changed services are detected
+        required: true
+        type: boolean
+        default: true
+      autoAllowAcrRunnerIp:
+        description: Temporarily allow GitHub runner egress IP in ACR firewall during deploy
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: deploy-azd-${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}-product-management-assortment-optimization
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    permissions:
+      id-token: write
+      contents: read
+      issues: write
+    uses: ./.github/workflows/deploy-azd-service.yml
+    with:
+      serviceName: product-management-assortment-optimization
+      environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}
+      location: ${{ github.event_name == 'workflow_dispatch' && inputs.location || 'centralus' }}
+      projectName: ${{ github.event_name == 'workflow_dispatch' && inputs.projectName || 'holidaypeakhub405' }}
+      imageTag: ${{ github.event_name == 'workflow_dispatch' && inputs.imageTag || github.sha }}
+      testedSourceSha: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceSha || github.sha }}
+      testedSourceRef: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceRef || github.ref }}
+      skipProvision: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.skipProvision) || 'true') }}
+      forceApimSync: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.forceApimSync) || 'true') }}
+      autoAllowAcrRunnerIp: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.autoAllowAcrRunnerIp) || 'true') }}
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/deploy-azd-product-management-consistency-validation.yml
+++ b/.github/workflows/deploy-azd-product-management-consistency-validation.yml
@@ -1,0 +1,87 @@
+name: deploy-azd-product-management-consistency-validation (entrypoint)
+
+on:
+  push:
+    branches:
+      - '**'
+    paths:
+      - apps/product-management-consistency-validation/**
+      - lib/**
+      - azure.yaml
+      - .infra/**
+      - .kubernetes/**
+      - .github/workflows/deploy-azd.yml
+      - .github/workflows/deploy-azd-service.yml
+      - .github/workflows/deploy-azd-product-management-consistency-validation.yml
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Target deployment environment
+        required: true
+        default: dev
+      location:
+        description: Azure location
+        required: true
+        default: centralus
+      projectName:
+        description: Project prefix used by naming convention
+        required: true
+        default: holidaypeakhub405
+      imageTag:
+        description: Image tag to deploy
+        required: true
+        default: latest
+      testedSourceSha:
+        description: Optional tested source commit SHA to deploy
+        required: false
+        default: ''
+      testedSourceRef:
+        description: Optional tested source ref to deploy when testedSourceSha is empty
+        required: false
+        default: ''
+      skipProvision:
+        description: Skip azd provision and reuse the current environment infrastructure
+        required: true
+        type: boolean
+        default: true
+      forceApimSync:
+        description: Force APIM sync and smoke checks even when no changed services are detected
+        required: true
+        type: boolean
+        default: true
+      autoAllowAcrRunnerIp:
+        description: Temporarily allow GitHub runner egress IP in ACR firewall during deploy
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: deploy-azd-${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}-product-management-consistency-validation
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    permissions:
+      id-token: write
+      contents: read
+      issues: write
+    uses: ./.github/workflows/deploy-azd-service.yml
+    with:
+      serviceName: product-management-consistency-validation
+      environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}
+      location: ${{ github.event_name == 'workflow_dispatch' && inputs.location || 'centralus' }}
+      projectName: ${{ github.event_name == 'workflow_dispatch' && inputs.projectName || 'holidaypeakhub405' }}
+      imageTag: ${{ github.event_name == 'workflow_dispatch' && inputs.imageTag || github.sha }}
+      testedSourceSha: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceSha || github.sha }}
+      testedSourceRef: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceRef || github.ref }}
+      skipProvision: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.skipProvision) || 'true') }}
+      forceApimSync: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.forceApimSync) || 'true') }}
+      autoAllowAcrRunnerIp: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.autoAllowAcrRunnerIp) || 'true') }}
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/deploy-azd-product-management-normalization-classification.yml
+++ b/.github/workflows/deploy-azd-product-management-normalization-classification.yml
@@ -1,0 +1,87 @@
+name: deploy-azd-product-management-normalization-classification (entrypoint)
+
+on:
+  push:
+    branches:
+      - '**'
+    paths:
+      - apps/product-management-normalization-classification/**
+      - lib/**
+      - azure.yaml
+      - .infra/**
+      - .kubernetes/**
+      - .github/workflows/deploy-azd.yml
+      - .github/workflows/deploy-azd-service.yml
+      - .github/workflows/deploy-azd-product-management-normalization-classification.yml
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Target deployment environment
+        required: true
+        default: dev
+      location:
+        description: Azure location
+        required: true
+        default: centralus
+      projectName:
+        description: Project prefix used by naming convention
+        required: true
+        default: holidaypeakhub405
+      imageTag:
+        description: Image tag to deploy
+        required: true
+        default: latest
+      testedSourceSha:
+        description: Optional tested source commit SHA to deploy
+        required: false
+        default: ''
+      testedSourceRef:
+        description: Optional tested source ref to deploy when testedSourceSha is empty
+        required: false
+        default: ''
+      skipProvision:
+        description: Skip azd provision and reuse the current environment infrastructure
+        required: true
+        type: boolean
+        default: true
+      forceApimSync:
+        description: Force APIM sync and smoke checks even when no changed services are detected
+        required: true
+        type: boolean
+        default: true
+      autoAllowAcrRunnerIp:
+        description: Temporarily allow GitHub runner egress IP in ACR firewall during deploy
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: deploy-azd-${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}-product-management-normalization-classification
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    permissions:
+      id-token: write
+      contents: read
+      issues: write
+    uses: ./.github/workflows/deploy-azd-service.yml
+    with:
+      serviceName: product-management-normalization-classification
+      environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}
+      location: ${{ github.event_name == 'workflow_dispatch' && inputs.location || 'centralus' }}
+      projectName: ${{ github.event_name == 'workflow_dispatch' && inputs.projectName || 'holidaypeakhub405' }}
+      imageTag: ${{ github.event_name == 'workflow_dispatch' && inputs.imageTag || github.sha }}
+      testedSourceSha: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceSha || github.sha }}
+      testedSourceRef: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceRef || github.ref }}
+      skipProvision: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.skipProvision) || 'true') }}
+      forceApimSync: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.forceApimSync) || 'true') }}
+      autoAllowAcrRunnerIp: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.autoAllowAcrRunnerIp) || 'true') }}
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/deploy-azd-search-enrichment-agent.yml
+++ b/.github/workflows/deploy-azd-search-enrichment-agent.yml
@@ -1,4 +1,4 @@
-name: deploy-azd-truth-agents (scoped entrypoint)
+name: deploy-azd-search-enrichment-agent (entrypoint)
 
 on:
   push:
@@ -6,18 +6,19 @@ on:
       - '**'
     paths:
       - apps/search-enrichment-agent/**
-      - apps/truth-ingestion/**
-      - apps/truth-enrichment/**
-      - apps/truth-export/**
-      - apps/truth-hitl/**
       - lib/**
       - azure.yaml
       - .infra/**
       - .kubernetes/**
       - .github/workflows/deploy-azd.yml
-      - .github/workflows/deploy-azd-truth.yml
+      - .github/workflows/deploy-azd-service.yml
+      - .github/workflows/deploy-azd-search-enrichment-agent.yml
   workflow_dispatch:
     inputs:
+      environment:
+        description: Target deployment environment
+        required: true
+        default: dev
       location:
         description: Azure location
         required: true
@@ -30,11 +31,24 @@ on:
         description: Image tag to deploy
         required: true
         default: latest
-      forceApimSync:
-        description: Explicitly force APIM sync after deploying truth agents during an image-only update
+      testedSourceSha:
+        description: Optional tested source commit SHA to deploy
+        required: false
+        default: ''
+      testedSourceRef:
+        description: Optional tested source ref to deploy when testedSourceSha is empty
+        required: false
+        default: ''
+      skipProvision:
+        description: Skip azd provision and reuse the current environment infrastructure
         required: true
         type: boolean
-        default: false
+        default: true
+      forceApimSync:
+        description: Force APIM sync and smoke checks even when no changed services are detected
+        required: true
+        type: boolean
+        default: true
       autoAllowAcrRunnerIp:
         description: Temporarily allow GitHub runner egress IP in ACR firewall during deploy
         required: true
@@ -46,7 +60,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: deploy-azd-truth-agents
+  group: deploy-azd-${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}-search-enrichment-agent
   cancel-in-progress: false
 
 jobs:
@@ -55,21 +69,18 @@ jobs:
       id-token: write
       contents: read
       issues: write
-    uses: ./.github/workflows/deploy-azd.yml
+    uses: ./.github/workflows/deploy-azd-service.yml
     with:
-      environment: truth-agents
+      serviceName: search-enrichment-agent
+      environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}
       location: ${{ github.event_name == 'workflow_dispatch' && inputs.location || 'centralus' }}
       projectName: ${{ github.event_name == 'workflow_dispatch' && inputs.projectName || 'holidaypeakhub405' }}
       imageTag: ${{ github.event_name == 'workflow_dispatch' && inputs.imageTag || github.sha }}
-      deployStatic: false
-      uiOnly: false
-      apiBaseUrl: ''
-      deployChangedOnly: true
-      skipProvision: true
-      forceApimSync: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.forceApimSync) || 'false') }}
+      testedSourceSha: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceSha || github.sha }}
+      testedSourceRef: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceRef || github.ref }}
+      skipProvision: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.skipProvision) || 'true') }}
+      forceApimSync: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.forceApimSync) || 'true') }}
       autoAllowAcrRunnerIp: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.autoAllowAcrRunnerIp) || 'true') }}
-      skipApiSmokeChecks: false
-      serviceFilter: search-enrichment-agent,truth-ingestion,truth-enrichment,truth-export,truth-hitl
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/deploy-azd-service.yml
+++ b/.github/workflows/deploy-azd-service.yml
@@ -12,6 +12,11 @@ on:
         required: false
         type: string
         default: dev
+      githubEnvironment:
+        description: GitHub Actions environment name used for approvals and protection rules
+        required: false
+        type: string
+        default: branch
       location:
         description: Azure location
         required: false
@@ -93,6 +98,7 @@ jobs:
     uses: ./.github/workflows/deploy-azd.yml
     with:
       environment: ${{ inputs.environment }}
+      githubEnvironment: ${{ inputs.githubEnvironment }}
       location: ${{ inputs.location }}
       projectName: ${{ inputs.projectName }}
       imageTag: ${{ inputs.imageTag }}

--- a/.github/workflows/deploy-azd-service.yml
+++ b/.github/workflows/deploy-azd-service.yml
@@ -1,0 +1,113 @@
+name: deploy-azd-service (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      serviceName:
+        description: Exact AZD service name from azure.yaml
+        required: true
+        type: string
+      environment:
+        description: Deployment environment name
+        required: false
+        type: string
+        default: dev
+      location:
+        description: Azure location
+        required: false
+        type: string
+        default: centralus
+      projectName:
+        description: Project prefix used by naming convention
+        required: false
+        type: string
+        default: holidaypeakhub405
+      imageTag:
+        description: Image tag to deploy
+        required: false
+        type: string
+        default: latest
+      testedSourceSha:
+        description: Optional tested source commit SHA to deploy
+        required: false
+        type: string
+        default: ''
+      testedSourceRef:
+        description: Optional tested source ref to deploy
+        required: false
+        type: string
+        default: ''
+      skipProvision:
+        description: Skip azd provision and reuse the current environment infrastructure
+        required: false
+        type: boolean
+        default: true
+      forceApimSync:
+        description: Force APIM sync and smoke checks
+        required: false
+        type: boolean
+        default: true
+      autoAllowAcrRunnerIp:
+        description: Temporarily allow the GitHub runner egress IP in the ACR firewall during deploy
+        required: false
+        type: boolean
+        default: true
+    secrets:
+      AZURE_CLIENT_ID:
+        required: true
+      AZURE_TENANT_ID:
+        required: true
+      AZURE_SUBSCRIPTION_ID:
+        required: true
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: deploy-azd-${{ inputs.environment }}-${{ inputs.serviceName }}
+  cancel-in-progress: false
+
+jobs:
+  validate-environment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce non-prod wrapper policy
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          TARGET_ENV="${{ inputs.environment }}"
+          if [ "$TARGET_ENV" = "prod" ]; then
+            echo "Service-scoped deployment wrappers are restricted to non-production targets." >&2
+            echo "Use the production release workflow for prod deployments." >&2
+            exit 1
+          fi
+
+  deploy:
+    needs: validate-environment
+    permissions:
+      id-token: write
+      contents: read
+      issues: write
+    uses: ./.github/workflows/deploy-azd.yml
+    with:
+      environment: ${{ inputs.environment }}
+      location: ${{ inputs.location }}
+      projectName: ${{ inputs.projectName }}
+      imageTag: ${{ inputs.imageTag }}
+      sourceSha: ${{ inputs.testedSourceSha }}
+      sourceRef: ${{ inputs.testedSourceRef }}
+      deployStatic: false
+      uiOnly: false
+      apiBaseUrl: ''
+      deployChangedOnly: true
+      skipProvision: ${{ inputs.skipProvision }}
+      serviceFilter: ${{ inputs.serviceName }}
+      forceApimSync: ${{ inputs.forceApimSync }}
+      autoAllowAcrRunnerIp: ${{ inputs.autoAllowAcrRunnerIp }}
+      skipApiSmokeChecks: false
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/deploy-azd-truth-enrichment.yml
+++ b/.github/workflows/deploy-azd-truth-enrichment.yml
@@ -1,23 +1,24 @@
-name: deploy-azd-truth-agents (scoped entrypoint)
+name: deploy-azd-truth-enrichment (entrypoint)
 
 on:
   push:
     branches:
       - '**'
     paths:
-      - apps/search-enrichment-agent/**
-      - apps/truth-ingestion/**
       - apps/truth-enrichment/**
-      - apps/truth-export/**
-      - apps/truth-hitl/**
       - lib/**
       - azure.yaml
       - .infra/**
       - .kubernetes/**
       - .github/workflows/deploy-azd.yml
-      - .github/workflows/deploy-azd-truth.yml
+      - .github/workflows/deploy-azd-service.yml
+      - .github/workflows/deploy-azd-truth-enrichment.yml
   workflow_dispatch:
     inputs:
+      environment:
+        description: Target deployment environment
+        required: true
+        default: dev
       location:
         description: Azure location
         required: true
@@ -30,11 +31,24 @@ on:
         description: Image tag to deploy
         required: true
         default: latest
-      forceApimSync:
-        description: Explicitly force APIM sync after deploying truth agents during an image-only update
+      testedSourceSha:
+        description: Optional tested source commit SHA to deploy
+        required: false
+        default: ''
+      testedSourceRef:
+        description: Optional tested source ref to deploy when testedSourceSha is empty
+        required: false
+        default: ''
+      skipProvision:
+        description: Skip azd provision and reuse the current environment infrastructure
         required: true
         type: boolean
-        default: false
+        default: true
+      forceApimSync:
+        description: Force APIM sync and smoke checks even when no changed services are detected
+        required: true
+        type: boolean
+        default: true
       autoAllowAcrRunnerIp:
         description: Temporarily allow GitHub runner egress IP in ACR firewall during deploy
         required: true
@@ -46,7 +60,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: deploy-azd-truth-agents
+  group: deploy-azd-${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}-truth-enrichment
   cancel-in-progress: false
 
 jobs:
@@ -55,21 +69,18 @@ jobs:
       id-token: write
       contents: read
       issues: write
-    uses: ./.github/workflows/deploy-azd.yml
+    uses: ./.github/workflows/deploy-azd-service.yml
     with:
-      environment: truth-agents
+      serviceName: truth-enrichment
+      environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}
       location: ${{ github.event_name == 'workflow_dispatch' && inputs.location || 'centralus' }}
       projectName: ${{ github.event_name == 'workflow_dispatch' && inputs.projectName || 'holidaypeakhub405' }}
       imageTag: ${{ github.event_name == 'workflow_dispatch' && inputs.imageTag || github.sha }}
-      deployStatic: false
-      uiOnly: false
-      apiBaseUrl: ''
-      deployChangedOnly: true
-      skipProvision: true
-      forceApimSync: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.forceApimSync) || 'false') }}
+      testedSourceSha: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceSha || github.sha }}
+      testedSourceRef: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceRef || github.ref }}
+      skipProvision: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.skipProvision) || 'true') }}
+      forceApimSync: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.forceApimSync) || 'true') }}
       autoAllowAcrRunnerIp: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.autoAllowAcrRunnerIp) || 'true') }}
-      skipApiSmokeChecks: false
-      serviceFilter: search-enrichment-agent,truth-ingestion,truth-enrichment,truth-export,truth-hitl
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/deploy-azd-truth-export.yml
+++ b/.github/workflows/deploy-azd-truth-export.yml
@@ -1,23 +1,24 @@
-name: deploy-azd-truth-agents (scoped entrypoint)
+name: deploy-azd-truth-export (entrypoint)
 
 on:
   push:
     branches:
       - '**'
     paths:
-      - apps/search-enrichment-agent/**
-      - apps/truth-ingestion/**
-      - apps/truth-enrichment/**
       - apps/truth-export/**
-      - apps/truth-hitl/**
       - lib/**
       - azure.yaml
       - .infra/**
       - .kubernetes/**
       - .github/workflows/deploy-azd.yml
-      - .github/workflows/deploy-azd-truth.yml
+      - .github/workflows/deploy-azd-service.yml
+      - .github/workflows/deploy-azd-truth-export.yml
   workflow_dispatch:
     inputs:
+      environment:
+        description: Target deployment environment
+        required: true
+        default: dev
       location:
         description: Azure location
         required: true
@@ -30,11 +31,24 @@ on:
         description: Image tag to deploy
         required: true
         default: latest
-      forceApimSync:
-        description: Explicitly force APIM sync after deploying truth agents during an image-only update
+      testedSourceSha:
+        description: Optional tested source commit SHA to deploy
+        required: false
+        default: ''
+      testedSourceRef:
+        description: Optional tested source ref to deploy when testedSourceSha is empty
+        required: false
+        default: ''
+      skipProvision:
+        description: Skip azd provision and reuse the current environment infrastructure
         required: true
         type: boolean
-        default: false
+        default: true
+      forceApimSync:
+        description: Force APIM sync and smoke checks even when no changed services are detected
+        required: true
+        type: boolean
+        default: true
       autoAllowAcrRunnerIp:
         description: Temporarily allow GitHub runner egress IP in ACR firewall during deploy
         required: true
@@ -46,7 +60,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: deploy-azd-truth-agents
+  group: deploy-azd-${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}-truth-export
   cancel-in-progress: false
 
 jobs:
@@ -55,21 +69,18 @@ jobs:
       id-token: write
       contents: read
       issues: write
-    uses: ./.github/workflows/deploy-azd.yml
+    uses: ./.github/workflows/deploy-azd-service.yml
     with:
-      environment: truth-agents
+      serviceName: truth-export
+      environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}
       location: ${{ github.event_name == 'workflow_dispatch' && inputs.location || 'centralus' }}
       projectName: ${{ github.event_name == 'workflow_dispatch' && inputs.projectName || 'holidaypeakhub405' }}
       imageTag: ${{ github.event_name == 'workflow_dispatch' && inputs.imageTag || github.sha }}
-      deployStatic: false
-      uiOnly: false
-      apiBaseUrl: ''
-      deployChangedOnly: true
-      skipProvision: true
-      forceApimSync: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.forceApimSync) || 'false') }}
+      testedSourceSha: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceSha || github.sha }}
+      testedSourceRef: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceRef || github.ref }}
+      skipProvision: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.skipProvision) || 'true') }}
+      forceApimSync: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.forceApimSync) || 'true') }}
       autoAllowAcrRunnerIp: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.autoAllowAcrRunnerIp) || 'true') }}
-      skipApiSmokeChecks: false
-      serviceFilter: search-enrichment-agent,truth-ingestion,truth-enrichment,truth-export,truth-hitl
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/deploy-azd-truth-hitl.yml
+++ b/.github/workflows/deploy-azd-truth-hitl.yml
@@ -1,23 +1,24 @@
-name: deploy-azd-truth-agents (scoped entrypoint)
+name: deploy-azd-truth-hitl (entrypoint)
 
 on:
   push:
     branches:
       - '**'
     paths:
-      - apps/search-enrichment-agent/**
-      - apps/truth-ingestion/**
-      - apps/truth-enrichment/**
-      - apps/truth-export/**
       - apps/truth-hitl/**
       - lib/**
       - azure.yaml
       - .infra/**
       - .kubernetes/**
       - .github/workflows/deploy-azd.yml
-      - .github/workflows/deploy-azd-truth.yml
+      - .github/workflows/deploy-azd-service.yml
+      - .github/workflows/deploy-azd-truth-hitl.yml
   workflow_dispatch:
     inputs:
+      environment:
+        description: Target deployment environment
+        required: true
+        default: dev
       location:
         description: Azure location
         required: true
@@ -30,11 +31,24 @@ on:
         description: Image tag to deploy
         required: true
         default: latest
-      forceApimSync:
-        description: Explicitly force APIM sync after deploying truth agents during an image-only update
+      testedSourceSha:
+        description: Optional tested source commit SHA to deploy
+        required: false
+        default: ''
+      testedSourceRef:
+        description: Optional tested source ref to deploy when testedSourceSha is empty
+        required: false
+        default: ''
+      skipProvision:
+        description: Skip azd provision and reuse the current environment infrastructure
         required: true
         type: boolean
-        default: false
+        default: true
+      forceApimSync:
+        description: Force APIM sync and smoke checks even when no changed services are detected
+        required: true
+        type: boolean
+        default: true
       autoAllowAcrRunnerIp:
         description: Temporarily allow GitHub runner egress IP in ACR firewall during deploy
         required: true
@@ -46,7 +60,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: deploy-azd-truth-agents
+  group: deploy-azd-${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}-truth-hitl
   cancel-in-progress: false
 
 jobs:
@@ -55,21 +69,18 @@ jobs:
       id-token: write
       contents: read
       issues: write
-    uses: ./.github/workflows/deploy-azd.yml
+    uses: ./.github/workflows/deploy-azd-service.yml
     with:
-      environment: truth-agents
+      serviceName: truth-hitl
+      environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}
       location: ${{ github.event_name == 'workflow_dispatch' && inputs.location || 'centralus' }}
       projectName: ${{ github.event_name == 'workflow_dispatch' && inputs.projectName || 'holidaypeakhub405' }}
       imageTag: ${{ github.event_name == 'workflow_dispatch' && inputs.imageTag || github.sha }}
-      deployStatic: false
-      uiOnly: false
-      apiBaseUrl: ''
-      deployChangedOnly: true
-      skipProvision: true
-      forceApimSync: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.forceApimSync) || 'false') }}
+      testedSourceSha: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceSha || github.sha }}
+      testedSourceRef: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceRef || github.ref }}
+      skipProvision: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.skipProvision) || 'true') }}
+      forceApimSync: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.forceApimSync) || 'true') }}
       autoAllowAcrRunnerIp: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.autoAllowAcrRunnerIp) || 'true') }}
-      skipApiSmokeChecks: false
-      serviceFilter: search-enrichment-agent,truth-ingestion,truth-enrichment,truth-export,truth-hitl
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/deploy-azd-truth-ingestion.yml
+++ b/.github/workflows/deploy-azd-truth-ingestion.yml
@@ -1,23 +1,24 @@
-name: deploy-azd-truth-agents (scoped entrypoint)
+name: deploy-azd-truth-ingestion (entrypoint)
 
 on:
   push:
     branches:
       - '**'
     paths:
-      - apps/search-enrichment-agent/**
       - apps/truth-ingestion/**
-      - apps/truth-enrichment/**
-      - apps/truth-export/**
-      - apps/truth-hitl/**
       - lib/**
       - azure.yaml
       - .infra/**
       - .kubernetes/**
       - .github/workflows/deploy-azd.yml
-      - .github/workflows/deploy-azd-truth.yml
+      - .github/workflows/deploy-azd-service.yml
+      - .github/workflows/deploy-azd-truth-ingestion.yml
   workflow_dispatch:
     inputs:
+      environment:
+        description: Target deployment environment
+        required: true
+        default: dev
       location:
         description: Azure location
         required: true
@@ -30,11 +31,24 @@ on:
         description: Image tag to deploy
         required: true
         default: latest
-      forceApimSync:
-        description: Explicitly force APIM sync after deploying truth agents during an image-only update
+      testedSourceSha:
+        description: Optional tested source commit SHA to deploy
+        required: false
+        default: ''
+      testedSourceRef:
+        description: Optional tested source ref to deploy when testedSourceSha is empty
+        required: false
+        default: ''
+      skipProvision:
+        description: Skip azd provision and reuse the current environment infrastructure
         required: true
         type: boolean
-        default: false
+        default: true
+      forceApimSync:
+        description: Force APIM sync and smoke checks even when no changed services are detected
+        required: true
+        type: boolean
+        default: true
       autoAllowAcrRunnerIp:
         description: Temporarily allow GitHub runner egress IP in ACR firewall during deploy
         required: true
@@ -46,7 +60,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: deploy-azd-truth-agents
+  group: deploy-azd-${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}-truth-ingestion
   cancel-in-progress: false
 
 jobs:
@@ -55,21 +69,18 @@ jobs:
       id-token: write
       contents: read
       issues: write
-    uses: ./.github/workflows/deploy-azd.yml
+    uses: ./.github/workflows/deploy-azd-service.yml
     with:
-      environment: truth-agents
+      serviceName: truth-ingestion
+      environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}
       location: ${{ github.event_name == 'workflow_dispatch' && inputs.location || 'centralus' }}
       projectName: ${{ github.event_name == 'workflow_dispatch' && inputs.projectName || 'holidaypeakhub405' }}
       imageTag: ${{ github.event_name == 'workflow_dispatch' && inputs.imageTag || github.sha }}
-      deployStatic: false
-      uiOnly: false
-      apiBaseUrl: ''
-      deployChangedOnly: true
-      skipProvision: true
-      forceApimSync: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.forceApimSync) || 'false') }}
+      testedSourceSha: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceSha || github.sha }}
+      testedSourceRef: ${{ github.event_name == 'workflow_dispatch' && inputs.testedSourceRef || github.ref }}
+      skipProvision: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.skipProvision) || 'true') }}
+      forceApimSync: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.forceApimSync) || 'true') }}
       autoAllowAcrRunnerIp: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.autoAllowAcrRunnerIp) || 'true') }}
-      skipApiSmokeChecks: false
-      serviceFilter: search-enrichment-agent,truth-ingestion,truth-enrichment,truth-export,truth-hitl
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/deploy-azd.yml
+++ b/.github/workflows/deploy-azd.yml
@@ -7,6 +7,11 @@ on:
         description: Deployment environment name (for azd -e)
         required: true
         type: string
+      githubEnvironment:
+        description: GitHub Actions environment name used for approvals and protection rules
+        required: false
+        type: string
+        default: branch
       location:
         description: Azure location
         required: true
@@ -336,7 +341,7 @@ jobs:
     if: ${{ !inputs.uiOnly }}
     needs: detect-changes
     runs-on: ubuntu-latest
-    environment: ${{ inputs.environment }}
+    environment: ${{ inputs.githubEnvironment }}
     outputs:
       AI_SERVICES_NAME: ${{ steps.outputs.outputs.AI_SERVICES_NAME }}
       AI_SEARCH_NAME: ${{ steps.outputs.outputs.AI_SEARCH_NAME }}
@@ -1103,7 +1108,7 @@ jobs:
     needs:
       - provision
       - detect-changes
-    environment: ${{ inputs.environment }}
+    environment: ${{ inputs.githubEnvironment }}
     outputs:
       acr_name: ${{ steps.registry.outputs.acr_name }}
       rg_name: ${{ steps.registry.outputs.rg_name }}
@@ -1281,7 +1286,7 @@ jobs:
       - provision
       - detect-changes
       - prepare-acr-build-access
-    environment: ${{ inputs.environment }}
+    environment: ${{ inputs.githubEnvironment }}
     strategy:
       fail-fast: false
       matrix:
@@ -1572,7 +1577,7 @@ jobs:
       - detect-changes
       - prepare-acr-build-access
       - build-aks-images
-    environment: ${{ inputs.environment }}
+    environment: ${{ inputs.githubEnvironment }}
     env:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
@@ -1661,7 +1666,7 @@ jobs:
       - provision
       - detect-changes
     if: ${{ !inputs.skipProvision && needs.detect-changes.outputs.infra_changed == 'true' }}
-    environment: ${{ inputs.environment }}
+    environment: ${{ inputs.githubEnvironment }}
     env:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
@@ -1695,7 +1700,7 @@ jobs:
       - build-aks-images
       - restore-acr-build-access
     if: ${{ !inputs.uiOnly && needs.detect-changes.outputs.crud_changed == 'true' }}
-    environment: ${{ inputs.environment }}
+    environment: ${{ inputs.githubEnvironment }}
     env:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
@@ -1906,7 +1911,7 @@ jobs:
       - sync-apim
       - ensure-foundry-agents
       - smoke-apim
-    environment: ${{ inputs.environment }}
+    environment: ${{ inputs.githubEnvironment }}
     env:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
@@ -2153,7 +2158,7 @@ jobs:
   deploy-ui-token:
     runs-on: ubuntu-latest
     if: ${{ inputs.deployStatic && inputs.uiOnly }}
-    environment: ${{ inputs.environment }}
+    environment: ${{ inputs.githubEnvironment }}
     env:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
@@ -2362,7 +2367,7 @@ jobs:
       - detect-changes
       - build-aks-images
       - restore-acr-build-access
-    environment: ${{ inputs.environment }}
+    environment: ${{ inputs.githubEnvironment }}
     strategy:
       fail-fast: false
       matrix:
@@ -2567,7 +2572,7 @@ jobs:
     needs:
       - commit-rendered-manifests
       - detect-changes
-    environment: ${{ inputs.environment }}
+    environment: ${{ inputs.githubEnvironment }}
     env:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
@@ -2677,7 +2682,7 @@ jobs:
       - deploy-crud
       - deploy-agents
       - detect-changes
-    environment: ${{ inputs.environment }}
+    environment: ${{ inputs.githubEnvironment }}
     outputs:
       approved_backend_hostnames: ${{ steps.resolve.outputs.approved_backend_hostnames }}
       approved_backend_scheme: ${{ steps.resolve.outputs.approved_backend_scheme }}
@@ -2816,7 +2821,7 @@ jobs:
       - deploy-agents
       - detect-changes
       - validate-agc-readiness
-    environment: ${{ inputs.environment }}
+    environment: ${{ inputs.githubEnvironment }}
     env:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
@@ -2887,7 +2892,7 @@ jobs:
     needs:
       - detect-changes
       - sync-apim
-    environment: ${{ inputs.environment }}
+    environment: ${{ inputs.githubEnvironment }}
     env:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
@@ -2918,7 +2923,7 @@ jobs:
       - sync-apim
       - ensure-foundry-agents
       - validate-agc-readiness
-    environment: ${{ inputs.environment }}
+    environment: ${{ inputs.githubEnvironment }}
     env:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
@@ -3152,7 +3157,7 @@ jobs:
     needs:
       - deploy-agents
       - detect-changes
-    environment: ${{ inputs.environment }}
+    environment: ${{ inputs.githubEnvironment }}
     env:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
@@ -3324,7 +3329,7 @@ jobs:
       - smoke-apim
       - deploy-ui
       - ensure-foundry-agents
-    environment: ${{ inputs.environment }}
+    environment: ${{ inputs.githubEnvironment }}
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/deploy-ui-swa.yml
+++ b/.github/workflows/deploy-ui-swa.yml
@@ -1,6 +1,15 @@
 name: deploy-ui-swa
 
 on:
+  push:
+    branches:
+      - '**'
+    paths:
+      - apps/ui/**
+      - lib/**
+      - azure.yaml
+      - .infra/**
+      - .github/workflows/deploy-ui-swa.yml
   workflow_dispatch:
     inputs:
       environment:
@@ -11,6 +20,14 @@ on:
         description: Project prefix used by naming convention
         required: true
         default: holidaypeakhub405
+      sourceSha:
+        description: Optional source commit SHA to deploy for the UI build
+        required: false
+        default: ''
+      sourceRef:
+        description: Optional source ref to deploy for the UI build when sourceSha is empty
+        required: false
+        default: ''
       apiUrl:
         description: Optional API base URL override (must match APIM gateway URL for drift safety)
         required: false
@@ -21,19 +38,44 @@ permissions:
   contents: read
 
 concurrency:
-  group: deploy-ui-swa-${{ inputs.environment }}
+  group: deploy-ui-swa-${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}
   cancel-in-progress: false
 
 jobs:
   deploy-ui:
     runs-on: ubuntu-latest
-    environment: ${{ inputs.environment }}
+    environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}
     env:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      DEPLOY_ENVIRONMENT: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}
+      DEPLOY_PROJECT_NAME: ${{ github.event_name == 'workflow_dispatch' && inputs.projectName || 'holidaypeakhub405' }}
+      DEPLOY_API_URL_OVERRIDE: ${{ github.event_name == 'workflow_dispatch' && inputs.apiUrl || '' }}
+      DEPLOY_SOURCE_CHECKOUT_REF: ${{ inputs.sourceSha != '' && inputs.sourceSha || (inputs.sourceRef != '' && inputs.sourceRef || github.ref) }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ env.DEPLOY_SOURCE_CHECKOUT_REF }}
+
+      - name: Enforce environment policy
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          TARGET_ENV="${DEPLOY_ENVIRONMENT}"
+          if [ "$TARGET_ENV" = "prod" ]; then
+            if [ "${{ github.event_name }}" = "push" ]; then
+              echo "Push-triggered UI deployments are restricted to dev." >&2
+              exit 1
+            fi
+
+            if [ "${GITHUB_REF}" != "refs/heads/main" ] && [[ "${GITHUB_REF}" != refs/tags/v* ]]; then
+              echo "Manual prod UI deployments must start from main or an approved release tag." >&2
+              exit 1
+            fi
+          fi
 
       - name: Azure login (OIDC)
         uses: azure/login@v2
@@ -53,10 +95,10 @@ jobs:
         run: |
           set -euo pipefail
 
-          RESOURCE_GROUP="${{ inputs.projectName }}-${{ inputs.environment }}-rg"
+          RESOURCE_GROUP="${DEPLOY_PROJECT_NAME}-${DEPLOY_ENVIRONMENT}-rg"
 
           APIM_URL=$(az apim show \
-            --name "${{ inputs.projectName }}-${{ inputs.environment }}-apim" \
+            --name "${DEPLOY_PROJECT_NAME}-${DEPLOY_ENVIRONMENT}-apim" \
             --resource-group "$RESOURCE_GROUP" \
             --query "gatewayUrl" -o tsv)
 
@@ -64,14 +106,14 @@ jobs:
           APIM_URL="${APIM_URL%/}"
 
           if [ -z "$APIM_URL" ]; then
-            echo "Failed to resolve APIM gateway URL for environment '${{ inputs.environment }}'." >&2
+            echo "Failed to resolve APIM gateway URL for environment '${DEPLOY_ENVIRONMENT}'." >&2
             exit 1
           fi
 
           RESOLVED_API_URL="$APIM_URL"
 
-          if [ -n "${{ inputs.apiUrl }}" ]; then
-            OVERRIDE_API_URL="$(echo "${{ inputs.apiUrl }}" | xargs)"
+          if [ -n "${DEPLOY_API_URL_OVERRIDE}" ]; then
+            OVERRIDE_API_URL="$(echo "${DEPLOY_API_URL_OVERRIDE}" | xargs)"
             OVERRIDE_API_URL="${OVERRIDE_API_URL%/}"
 
             if [ "$OVERRIDE_API_URL" != "$APIM_URL" ]; then
@@ -128,8 +170,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          RESOURCE_GROUP="${{ inputs.projectName }}-${{ inputs.environment }}-rg"
-          SWA_NAME="${{ inputs.projectName }}-ui-${{ inputs.environment }}"
+          RESOURCE_GROUP="${DEPLOY_PROJECT_NAME}-${DEPLOY_ENVIRONMENT}-rg"
+          SWA_NAME="${DEPLOY_PROJECT_NAME}-ui-${DEPLOY_ENVIRONMENT}"
 
           mapfile -t AZD_UI_SWAS < <(az resource list \
             --resource-group "$RESOURCE_GROUP" \
@@ -173,8 +215,8 @@ jobs:
           NEXT_PUBLIC_API_URL: ${{ steps.api.outputs.api_url }}
           NEXT_PUBLIC_CRUD_API_URL: ${{ steps.api.outputs.crud_api_url }}
           NEXT_PUBLIC_AGENT_API_URL: ${{ steps.api.outputs.agent_api_url }}
-          NEXT_PUBLIC_DEV_AUTH_MOCK: ${{ inputs.environment == 'dev' && 'true' || vars.NEXT_PUBLIC_DEV_AUTH_MOCK }}
-          NEXT_PUBLIC_DEV_AUTH_MOCK_ALLOW_PROD: ${{ inputs.environment == 'dev' && 'false' || vars.NEXT_PUBLIC_DEV_AUTH_MOCK_ALLOW_PROD }}
+          NEXT_PUBLIC_DEV_AUTH_MOCK: ${{ env.DEPLOY_ENVIRONMENT == 'dev' && 'true' || vars.NEXT_PUBLIC_DEV_AUTH_MOCK }}
+          NEXT_PUBLIC_DEV_AUTH_MOCK_ALLOW_PROD: ${{ env.DEPLOY_ENVIRONMENT == 'dev' && 'false' || vars.NEXT_PUBLIC_DEV_AUTH_MOCK_ALLOW_PROD }}
           NEXT_PUBLIC_ENTRA_CLIENT_ID: ${{ vars.NEXT_PUBLIC_ENTRA_CLIENT_ID }}
           NEXT_PUBLIC_ENTRA_TENANT_ID: ${{ vars.NEXT_PUBLIC_ENTRA_TENANT_ID }}
 
@@ -183,7 +225,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          RESOURCE_GROUP="${{ inputs.projectName }}-${{ inputs.environment }}-rg"
+          RESOURCE_GROUP="${DEPLOY_PROJECT_NAME}-${DEPLOY_ENVIRONMENT}-rg"
           SWA_NAME="${{ steps.swa.outputs.swa_name }}"
 
           SWA_HOSTNAME=$(az staticwebapp show \

--- a/.github/workflows/deploy-ui-swa.yml
+++ b/.github/workflows/deploy-ui-swa.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
     inputs:
       environment:
-        description: Target GitHub environment
+        description: Target Azure environment
         required: true
         default: dev
       projectName:
@@ -44,7 +44,7 @@ concurrency:
 jobs:
   deploy-ui:
     runs-on: ubuntu-latest
-    environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}
+    environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'branch' }}
     env:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -57,6 +57,11 @@ jobs:
           for d in apps/*/src; do
             [ -f "$d/pyproject.toml" ] && uv pip install --system -e "$d" || echo "Skipping $d"
           done
+      - name: Fix agent-framework init overwrite
+        run: |
+          # App installs pull agent-framework[all] which includes sub-packages
+          # that overwrite agent_framework/__init__.py with an empty file.
+          uv pip install --system --reinstall-package agent-framework-core agent-framework-core
       - name: Lint
         run: |
           python -m isort --check-only lib apps

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
           uv pip install --system -e ./lib/src
           uv pip install --system --reinstall-package agent-framework-core agent-framework-core
       - name: Verify core imports
-        run: python -c "from agent_framework import BaseAgent; print(f'OK: {BaseAgent}')"
+        run: python -c "from agent_framework import BaseAgent; print('OK:', BaseAgent)"
       - name: Run lib tests with coverage
         working-directory: lib
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,27 @@ jobs:
               echo "Skipping $d (no pyproject.toml)"
             fi
           done
+      - name: Re-install lib (restore editable after app overrides)
+        run: uv pip install --system -e ./lib/src
+      - name: Verify core imports
+        run: |
+          python -c "
+          import traceback, sys
+          try:
+              from agent_framework import BaseAgent
+              print(f'OK: BaseAgent={BaseAgent}')
+          except Exception:
+              traceback.print_exc()
+              print('---')
+              # Show what is actually in the module
+              try:
+                  import agent_framework
+                  print(f'agent_framework.__file__={agent_framework.__file__}')
+                  print(f'dir={[x for x in dir(agent_framework) if not x.startswith(\"_\")]}')
+              except Exception:
+                  traceback.print_exc()
+              sys.exit(1)
+          "
       - name: Run lib tests with coverage
         working-directory: lib
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,34 +49,15 @@ jobs:
               echo "Skipping $d (no pyproject.toml)"
             fi
           done
-      - name: Re-install lib (restore editable after app overrides)
-        run: uv pip install --system -e ./lib/src
-      - name: Verify core imports
+      - name: Re-install lib and fix agent-framework
         run: |
-          python -c "
-          import traceback, sys, os, importlib.metadata
-          # Show installed agent-framework packages
-          for dist in importlib.metadata.distributions():
-              if 'agent-framework' in dist.metadata['Name']:
-                  loc = dist._path.parent
-                  print(f'{dist.metadata[\"Name\"]}=={dist.metadata[\"Version\"]}  @ {loc}')
-          # Show the actual __init__.py content
-          af_init = os.path.join(sys.prefix, 'lib', 'python3.13', 'site-packages', 'agent_framework', '__init__.py')
-          if os.path.exists(af_init):
-              content = open(af_init).read()
-              print(f'--- {af_init} ({len(content)} bytes) ---')
-              print(content[:2000])
-              print('--- END ---')
-          else:
-              print(f'NOT FOUND: {af_init}')
-          # Try the import
-          try:
-              from agent_framework import BaseAgent
-              print(f'OK: BaseAgent={BaseAgent}')
-          except Exception:
-              traceback.print_exc()
-              sys.exit(1)
-          "
+          # App installs pull agent-framework[all] from git-pinned lib on main.
+          # Sub-packages overwrite agent_framework/__init__.py with an empty file.
+          # Force-reinstall core so the real __init__.py is restored.
+          uv pip install --system -e ./lib/src
+          uv pip install --system --reinstall-package agent-framework-core agent-framework-core
+      - name: Verify core imports
+        run: python -c "from agent_framework import BaseAgent; print(f'OK: {BaseAgent}')"
       - name: Run lib tests with coverage
         working-directory: lib
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,20 +54,27 @@ jobs:
       - name: Verify core imports
         run: |
           python -c "
-          import traceback, sys
+          import traceback, sys, os, importlib.metadata
+          # Show installed agent-framework packages
+          for dist in importlib.metadata.distributions():
+              if 'agent-framework' in dist.metadata['Name']:
+                  loc = dist._path.parent
+                  print(f'{dist.metadata[\"Name\"]}=={dist.metadata[\"Version\"]}  @ {loc}')
+          # Show the actual __init__.py content
+          af_init = os.path.join(sys.prefix, 'lib', 'python3.13', 'site-packages', 'agent_framework', '__init__.py')
+          if os.path.exists(af_init):
+              content = open(af_init).read()
+              print(f'--- {af_init} ({len(content)} bytes) ---')
+              print(content[:2000])
+              print('--- END ---')
+          else:
+              print(f'NOT FOUND: {af_init}')
+          # Try the import
           try:
               from agent_framework import BaseAgent
               print(f'OK: BaseAgent={BaseAgent}')
           except Exception:
               traceback.print_exc()
-              print('---')
-              # Show what is actually in the module
-              try:
-                  import agent_framework
-                  print(f'agent_framework.__file__={agent_framework.__file__}')
-                  print(f'dir={[x for x in dir(agent_framework) if not x.startswith(\"_\")]}')
-              except Exception:
-                  traceback.print_exc()
               sys.exit(1)
           "
       - name: Run lib tests with coverage

--- a/apps/ecommerce-catalog-search/src/ecommerce_catalog_search/agents.py
+++ b/apps/ecommerce-catalog-search/src/ecommerce_catalog_search/agents.py
@@ -1016,11 +1016,32 @@ async def _search_products_keyword(
     ai_search_skus = ai_search_result.skus
     strict_mode = ai_search_required_runtime_enabled()
     if ai_search_skus:
+        # Fail-soft boundary: dependency exceptions should degrade search quality,
+        # not bubble out as a 500 response.
         resolved_products = await asyncio.gather(
             *[adapters.products.get_product(sku) for sku in ai_search_skus],
-            return_exceptions=False,
+            return_exceptions=True,
         )
-        ai_search_products = [product for product in resolved_products if product is not None]
+        ai_search_products: list[CatalogProduct] = []
+        for idx, resolved_product in enumerate(resolved_products):
+            if isinstance(resolved_product, Exception):
+                logger.warning(
+                    "catalog_search_product_lookup_failed",
+                    extra={
+                        "sku": ai_search_skus[idx],
+                        "query_length": len(query),
+                        "limit": limit,
+                    },
+                    exc_info=(
+                        type(resolved_product),
+                        resolved_product,
+                        resolved_product.__traceback__,
+                    ),
+                )
+                continue
+            if resolved_product is not None:
+                ai_search_products.append(resolved_product)
+
         if ai_search_products:
             ranked_products = _rank_products_by_query_relevance(
                 query=query,
@@ -1071,8 +1092,17 @@ async def _search_products_keyword(
         return []
 
     primary_sku = _coerce_query_to_sku(query)
-    primary = await adapters.products.get_product(primary_sku)
-    related = await adapters.products.get_related(primary_sku, limit=max(limit - 1, 0))
+    try:
+        primary = await adapters.products.get_product(primary_sku)
+        related = await adapters.products.get_related(primary_sku, limit=max(limit - 1, 0))
+    except Exception:  # pylint: disable=broad-exception-caught
+        logger.warning(
+            "catalog_search_sku_fallback_lookup_failed",
+            extra={"sku": primary_sku, "query_length": len(query), "limit": limit},
+            exc_info=True,
+        )
+        return []
+
     products = [p for p in [primary] if p is not None] + related
     return products[:limit]
 
@@ -1248,11 +1278,18 @@ async def _resolve_availability(
 ) -> list[str]:
     inventory = await asyncio.gather(
         *[adapters.inventory.get_item(product.sku) for product in products],
-        return_exceptions=False,
+        return_exceptions=True,
     )
     availability: list[str] = []
-    for item in inventory:
-        if item is None:
+    for idx, item in enumerate(inventory):
+        if isinstance(item, Exception):
+            logger.warning(
+                "catalog_search_inventory_lookup_failed",
+                extra={"sku": products[idx].sku},
+                exc_info=(type(item), item, item.__traceback__),
+            )
+            availability.append("unknown")
+        elif item is None:
             availability.append("unknown")
         elif item.available > 0:
             availability.append("in_stock")
@@ -1262,7 +1299,16 @@ async def _resolve_availability(
 
 
 async def _availability_for_sku(adapters: CatalogAdapters, sku: str) -> str:
-    item = await adapters.inventory.get_item(sku)
+    try:
+        item = await adapters.inventory.get_item(sku)
+    except Exception:  # pylint: disable=broad-exception-caught
+        logger.warning(
+            "catalog_search_inventory_lookup_failed",
+            extra={"sku": sku},
+            exc_info=True,
+        )
+        return "unknown"
+
     if item is None:
         return "unknown"
     return "in_stock" if item.available > 0 else "out_of_stock"

--- a/apps/ecommerce-catalog-search/tests/test_agents.py
+++ b/apps/ecommerce-catalog-search/tests/test_agents.py
@@ -1093,6 +1093,73 @@ class TestCatalogSearchAgent:
             mock_multi.assert_awaited_once()
             assert mock_search.await_count >= 2
 
+    @pytest.mark.asyncio
+    async def test_handle_inventory_lookup_error_returns_unknown_availability(
+        self, agent_dependencies, mock_catalog_product
+    ):
+        """Inventory dependency errors should degrade to unknown availability, not 500."""
+        with (
+            patch("ecommerce_catalog_search.agents.build_catalog_adapters") as mock_build,
+            patch("ecommerce_catalog_search.agents.search_catalog_skus_detailed") as mock_search,
+        ):
+            mock_search.return_value = AISearchSkuResult(skus=["SKU-001"])
+
+            mock_products = AsyncMock()
+            mock_products.get_product = AsyncMock(return_value=mock_catalog_product)
+            mock_products.get_related = AsyncMock(return_value=[])
+
+            mock_inventory = AsyncMock()
+            mock_inventory.get_item = AsyncMock(side_effect=RuntimeError("inventory unavailable"))
+
+            mock_build.return_value = CatalogAdapters(
+                products=mock_products,
+                inventory=mock_inventory,
+                mapping=AcpCatalogMapper(),
+            )
+
+            agent = CatalogSearchAgent(config=agent_dependencies)
+            result = await agent.handle({"query": "test product", "limit": 5, "mode": "keyword"})
+
+            assert len(result["results"]) == 1
+            assert result["results"][0]["item_id"] == "SKU-001"
+            assert result["results"][0]["availability"] == "unknown"
+            assert result["answer_source"] == "agent_fallback"
+
+    @pytest.mark.asyncio
+    async def test_handle_ai_search_product_lookup_error_returns_graceful_response(
+        self, agent_dependencies
+    ):
+        """AI-search SKU resolution errors should return deterministic empty results, not 500."""
+        with (
+            patch("ecommerce_catalog_search.agents.build_catalog_adapters") as mock_build,
+            patch("ecommerce_catalog_search.agents.search_catalog_skus_detailed") as mock_search,
+        ):
+            mock_search.return_value = AISearchSkuResult(skus=["SKU-001"])
+
+            mock_products = AsyncMock()
+            mock_products.search = AsyncMock(return_value=[])
+            mock_products.get_product = AsyncMock(side_effect=RuntimeError("product unavailable"))
+            mock_products.get_related = AsyncMock(return_value=[])
+
+            mock_inventory = AsyncMock()
+            mock_inventory.get_item = AsyncMock(return_value=None)
+
+            mock_build.return_value = CatalogAdapters(
+                products=mock_products,
+                inventory=mock_inventory,
+                mapping=AcpCatalogMapper(),
+            )
+
+            agent = CatalogSearchAgent(config=agent_dependencies)
+            result = await agent.handle({"query": "travel backpack", "limit": 5, "mode": "keyword"})
+
+            assert result["service"] == "test-catalog-search"
+            assert result["query"] == "travel backpack"
+            assert result["results"] == []
+            assert result["answer_source"] == "agent_fallback"
+            assert isinstance(result["summary"], str)
+            assert isinstance(result["recommendation"], str)
+
     def test_build_sub_queries_from_intent_entities(self, agent_dependencies):
         """Private sub-query builder should include deduped intent entities."""
         with patch("ecommerce_catalog_search.agents.build_catalog_adapters") as mock_build:

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,8 @@ The Python CLI in `.infra/cli.py` is scaffolding-only (`generate-bicep`, `genera
 
 In addition to the shared environment entrypoints, the repository supports thin service-scoped GitHub workflow wrappers for agent-by-agent deployment operations. These wrappers forward to the reusable azd deployment engine and can target an explicit branch or commit SHA without first merging to `main`.
 
+Push-triggered service and UI wrapper runs now use a non-protected GitHub deployment context while still targeting the selected Azure environment. This keeps feature-branch validation unblocked without weakening the protected `dev` live-validation boundary or the protected production release path.
+
 Examples:
 
 ```bash

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,18 @@ Python package management in this repository is uv-first. In CI, dependency inst
 Provisioning and deployment use the azd project defined in `azure.yaml`.
 The Python CLI in `.infra/cli.py` is scaffolding-only (`generate-bicep`, `generate-dockerfile`).
 
+### Service-scoped deployment wrappers
+
+In addition to the shared environment entrypoints, the repository supports thin service-scoped GitHub workflow wrappers for agent-by-agent deployment operations. These wrappers forward to the reusable azd deployment engine and can target an explicit branch or commit SHA without first merging to `main`.
+
+Examples:
+
+```bash
+gh workflow run deploy-azd-ecommerce-catalog-search.yml -f environment=dev -f testedSourceRef=refs/heads/feature/123-catalog-update
+gh workflow run deploy-azd-truth-enrichment.yml -f environment=dev -f testedSourceSha=<commit-sha>
+gh workflow run deploy-ui-swa.yml -f environment=dev -f sourceRef=refs/heads/feature/123-ui-update
+```
+
 ### Deployment Runbook (GitHub Actions + azd)
 
 Use environment-specific entry workflows:

--- a/docs/governance/infrastructure-governance.md
+++ b/docs/governance/infrastructure-governance.md
@@ -47,6 +47,11 @@ Infrastructure provisioning, deployment orchestration, identity, security contro
 
 - Entrypoint workflows should avoid duplicated job blocks for push/manual variants when the same reusable workflow call can be parameterized with event-aware expressions.
 - `deploy-azd-dev.yml` is maintained as a single reusable-workflow invocation path to reduce drift between trigger types.
+- Per-service wrappers should remain thin and delegate to the reusable deployment engine rather than duplicating Azure auth, build, and smoke-check logic.
+- The canonical naming pattern for service-scoped wrappers is `.github/workflows/deploy-azd-<service-name>.yml`, using the exact service key from `azure.yaml`.
+- Service-scoped wrappers are approved for branch-independent execution from any pushed branch when their scoped path filters match; manual runs may still pass `testedSourceSha` or `testedSourceRef` for explicit targeting.
+- Service-scoped wrappers are non-production by policy. Production rollouts must continue through the protected release path in `.github/workflows/deploy-azd-prod.yml`.
+- Shared `dev` auto-promotion remains governed separately through the protected environment flow, and GitHub Environment branch restrictions still apply where configured.
 
 ### Protected live validation boundary
 

--- a/lib/src/pyproject.toml
+++ b/lib/src/pyproject.toml
@@ -13,7 +13,6 @@ dependencies = [
     "uvicorn",
     "pydantic>=2",
     "pydantic-settings>=2",
-    "agent-framework>=1.0.1",
     "agent-framework-core>=1.0.1",
     "agent-framework-foundry>=1.0.1",
     "httpx",


### PR DESCRIPTION
## Summary
- add thin app-scoped deployment workflow wrappers for the service apps
- trigger deploy workflows from app updates on pushed branches using scoped path filters
- keep production protected through the release workflow while enabling dev branch deployments
- update UI deployment behavior and governance documentation

## Validation
- workflow validation completed with no errors
- repository push gates passed lint and tests before branch push