### PR TITLE
fix: detect and resolve Foundry agent instruction drift on startup (#864)

### DIFF
--- a/lib/src/holiday_peak_lib/agents/foundry.py
+++ b/lib/src/holiday_peak_lib/agents/foundry.py
@@ -1,8 +1,10 @@
 """Helpers for Azure AI Foundry (Microsoft Agent Framework) integration."""
 
 import asyncio
+import hashlib
 import inspect
 import json
+import logging
 import os
 from dataclasses import dataclass
 from time import perf_counter
@@ -33,6 +35,8 @@ _DEFAULT_FOUNDRY_INVOKE_TIMEOUT = float(os.getenv("AGENT_FOUNDRY_INVOKE_TIMEOUT_
 
 _FOUNDRY_RESOURCE_HOST_SUFFIX = ".cognitiveservices.azure.com"
 _FOUNDRY_PROJECT_PATH_PREFIX = "/api/projects/"
+
+_logger = logging.getLogger(__name__)
 
 
 class FoundryConfigurationError(ValueError):
@@ -368,6 +372,116 @@ async def _lookup_existing_agent(
     return None
 
 
+async def _get_latest_version_instructions(
+    agents_client: Any,
+    *,
+    agent_name: str,
+) -> str | None:
+    """Fetch the instructions from the latest version of an agent.
+
+    Returns ``None`` when versions cannot be retrieved.
+    """
+    try:
+        listed = await _call_first_available(
+            agents_client, ("list_versions",), agent_name=agent_name
+        )
+        if listed is None:
+            return None
+        if hasattr(listed, "__aiter__"):
+            async for version in listed:
+                defn = getattr(version, "definition", None)
+                return str(getattr(defn, "instructions", "") or "") if defn else ""
+            return None
+        if isinstance(listed, (list, tuple)) and listed:
+            defn = getattr(listed[0], "definition", None)
+            return str(getattr(defn, "instructions", "") or "") if defn else ""
+        return None
+    except (HttpResponseError, AttributeError, TypeError, RuntimeError) as exc:
+        _logger.warning("Failed to fetch versions for agent %r: %s", agent_name, exc)
+        return None
+
+
+def _instructions_hash(text: str) -> str:
+    """Return a short SHA-256 hex digest for logging."""
+    return hashlib.sha256(text.encode()).hexdigest()[:12]
+
+
+async def _check_instruction_drift(
+    agents_client: Any,
+    *,
+    config: FoundryAgentConfig,
+    found_result: dict[str, Any],
+    instructions: str | None,
+    model: str | None,
+) -> dict[str, Any] | None:
+    """Compare provided instructions with latest Foundry version; update if different.
+
+    Returns an updated result dict when a new version is created, or ``None``
+    when no drift is detected (caller should use the original *found_result*).
+    """
+    if not instructions or not instructions.strip():
+        return None
+
+    agent_name = found_result.get("agent_name") or config.agent_name
+    if not agent_name:
+        return None
+
+    remote_instructions = await _get_latest_version_instructions(
+        agents_client, agent_name=agent_name
+    )
+    if remote_instructions is None:
+        _logger.debug(
+            "Skipping drift check for %r — could not retrieve remote instructions",
+            agent_name,
+        )
+        return None
+
+    local_stripped = instructions.strip()
+    remote_stripped = remote_instructions.strip()
+    if local_stripped == remote_stripped:
+        _logger.debug(
+            "No instruction drift for agent %r (hash=%s, len=%d)",
+            agent_name,
+            _instructions_hash(local_stripped),
+            len(local_stripped),
+        )
+        return None
+
+    _logger.info(
+        "Instruction drift detected for agent %r: "
+        "remote_len=%d remote_hash=%s → local_len=%d local_hash=%s. "
+        "Creating new version.",
+        agent_name,
+        len(remote_stripped),
+        _instructions_hash(remote_stripped),
+        len(local_stripped),
+        _instructions_hash(local_stripped),
+    )
+
+    create_result = await _create_agent_version(
+        agents_client,
+        config=config,
+        resolved_agent_name=agent_name,
+        instructions=instructions,
+        model=model,
+    )
+
+    if create_result.get("created"):
+        return {
+            **create_result,
+            "status": "instructions_updated",
+            "agent_id": create_result.get("agent_id") or found_result.get("agent_id"),
+            "agent_name": create_result.get("agent_name") or agent_name,
+        }
+
+    _logger.warning(
+        "Drift detected for %r but version creation failed: %s",
+        agent_name,
+        create_result.get("status"),
+    )
+    return None
+
+
 async def _create_agent_version(
     agents_client: Any,
     *,
@@ -477,6 +591,16 @@ async def ensure_foundry_agent(
                 create_if_missing=create_if_missing,
             )
             if found is not None:
+                if found.get("status") in ("exists", "found_by_name"):
+                    drift_result = await _check_instruction_drift(
+                        agents_client,
+                        config=config,
+                        found_result=found,
+                        instructions=instructions,
+                        model=model,
+                    )
+                    if drift_result is not None:
+                        return drift_result
                 return found
 
             if not create_if_missing:

--- a/lib/src/holiday_peak_lib/app_factory_components/foundry_lifecycle.py
+++ b/lib/src/holiday_peak_lib/app_factory_components/foundry_lifecycle.py
@@ -12,7 +12,7 @@ DEFAULT_FOUNDRY_MODELS = {
     "rich": "gpt-5",
 }
 
-FOUNDRY_READY_STATUSES = frozenset({"exists", "found_by_name", "created"})
+FOUNDRY_READY_STATUSES = frozenset({"exists", "found_by_name", "created", "instructions_updated"})
 
 
 def _has_resolved_agent_id(agent_id: str | None) -> bool:

--- a/lib/tests/test_app_factory_foundry_lifecycle.py
+++ b/lib/tests/test_app_factory_foundry_lifecycle.py
@@ -205,3 +205,42 @@ async def test_ensure_role_skips_wiring_when_id_remains_pending():
     assert result["status"] == "missing"
     assert cfg.runtime_agent_id is None
     assert agent.slm is None
+
+
+@pytest.mark.asyncio
+async def test_ensure_role_wires_model_target_on_instructions_updated():
+    """Lifecycle manager wires model target when drift detection updates instructions."""
+    agent = _Agent(config=AgentDependencies())
+    cfg = FoundryAgentConfig(
+        endpoint=TEST_PROJECT_ENDPOINT,
+        agent_id="pending",
+        deployment_name="gpt-5-nano",
+    )
+    ensure_fn = AsyncMock(
+        return_value={
+            "status": "instructions_updated",
+            "agent_id": "svc-fast:2",
+            "agent_name": "svc-fast",
+            "created": True,
+        }
+    )
+
+    manager = FoundryLifecycleManager(
+        service_name="svc",
+        agent=agent,
+        slm_config=cfg,
+        llm_config=None,
+        ensure_foundry_agent_fn=ensure_fn,
+        build_foundry_model_target_fn=lambda _: "target-fast-v2",
+    )
+
+    result = await manager.ensure_role(
+        selected_role="fast",
+        config=cfg,
+        instructions="Updated instructions",
+        create_if_missing=True,
+    )
+
+    assert result["status"] == "instructions_updated"
+    assert cfg.runtime_agent_id == "svc-fast:2"
+    assert agent.slm == "target-fast-v2"

--- a/lib/tests/test_foundry.py
+++ b/lib/tests/test_foundry.py
@@ -611,3 +611,144 @@ class TestEnsureFoundryAgent:
 
         assert result["status"] == "agents_service_unavailable"
         assert result["created"] is False
+
+
+@pytest.mark.asyncio
+class TestInstructionDriftDetection:
+    """Tests for instruction drift detection in ensure_foundry_agent."""
+
+    async def test_drift_detected_creates_new_version(self):
+        """When remote instructions differ from local, a new version is created."""
+        config = FoundryAgentConfig(
+            endpoint=TEST_PROJECT_ENDPOINT,
+            agent_id="pending",
+            agent_name="svc-fast",
+            deployment_name="gpt-5-nano",
+        )
+        old_version = MagicMock()
+        old_version.definition = MagicMock()
+        old_version.definition.instructions = "Old instructions"
+
+        mock_client = MagicMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_agents = MagicMock()
+        mock_agents.create_version = AsyncMock(
+            return_value={"id": "svc-fast:2", "name": "svc-fast"}
+        )
+        mock_agents.list = AsyncMock(return_value=[{"id": "svc-fast:1", "name": "svc-fast"}])
+
+        async def _fake_list_versions(**kwargs):
+            return [old_version]
+
+        mock_agents.list_versions = _fake_list_versions
+        mock_client.agents = mock_agents
+
+        with patch("holiday_peak_lib.agents.foundry._ensure_client", return_value=mock_client):
+            result = await ensure_foundry_agent(
+                config,
+                agent_name="svc-fast",
+                instructions="New updated instructions",
+                create_if_missing=True,
+                model="gpt-5-nano",
+            )
+
+        assert result["status"] == "instructions_updated"
+        assert result["agent_id"] == "svc-fast:2"
+        mock_agents.create_version.assert_called_once()
+
+    async def test_no_drift_skips_version_creation(self):
+        """When remote and local instructions match, no new version is created."""
+        config = FoundryAgentConfig(
+            endpoint=TEST_PROJECT_ENDPOINT,
+            agent_id="pending",
+            agent_name="svc-fast",
+            deployment_name="gpt-5-nano",
+        )
+        matching_version = MagicMock()
+        matching_version.definition = MagicMock()
+        matching_version.definition.instructions = "Same instructions"
+
+        mock_client = MagicMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_agents = MagicMock()
+        mock_agents.create_version = AsyncMock()
+        mock_agents.list = AsyncMock(return_value=[{"id": "svc-fast:1", "name": "svc-fast"}])
+
+        async def _fake_list_versions(**kwargs):
+            return [matching_version]
+
+        mock_agents.list_versions = _fake_list_versions
+        mock_client.agents = mock_agents
+
+        with patch("holiday_peak_lib.agents.foundry._ensure_client", return_value=mock_client):
+            result = await ensure_foundry_agent(
+                config,
+                agent_name="svc-fast",
+                instructions="Same instructions",
+                create_if_missing=True,
+                model="gpt-5-nano",
+            )
+
+        assert result["status"] == "found_by_name"
+        mock_agents.create_version.assert_not_called()
+
+    async def test_no_instructions_skips_drift_check(self):
+        """When no instructions are provided, drift check is skipped entirely."""
+        config = FoundryAgentConfig(
+            endpoint=TEST_PROJECT_ENDPOINT,
+            agent_id="pending",
+            agent_name="svc-fast",
+            deployment_name="gpt-5-nano",
+        )
+        mock_client = MagicMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_agents = MagicMock()
+        mock_agents.create_version = AsyncMock()
+        mock_agents.list = AsyncMock(return_value=[{"id": "svc-fast:1", "name": "svc-fast"}])
+        mock_agents.list_versions = AsyncMock()
+        mock_client.agents = mock_agents
+
+        with patch("holiday_peak_lib.agents.foundry._ensure_client", return_value=mock_client):
+            result = await ensure_foundry_agent(
+                config,
+                agent_name="svc-fast",
+                create_if_missing=True,
+            )
+
+        assert result["status"] == "found_by_name"
+        mock_agents.list_versions.assert_not_called()
+        mock_agents.create_version.assert_not_called()
+
+    async def test_list_versions_failure_returns_original_result(self):
+        """When list_versions raises, the original found result is returned."""
+        config = FoundryAgentConfig(
+            endpoint=TEST_PROJECT_ENDPOINT,
+            agent_id="pending",
+            agent_name="svc-fast",
+            deployment_name="gpt-5-nano",
+        )
+        mock_client = MagicMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_agents = MagicMock()
+        mock_agents.create_version = AsyncMock()
+        mock_agents.list = AsyncMock(return_value=[{"id": "svc-fast:1", "name": "svc-fast"}])
+        mock_agents.list_versions = AsyncMock(
+            side_effect=HttpResponseError(message="service unavailable")
+        )
+        mock_client.agents = mock_agents
+
+        with patch("holiday_peak_lib.agents.foundry._ensure_client", return_value=mock_client):
+            result = await ensure_foundry_agent(
+                config,
+                agent_name="svc-fast",
+                instructions="Updated instructions",
+                create_if_missing=True,
+                model="gpt-5-nano",
+            )
+
+        assert result["status"] == "found_by_name"
+        mock_agents.create_version.assert_not_called()


### PR DESCRIPTION
## Summary

Closes #864

All 52 Foundry agents had stale/empty instructions because `ensure_foundry_agent` never compared or updated instructions after initial creation. This PR adds automatic instruction drift detection during the startup ensure flow.

## Changes

### `lib/src/holiday_peak_lib/agents/foundry.py`
- Add `_get_latest_version_instructions`: fetches instructions from latest agent version via `list_versions`  
- Add `_check_instruction_drift`: compares local vs remote instructions, creates new version when they differ
- Wire drift check into `ensure_foundry_agent` after lookup returns `exists`/`found_by_name`
- Add logging with instruction lengths and SHA-256 hashes for observability

### `lib/src/holiday_peak_lib/app_factory_components/foundry_lifecycle.py`
- Add `instructions_updated` to `FOUNDRY_READY_STATUSES`

### Tests
- 4 new unit tests in `test_foundry.py`: drift detected, no drift, no instructions, list_versions failure
- 1 new lifecycle test in `test_app_factory_foundry_lifecycle.py`: instructions_updated wiring

## Behavior

On every pod startup with `FOUNDRY_AUTO_ENSURE_ON_STARTUP=true`:
1. Agent found by name (existing behavior)
2. **NEW**: Fetch latest version instructions via `list_versions`  
3. **NEW**: Compare with local `prompts/instructions.md` content  
4. **NEW**: If different, create new version with updated instructions  
5. Wire model target (existing behavior)

All 52 agents will get updated instructions on their next pod restart.