### PR TITLE
fix(ci): normalize line endings in prompt SHA gates

### DIFF
--- a/scripts/ci/verify_foundry_prompt.py
+++ b/scripts/ci/verify_foundry_prompt.py
@@ -62,8 +62,12 @@ def repo_prompt_path(service_name: str) -> Path:
     return REPO_ROOT / "apps" / service_name / "src" / package / "prompts" / "instructions.md"
 
 
+def _normalize(text: str) -> str:
+    return text.replace("\r\n", "\n").replace("\r", "\n").rstrip() + "\n"
+
+
 def sha256_text(text: str) -> str:
-    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+    return hashlib.sha256(_normalize(text).encode("utf-8")).hexdigest()
 
 
 def compose_published_prompt(raw: str) -> str:

--- a/scripts/ci/verify_image_prompt.py
+++ b/scripts/ci/verify_image_prompt.py
@@ -41,8 +41,15 @@ def repo_prompt_path(service_name: str) -> Path:
     return REPO_ROOT / "apps" / service_name / "src" / package / "prompts" / "instructions.md"
 
 
+def _normalize(text: str) -> str:
+    """Normalize line endings and strip trailing whitespace so that cross-OS
+    checkouts (CRLF on Windows, LF on Linux) and editor trailing-newline
+    differences do not cause false-positive SHA divergences."""
+    return text.replace("\r\n", "\n").replace("\r", "\n").rstrip() + "\n"
+
+
 def sha256_text(text: str) -> str:
-    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+    return hashlib.sha256(_normalize(text).encode("utf-8")).hexdigest()
 
 
 def _docker_available() -> bool:


### PR DESCRIPTION
## Summary

Follow-up to PR #876. The `verify_image_prompt` CI gate correctly caught a 1-byte divergence when the first post-merge deploy built the catalog-search image — **repo=1278, image=1277**. Root cause: SHA comparison was byte-for-byte, so Windows CRLF vs Linux LF produced a spurious mismatch. The prompt itself is functionally identical.

## Fix
Normalize line endings (CRLF/CR → LF) and strip trailing whitespace before hashing, in both:
- `scripts/ci/verify_image_prompt.py`
- `scripts/ci/verify_foundry_prompt.py`

Same normalization applied consistently on both sides (repo + image / repo + Foundry) so the gate still detects real content changes while ignoring OS-level encoding noise.

## Validation
- CRUD image built OK on PR #876 post-merge deploy.
- AGC NSG fix applied by provision — AGC now serves HTTP 200/404/500 in ~300ms (was timing out for 2+ days).
- Blocking the catalog-search deploy so live endpoint tests cannot yet run.

## Next
Merge → re-dispatch `deploy-azd-dev` with serviceFilter=crud-service,ecommerce-catalog-search → run `tests/e2e/test_intelligent_pipeline_live.py`.
