### PR TITLE
fix(swa): add NEXT_PUBLIC_AGENT_API_URL and AGENT_API_URL to SWA runtime appsettings

### DIFF
--- a/.infra/modules/static-web-app/static-web-app.bicep
+++ b/.infra/modules/static-web-app/static-web-app.bicep
@@ -51,6 +51,11 @@ resource customDomain 'Microsoft.Web/staticSites/customDomains@2025-03-01' = if 
 }
 
 // App Settings
+// Runtime environment available to the Next.js server (including
+// `/app/agent-api/[...path]/route.ts` and `/app/api/[...path]/route.ts`
+// proxies). These complement the build-time vars injected by the UI
+// deploy workflow.
+var agentApiUrl = '${apimBaseUrl}/agents'
 resource appSettings 'Microsoft.Web/staticSites/config@2025-03-01' = {
   parent: staticWebApp
   name: 'appsettings'
@@ -58,6 +63,8 @@ resource appSettings 'Microsoft.Web/staticSites/config@2025-03-01' = {
     NEXT_PUBLIC_API_BASE_URL: apimBaseUrl
     NEXT_PUBLIC_API_URL: apimBaseUrl
     NEXT_PUBLIC_CRUD_API_URL: apimBaseUrl
+    NEXT_PUBLIC_AGENT_API_URL: agentApiUrl
+    AGENT_API_URL: agentApiUrl
     NEXT_PUBLIC_ENVIRONMENT: environment
   }
 }


### PR DESCRIPTION
## Problem

POST https://blue-meadow-00fcb8810.4.azurestaticapps.net/agent-api/<svc>/invoke returned 502 with body:

```json
{"error":"Agent API proxy is not configured for backend routing.","proxy":{"failureKind":"config","sourceKey":null,"baseUrl":null,...}}
```n
## Root cause

The Next.js server-side proxy at `apps/ui/app/agent-api/[...path]/route.ts` resolves its upstream base URL at **request time** from `process.env.NEXT_PUBLIC_AGENT_API_URL` then `process.env.AGENT_API_URL` (via `base-url-resolver.ts`).

The SWA Bicep module (`.infra/modules/static-web-app/static-web-app.bicep`) declares runtime appsettings for `NEXT_PUBLIC_API_URL`, `NEXT_PUBLIC_CRUD_API_URL`, etc., but **neither `NEXT_PUBLIC_AGENT_API_URL` nor `AGENT_API_URL` was declared**. The build-time env vars injected by the UI deploy workflow only reach the client bundle, not the Next.js server runtime on the SWA managed function host.

Result: the resolver returned `baseUrl=null, sourceKey=null` on every request → 502 config failure.

## Fix

Add both vars to the SWA appsettings Bicep resource, pointing at `{apimBaseUrl}/agents`.

## Verification

- `az bicep build` green.
- Applied immediately via `az staticwebapp appsettings set` on `holidaypeakhub405-ui-dev`.
- Re-probed: 502 config error is gone; proxy now returns `x-holiday-peak-proxy-source: NEXT_PUBLIC_AGENT_API_URL`.
- Residual 503 `no healthy upstream` is observed **both directly on APIM and via SWA**, so it is an upstream AGC/agent transient, unrelated to this fix.