### PR TITLE
docs(adrs): draft ADR-036 + ADR-037 and align 5 existing ADRs for agent isolation

### DIFF
--- a/docs/architecture/ADRs.md
+++ b/docs/architecture/ADRs.md
@@ -41,6 +41,8 @@ This document indexes all architectural decisions for the Holiday Peak Hub accel
 | [ADR-033](adrs/adr-033-helm-deployment-strategy.md) | Helm Deployment Strategy with Flux CD GitOps | Accepted | 2026-04 |
 | [ADR-034](adrs/adr-034-namespace-isolation-strategy.md) | Namespace Isolation Strategy (CRUD vs Agent Namespaces) | Accepted | 2026-04 |
 | [ADR-035](adrs/adr-035-api-center-apim-mcp-strategy.md) | API Center + APIM MCP Strategy | Accepted | 2026-04 |
+| [ADR-036](adrs/adr-036-agent-isolation-policy.md) | Agent Isolation Policy | Accepted | 2026-04 |
+| [ADR-037](adrs/adr-037-async-communication-contract.md) | Async Communication Contract | Accepted | 2026-04 |
 
 ## How to Use ADRs
 
@@ -109,6 +111,8 @@ Each ADR follows a standard template:
 - MCP internal communication policy and rollout gates ([ADR-031](adrs/adr-031-mcp-internal-communication-policy.md))
 - Self-healing boundaries, risk tiers, and prohibited actions ([ADR-032](adrs/adr-032-self-healing-boundaries.md))
 - API Center + APIM MCP strategy for API governance ([ADR-035](adrs/adr-035-api-center-apim-mcp-strategy.md))
+- Agent isolation policy — agents must not call CRUD directly ([ADR-036](adrs/adr-036-agent-isolation-policy.md))
+- Async communication contract with Observer pattern primitives ([ADR-037](adrs/adr-037-async-communication-contract.md))
 
 ### Enterprise Integration
 - Enterprise resilience patterns (Circuit Breaker, Bulkhead, Rate Limiter) ([ADR-023](adrs/adr-023-enterprise-resilience-patterns.md))

--- a/docs/architecture/adrs/adr-009-aks-deployment.md
+++ b/docs/architecture/adrs/adr-009-aks-deployment.md
@@ -70,10 +70,10 @@ Services deploy via azd with Helm predeploy hooks:
 4. **azd** applies the rendered manifests to the AKS cluster via `kubectl apply`
 
 ```bash
-# Deploy CRUD first (must exist before agents)
+# Deploy CRUD first (provisions transactional data layer and Event Hub connections)
 azd deploy --service crud-service -e dev
 
-# Deploy all agents in parallel
+# Deploy all agents in parallel (agents consume events asynchronously per ADR-036)
 azd deploy --all -e dev
 ```
 
@@ -135,7 +135,7 @@ az aks command invoke \
 The GitHub Actions workflow (`.github/workflows/deploy-azd.yml`) enforces ordered rollout:
 
 1. **provision** — `azd provision` for infrastructure
-2. **deploy-crud** — CRUD service first (other services depend on it)
+2. **deploy-crud** — CRUD service first (provisions the transactional data layer, Event Hub connections, and K8s services that agents reference via cross-namespace DNS per ADR-034; agents do not call CRUD REST endpoints directly per ADR-036)
 3. **deploy-agents** — 21 agent services in parallel matrix
 
 Authentication uses OIDC federation (no stored secrets for Azure credentials).
@@ -145,7 +145,7 @@ Authentication uses OIDC federation (no stored secrets for Azure credentials).
 **Positive**:
 - Workload isolation via node pool taints
 - Event-driven autoscaling with KEDA
-- Ordered deployment (CRUD → agents) prevents dependency failures
+- Ordered deployment (CRUD → agents) prevents dependency failures; agents are independently deployable and do not call CRUD REST endpoints directly (ADR-036)
 - azd provides repeatable, environment-scoped deployments
 - Private cluster support for production security
 
@@ -159,3 +159,5 @@ Authentication uses OIDC federation (no stored secrets for Azure credentials).
 
 - [ADR-002: Azure Services](adr-002-azure-services.md) — AKS and ACR selection
 - [ADR-021: azd-First Deployment](adr-021-azd-first-deployment.md) — CI/CD and deployment strategy
+- [ADR-034: Namespace Isolation](adr-034-namespace-isolation-strategy.md) — CRUD and agent namespace split
+- [ADR-036: Agent Isolation Policy](adr-036-agent-isolation-policy.md) — Agents must not call CRUD directly

--- a/docs/architecture/adrs/adr-021-azd-first-deployment.md
+++ b/docs/architecture/adrs/adr-021-azd-first-deployment.md
@@ -96,8 +96,9 @@ Zones, App Insights.
 azd deploy --service crud-service -e dev
 ```
 
-CRUD must be available before agents because agents call CRUD REST endpoints
-for transactional operations (products, orders, cart).
+CRUD must deploy before agents because it provisions the transactional data layer,
+Event Hub connections, and Kubernetes services that agents reference via cross-namespace
+DNS (ADR-034). Agents do not call CRUD REST endpoints directly (ADR-036).
 
 #### 3. Parallel Agent Deployment
 
@@ -178,7 +179,7 @@ Required repository secrets:
 ### Positive
 
 - **Single source of truth**: `azure.yaml` defines all 22 services and their deployment config
-- **Ordered rollout**: CRUD deploys first, agents follow — prevents dependency failures
+- **Ordered rollout**: CRUD deploys first, agents follow — prevents dependency failures; agents do not call CRUD directly (ADR-036)
 - **Environment scoping**: azd environments isolate dev/staging/prod config
 - **Local parity**: Same `azd deploy` command works locally and in CI
 - **Separation of concerns**: CLI stays lightweight (scaffolding only)

--- a/docs/architecture/adrs/adr-031-mcp-internal-communication-policy.md
+++ b/docs/architecture/adrs/adr-031-mcp-internal-communication-policy.md
@@ -60,6 +60,7 @@ Adopt a mandatory **MCP-first internal communication policy** for agent-to-agent
 3. Shared mutable schema ownership across bounded contexts without an owning contract.
 4. Hard-coded service internals (pod IPs, internal hostnames, storage keys) in application call paths.
 5. Runtime dependency on undocumented tool names or unversioned MCP payload fields.
+6. Agent service invoking CRUD REST endpoints directly — all agent-to-CRUD reads must use approved cross-namespace DNS paths (ADR-034); enrichment and decision flows are initiated by CRUD calling agents, not the reverse (ADR-036).
 
 ```mermaid
 %%{init: {'theme':'base', 'themeVariables': {
@@ -73,13 +74,15 @@ Adopt a mandatory **MCP-first internal communication policy** for agent-to-agent
 flowchart LR
     UI[Frontend] -->|REST| CRUD[CRUD Service]
     UI -->|REST| AGENTA[Agent Service A]
-    CRUD -->|REST (approved)| AGENTA
+    CRUD -->|REST approved| AGENTA
     AGENTA -->|MCP Tools| AGENTB[Agent Service B]
     AGENTA -->|Events| EH[(Event Hubs)]
     AGENTB -->|Events| EH
+    AGENTA -.->|cross-ns DNS<br/>reads only, ADR-034| CRUD
 
     AGENTA -. prohibited .-> DBB[(Service B DB)]
     AGENTA -. prohibited .-> PRIVB[Service B Private Endpoint]
+    AGENTA -. "prohibited: direct\nCRUD REST calls\n(ADR-036)" .-> CRUD_REST[CRUD REST API]
 ```
 
 ### Observability and Compliance Expectations
@@ -162,4 +165,6 @@ The following gates are required for service-team rollout approval.
 - [ADR-010](adr-010-rest-and-mcp-exposition.md)
 - [ADR-012](adr-012-adapter-boundaries.md)
 - [ADR-023](adr-023-enterprise-resilience-patterns.md)
+- [ADR-034](adr-034-namespace-isolation-strategy.md)
+- [ADR-036](adr-036-agent-isolation-policy.md)
 - [Architecture Overview](../architecture.md)

--- a/docs/architecture/adrs/adr-034-namespace-isolation-strategy.md
+++ b/docs/architecture/adrs/adr-034-namespace-isolation-strategy.md
@@ -1,10 +1,10 @@
 # ADR-034: Namespace Isolation Strategy
 
-**Status**: Proposed
+**Status**: Accepted
 **Date**: 2026-04-11
 **Deciders**: Architecture Team, Ricardo Cataldi
 **Tags**: infrastructure, kubernetes, aks, namespace, security, istio, flux, network-policy
-**References**: [ADR-031](adr-031-mcp-internal-communication-policy.md), [ADR-033](adr-033-helm-deployment-strategy.md), [ADR-009](adr-009-aks-deployment.md), [ADR-027](adr-027-apim-agc-edge.md), [ADR-028](adr-028-memory-namespace-isolation-contract.md)
+**References**: [ADR-031](adr-031-mcp-internal-communication-policy.md), [ADR-033](adr-033-helm-deployment-strategy.md), [ADR-009](adr-009-aks-deployment.md), [ADR-027](adr-027-apim-agc-edge.md), [ADR-028](adr-028-memory-namespace-isolation-contract.md), [ADR-036](adr-036-agent-isolation-policy.md)
 
 ## Context
 
@@ -148,6 +148,8 @@ All 26 agent services read `CRUD_SERVICE_URL` from environment variables. The mi
 | Before | After |
 |--------|-------|
 | `http://crud-service-crud-service.holiday-peak.svc.cluster.local:8000` | `http://crud-service-crud-service.holiday-peak-crud.svc.cluster.local:8000` |
+
+Per ADR-036, `CRUD_SERVICE_URL` is used exclusively for approved cross-namespace DNS routing of transactional reads. Agents are forbidden from using this URL for general CRUD API consumption (e.g., creating orders, updating products, or invoking CRUD business logic).
 
 This is set in Helm values per service and rendered into deployment manifests by `render-helm.sh`. The change is a values-only update — no application code changes required.
 

--- a/docs/architecture/adrs/adr-035-api-center-apim-mcp-strategy.md
+++ b/docs/architecture/adrs/adr-035-api-center-apim-mcp-strategy.md
@@ -4,7 +4,7 @@
 **Date**: 2026-04-11
 **Deciders**: Architecture Team, Ricardo Cataldi
 **Tags**: api-governance, api-center, apim, mcp, api-discovery
-**References**: [ADR-027](adr-027-apim-agc-edge.md), [ADR-031](adr-031-mcp-internal-communication-policy.md), [ADR-034](adr-034-namespace-isolation-strategy.md)
+**References**: [ADR-027](adr-027-apim-agc-edge.md), [ADR-031](adr-031-mcp-internal-communication-policy.md), [ADR-034](adr-034-namespace-isolation-strategy.md), [ADR-036](adr-036-agent-isolation-policy.md)
 
 ## Context
 
@@ -56,6 +56,14 @@ Per-agent `POST /mcp/{tool}` operations are already registered in APIM and funct
 - Bicep/AVM modules support MCP Server configuration
 
 **Workaround**: Each agent's `/mcp/{tool}` endpoint is already accessible through APIM. Consumers can invoke MCP tools via `POST https://{apim-gateway}/agents/{service-name}/mcp/{tool}`.
+
+### 4. Communication Path Topology
+
+APIM serves a dual role in the platform's communication architecture:
+
+1. **Public facade** — Frontend → CRUD and Frontend → Agent REST calls are routed through APIM for authentication, rate limiting, and observability (ADR-027).
+2. **Internal MCP gateway** — CRUD → Agent enrichment/decision-assist calls use APIM-routed MCP tool invocations, maintaining governance and telemetry (ADR-031).
+3. **Agents do NOT use APIM for CRUD reads** — Agent → CRUD transactional reads use cross-namespace Kubernetes DNS (ADR-034 Option A). Agents are forbidden from invoking CRUD REST endpoints directly for general API consumption (ADR-036).
 
 ## Consequences
 

--- a/docs/architecture/adrs/adr-036-agent-isolation-policy.md
+++ b/docs/architecture/adrs/adr-036-agent-isolation-policy.md
@@ -1,0 +1,147 @@
+# ADR-036: Agent Isolation Policy
+
+**Status**: Accepted
+**Date**: 2026-04
+**Deciders**: Architecture Team, Ricardo Cataldi
+**Tags**: architecture, agents, isolation, coupling, deployment, security
+**References**: [ADR-007](adr-007-saga-choreography.md), [ADR-009](adr-009-aks-deployment.md), [ADR-031](adr-031-mcp-internal-communication-policy.md), [ADR-034](adr-034-namespace-isolation-strategy.md), [ADR-037](adr-037-async-communication-contract.md)
+
+## Context
+
+The holiday-peak-hub platform deploys 26 agent services alongside 1 CRUD service. Prior to this decision, agent services imported and called CRUD service adapters and REST endpoints directly — a coupling pattern that created several architectural liabilities:
+
+1. **Blast radius** — A CRUD deployment failure, schema change, or latency spike cascaded into every agent that held a direct HTTP dependency. Agents could not be tested or deployed in isolation.
+2. **Coupling** — `BaseCRUDAdapter` in `holiday_peak_lib` and `register_crud_tools()` in `registration_helpers.py` gave every agent a compile-time dependency on CRUD internals. Updating the CRUD contract required coordinated changes across 22+ services.
+3. **Independent deployability** — Agents could not scale, version, or roll back independently because their runtime depended on CRUD being reachable at a specific version.
+4. **Security surface** — Every agent held `CRUD_SERVICE_URL` credentials and could invoke any CRUD endpoint, violating the principle of least privilege.
+5. **Observability noise** — Direct agent→CRUD REST calls bypassed APIM, making traffic flows invisible to the governance layer (ADR-031) and harder to trace.
+
+Architecture frameworks applied:
+
+- **Domain-Driven Design (Bounded Contexts)**: Agents (intelligence) and CRUD (transactional) are separate bounded contexts that must communicate through explicit, governed interfaces — not shared code.
+- **microservices.io (Loose Coupling, Database per Service)**: Direct adapter sharing is the microservices equivalent of a shared database — it defeats independent deployability.
+- **Azure Well-Architected Framework (Operational Excellence)**: Independent deployment units reduce change failure rate and mean time to recovery.
+- **TOGAF (Architecture Governance)**: Communication paths are governed architecture building blocks with explicit approval gates (ADR-031 §5).
+
+## Decision
+
+**Agents are forbidden from importing or calling CRUD service adapters and REST endpoints directly.**
+
+All agent-to-CRUD communication MUST use one of the following approved paths:
+
+### Approved Communication Paths
+
+| Path | Direction | Mechanism | Governed By |
+|------|-----------|-----------|-------------|
+| Cross-namespace K8s DNS | Agent → CRUD | Transactional reads only via `CRUD_SERVICE_URL` cross-namespace FQDN | ADR-034 Option A |
+| APIM MCP tools | Agent → Agent | MCP tool invocation through APIM gateway | ADR-031 |
+| Event Hubs | Agent ↔ CRUD | Asynchronous domain events (SAGA choreography) | ADR-007 |
+| APIM REST | CRUD → Agent | Enrichment/decision-assist calls initiated by CRUD | ADR-031, ADR-035 |
+| APIM REST | Frontend → CRUD | Transactional UI operations | ADR-027 |
+| APIM REST | Frontend → Agent | Intelligence endpoints for UI | ADR-027 |
+
+### Prohibited Patterns
+
+The following patterns are explicitly forbidden:
+
+1. **Agent importing `BaseCRUDAdapter`** or any CRUD-specific adapter from `holiday_peak_lib` or application code.
+2. **Agent calling `register_crud_tools()`** or any function that registers CRUD endpoints as MCP tools within agent processes.
+3. **Agent making direct HTTP calls** to CRUD REST endpoints (e.g., `POST /api/products`, `PUT /api/orders/{id}`) outside the approved cross-namespace DNS path for transactional reads.
+4. **Agent holding CRUD database connection strings** or accessing CRUD's PostgreSQL, Redis, or Cosmos DB instances directly.
+5. **Shared mutable state** between agent and CRUD services via any mechanism other than Event Hubs.
+
+### Communication Path Topology
+
+```mermaid
+%%{init: {'theme':'base', 'themeVariables': {
+  'primaryColor':'#FFB3BA',
+  'primaryTextColor':'#000',
+  'primaryBorderColor':'#FF8B94',
+  'lineColor':'#BAE1FF',
+  'secondaryColor':'#BAE1FF',
+  'tertiaryColor':'#FFFFFF'
+}}}%%
+flowchart LR
+    subgraph Approved["Approved Communication Paths"]
+        direction TB
+        UI[Frontend] -->|REST via APIM| CRUD[CRUD Service]
+        UI -->|REST via APIM| AGENT_A[Agent Service A]
+        CRUD -->|REST via APIM| AGENT_A
+        AGENT_A -->|MCP via APIM| AGENT_B[Agent Service B]
+        AGENT_A -->|cross-ns DNS<br/>reads only| CRUD
+        AGENT_A -->|Events| EH[(Event Hubs)]
+        CRUD -->|Events| EH
+        EH -->|Events| AGENT_B
+    end
+
+    subgraph Prohibited["Prohibited Patterns"]
+        direction TB
+        BAD_AGENT[Agent Service] -. BaseCRUDAdapter .-> BAD_CRUD[CRUD Internals]
+        BAD_AGENT -. register_crud_tools .-> BAD_MCP[CRUD MCP Tools]
+        BAD_AGENT -. direct REST calls .-> BAD_REST[CRUD REST API]
+        BAD_AGENT -. shared DB access .-> BAD_DB[(CRUD Database)]
+    end
+
+    style Approved fill:#e8f5e9,stroke:#4caf50,color:#000
+    style Prohibited fill:#ffebee,stroke:#f44336,color:#000
+    style BAD_CRUD fill:#ffcdd2,stroke:#f44336,color:#000
+    style BAD_MCP fill:#ffcdd2,stroke:#f44336,color:#000
+    style BAD_REST fill:#ffcdd2,stroke:#f44336,color:#000
+    style BAD_DB fill:#ffcdd2,stroke:#f44336,color:#000
+```
+
+### Implementation Evidence
+
+The following changes were made to enforce this policy:
+
+| Change | PR | Scope |
+|--------|----|-------|
+| Removed `BaseCRUDAdapter` from `holiday_peak_lib` | #881 | Eliminates compile-time CRUD coupling from shared library |
+| Removed `register_crud_tools()` from `registration_helpers.py` | #881 | Prevents agents from registering CRUD endpoints as MCP tools |
+| Swept 22 agent services to drop CRUD imports/calls | #882 | Removes all direct CRUD invocations from agent application code |
+| Stripped `CRUD_SERVICE_URL` env entries from 25 rendered manifests | #882 | Removes runtime CRUD endpoint configuration from agent deployments |
+
+## Consequences
+
+### Positive
+
+1. **Independent deployability** — Agent services can be deployed, scaled, and rolled back without CRUD dependency. CRUD changes do not cascade to agents.
+2. **Reduced blast radius** — CRUD outages do not propagate to agent services; agents degrade gracefully when async events are delayed.
+3. **Testability** — Agent unit and integration tests no longer require CRUD service stubs or mocks for adapter internals.
+4. **Security** — Agents no longer hold CRUD credentials or have direct access to CRUD's data layer, enforcing least privilege.
+5. **Observability** — All agent↔CRUD communication flows through governed paths (Event Hubs, APIM, or Istio-monitored cross-namespace DNS), making traffic visible to the platform's observability stack.
+6. **Architectural clarity** — The separation between transactional (CRUD) and intelligence (Agent) bounded contexts is now enforced at the code and infrastructure level.
+
+### Negative
+
+1. **Async latency** — Operations that were previously synchronous CRUD calls now require Event Hub publish/subscribe, introducing eventual consistency and higher latency for write operations.
+2. **Migration effort** — 22 agent services required code changes to remove CRUD dependencies (completed in PRs #881, #882).
+3. **Cross-namespace DNS dependency** — Agents that need transactional reads still depend on the CRUD service FQDN, which is a single Helm value but still a configuration coupling point.
+
+### Compliance
+
+This ADR extends the prohibited patterns defined in [ADR-031](adr-031-mcp-internal-communication-policy.md) §Prohibited Direct Coupling Patterns. Compliance is enforced through:
+
+- **CI/CD checks**: Import scanning for `BaseCRUDAdapter` and `register_crud_tools` in agent service code.
+- **Architecture review**: New agent→CRUD communication paths require ADR reference and architecture team approval (ADR-031 §5).
+- **Runtime monitoring**: APIM and Istio telemetry detect unauthorized direct REST calls between namespaces.
+
+## Alternatives Considered
+
+### Alternative 1: Allow Agent→CRUD REST Calls Through APIM
+
+Route all agent→CRUD calls through APIM for governance and observability.
+
+**Rejected**: Adds 15-30 ms latency per call on hot paths. APIM is the public facade (ADR-027), not an internal service bus. This alternative was also rejected in ADR-034 (Option B analysis).
+
+### Alternative 2: Maintain BaseCRUDAdapter with Versioned Contracts
+
+Keep the shared adapter but version its interface and enforce backward compatibility.
+
+**Rejected**: Shared adapters create compile-time coupling regardless of versioning. Any adapter change requires coordinated releases across 22+ services. This violates the independent deployability principle.
+
+### Alternative 3: Event Hubs Only (No Cross-Namespace DNS)
+
+Require all agent→CRUD communication to go through Event Hubs, eliminating even read-path DNS coupling.
+
+**Rejected**: Event Hubs introduce eventual consistency for read operations that require current state (e.g., product lookup during enrichment). The latency and complexity cost is not justified for read-only data plane operations. Cross-namespace DNS reads (ADR-034 Option A) provide sub-2ms latency for hot-path lookups.

--- a/docs/architecture/adrs/adr-037-async-communication-contract.md
+++ b/docs/architecture/adrs/adr-037-async-communication-contract.md
@@ -1,0 +1,213 @@
+# ADR-037: Async Communication Contract
+
+**Status**: Accepted
+**Date**: 2026-04
+**Deciders**: Architecture Team, Ricardo Cataldi
+**Tags**: architecture, messaging, event-hubs, observer-pattern, async, contracts
+**References**: [ADR-007](adr-007-saga-choreography.md), [ADR-036](adr-036-agent-isolation-policy.md)
+
+## Context
+
+With agent isolation enforced (ADR-036), agents are forbidden from calling CRUD REST endpoints directly. The primary asynchronous communication mechanism is Azure Event Hubs, governed by SAGA choreography patterns (ADR-007). The existing implementation in `holiday_peak_lib.utils.event_hub` provides low-level primitives:
+
+- **`EventPublisher`**: Publishes events to a named Event Hub topic.
+- **`EventHubSubscriber`**: Subscribes to a named Event Hub topic and invokes a callback.
+
+These primitives are functional but lack:
+
+1. **Observer pattern abstraction** — There is no formal mechanism for agents to register interest in topics, discover available topics, or manage subscriptions declaratively.
+2. **Self-describing contracts** — Agents publish and consume events, but there is no machine-readable description of which topics an agent publishes to, which it consumes from, and what schemas those events use.
+3. **Runtime discoverability** — There is no endpoint or registry where other agents (or operators) can query an agent's async capabilities without reading its source code.
+
+As the platform scales beyond 26 agent services, the absence of formal async contracts will lead to:
+
+- **Integration drift** — New agents wire up event subscriptions ad hoc, without visibility into the existing topic topology.
+- **Schema breakage** — Event producers change payload schemas without consumers being aware, because there is no contract registry.
+- **Operational blindness** — Operators cannot determine which agents are affected by an Event Hub topic outage without tracing source code.
+
+Architecture frameworks applied:
+
+- **Enterprise Integration Patterns (Observer, Publish-Subscribe Channel)**: The Observer pattern formalizes the relationship between event producers and consumers, making subscriptions explicit and manageable.
+- **Domain-Driven Design (Domain Events)**: Domain events are first-class citizens with explicit schemas that cross bounded context boundaries.
+- **microservices.io (Event-Driven Architecture)**: Self-describing event contracts enable loose coupling while maintaining integration visibility.
+
+## Decision
+
+Introduce **Observer pattern primitives** in `holiday_peak_lib.messaging` that wrap the existing `EventPublisher`/`EventHubSubscriber` and add contract self-description capabilities.
+
+### Core Components
+
+#### 1. `TopicSubject`
+
+A named topic wrapper that implements the Observer pattern, providing:
+
+- Topic name registration
+- Observer (subscriber) registration and deregistration
+- Event publishing through the wrapped `EventPublisher`
+- Subscriber notification through the wrapped `EventHubSubscriber`
+
+```python
+from holiday_peak_lib.messaging import TopicSubject
+
+# Producer side
+product_events = TopicSubject(
+    topic="product-updates",
+    schema=ProductUpdateEvent,
+)
+await product_events.publish(ProductUpdateEvent(product_id="123", action="enriched"))
+
+# Consumer side
+product_events = TopicSubject(topic="product-updates", schema=ProductUpdateEvent)
+product_events.register_observer(handle_product_update)
+await product_events.start_consuming()
+```
+
+#### 2. `AgentAsyncContract`
+
+A Pydantic model that self-describes an agent's async capabilities:
+
+```python
+from holiday_peak_lib.messaging import AgentAsyncContract, TopicDescriptor
+
+contract = AgentAsyncContract(
+    agent_name="ecommerce-catalog-search",
+    publishes=[
+        TopicDescriptor(
+            topic="search-index-updated",
+            schema_ref="SearchIndexEvent",
+            description="Emitted when catalog search index is refreshed",
+        ),
+    ],
+    consumes=[
+        TopicDescriptor(
+            topic="product-updates",
+            schema_ref="ProductUpdateEvent",
+            description="Triggers re-indexing when product data changes",
+        ),
+    ],
+)
+```
+
+#### 3. `/async/contract` Endpoint
+
+Auto-registered by `create_standard_app()` to expose the agent's async contract as a machine-readable JSON endpoint:
+
+```
+GET /async/contract
+```
+
+Response:
+
+```json
+{
+  "agent_name": "ecommerce-catalog-search",
+  "publishes": [
+    {
+      "topic": "search-index-updated",
+      "schema_ref": "SearchIndexEvent",
+      "description": "Emitted when catalog search index is refreshed"
+    }
+  ],
+  "consumes": [
+    {
+      "topic": "product-updates",
+      "schema_ref": "ProductUpdateEvent",
+      "description": "Triggers re-indexing when product data changes"
+    }
+  ]
+}
+```
+
+### Async Contract Topology
+
+```mermaid
+%%{init: {'theme':'base', 'themeVariables': {
+  'primaryColor':'#FFB3BA',
+  'primaryTextColor':'#000',
+  'primaryBorderColor':'#FF8B94',
+  'lineColor':'#BAE1FF',
+  'secondaryColor':'#BAE1FF',
+  'tertiaryColor':'#FFFFFF'
+}}}%%
+flowchart LR
+    subgraph CRUD_NS["holiday-peak-crud"]
+        CRUD[CRUD Service]
+    end
+
+    subgraph EH["Azure Event Hubs"]
+        T1([product-updates])
+        T2([order-events])
+        T3([inventory-alerts])
+    end
+
+    subgraph AGENTS_NS["holiday-peak-agents"]
+        A1[catalog-search<br/>/async/contract]
+        A2[cart-intelligence<br/>/async/contract]
+        A3[inventory-alerts<br/>/async/contract]
+    end
+
+    CRUD -->|publish| T1
+    CRUD -->|publish| T2
+    T1 -->|consume| A1
+    T2 -->|consume| A2
+    T3 -->|consume| A3
+    A3 -->|publish| T3
+
+    style CRUD_NS fill:#e3f2fd,stroke:#1565c0,color:#000
+    style AGENTS_NS fill:#f3e5f5,stroke:#7b1fa2,color:#000
+    style EH fill:#fff3e0,stroke:#e65100,color:#000
+```
+
+### Integration with Existing Infrastructure
+
+| Component | Relationship |
+|-----------|-------------|
+| `holiday_peak_lib.utils.event_hub.EventPublisher` | Wrapped by `TopicSubject` for publishing |
+| `holiday_peak_lib.utils.event_hub.EventHubSubscriber` | Wrapped by `TopicSubject` for consuming |
+| `create_standard_app()` | Auto-registers `/async/contract` endpoint when an `AgentAsyncContract` is provided |
+| APIM (ADR-035) | `/async/contract` endpoints are registered in API Center for discoverability |
+| ADR-036 (Agent Isolation) | Async contracts formalize the Event Hub path as the primary agent↔CRUD communication channel for write operations |
+
+## Consequences
+
+### Positive
+
+1. **Runtime discoverability** — Agents expose their async capabilities as machine-readable contracts, enabling operators and other agents to understand the event topology without reading source code.
+2. **Schema governance** — `TopicDescriptor` references explicit schema types, making it possible to detect breaking changes before deployment.
+3. **Observer pattern clarity** — `TopicSubject` formalizes the publish/subscribe relationship, replacing ad-hoc `EventPublisher`/`EventHubSubscriber` wiring with a consistent pattern.
+4. **Operational visibility** — The `/async/contract` endpoint enables automated topology mapping, impact analysis for Event Hub outages, and integration testing validation.
+5. **Incremental adoption** — Existing agents can adopt `TopicSubject` and `AgentAsyncContract` incrementally; the low-level Event Hub utilities remain available for edge cases.
+
+### Negative
+
+1. **Abstraction layer** — `TopicSubject` adds an indirection layer over `EventPublisher`/`EventHubSubscriber`. If the abstraction does not carry its weight, it becomes accidental complexity.
+2. **Contract maintenance** — Each agent must keep its `AgentAsyncContract` in sync with its actual event subscriptions. Stale contracts are worse than no contracts.
+3. **Implementation effort** — 26 agent services will need to adopt the new primitives to achieve full topology coverage.
+
+### Risk Mitigation
+
+| Risk | Mitigation |
+|------|------------|
+| Contract drift (declared vs. actual) | CI check comparing declared topics against `TopicSubject` instantiations in agent code |
+| Over-abstraction | `TopicSubject` wraps existing primitives; agents can fall back to raw `EventPublisher`/`EventHubSubscriber` if needed |
+| Adoption lag | Incremental rollout by domain (truth-layer first, then ecommerce, CRM, inventory, logistics, product-management) |
+
+## Alternatives Considered
+
+### Alternative 1: Schema Registry (Confluent/Azure Schema Registry)
+
+Use a centralized schema registry for event contract governance.
+
+**Rejected at current scale**: A full schema registry adds infrastructure cost and operational complexity for 26 services with ~10-15 distinct event topics. The `AgentAsyncContract` model provides 80% of the value at 20% of the cost. If the platform scales to 50+ services or 50+ topics, a schema registry should be reconsidered.
+
+### Alternative 2: AsyncAPI Specification
+
+Use the AsyncAPI standard to describe agent event interfaces.
+
+**Deferred**: AsyncAPI is a good fit for external documentation and tooling but is heavier than needed for internal runtime discoverability. The `/async/contract` endpoint can be extended to return AsyncAPI-compatible output in a future iteration without breaking changes.
+
+### Alternative 3: No Formal Contract — Rely on Documentation
+
+Keep event subscriptions documented in each agent's README.
+
+**Rejected**: Documentation drifts from implementation. Machine-readable contracts enable automated topology mapping, CI validation, and runtime discovery — none of which are possible with markdown documentation alone.


### PR DESCRIPTION
## Summary
Drafts ADR-036 (Agent Isolation Policy) and ADR-037 (Async Communication Contract), and revises 5 existing ADRs (009, 021, 031, 034, 035) to align with the agent isolation enforcement shipped in PRs #881/#882.

## Changes
- **ADR-036**: Formalizes prohibition of direct agent-to-CRUD calls; documents approved communication paths
- **ADR-037**: Defines Observer pattern primitives (TopicSubject, AgentAsyncContract, /async/contract endpoint)
- **ADR-009**: Clarifies deployment ordering is for infrastructure readiness, not agent→CRUD dependency
- **ADR-021**: Updates CRUD-first deployment rationale
- **ADR-031**: Adds explicit prohibition of Agent→CRUD REST calls; updates Mermaid diagram
- **ADR-034**: Status Proposed→Accepted; adds ADR-036 cross-reference to CRUD_SERVICE_URL section
- **ADR-035**: Adds Communication Path Topology section documenting APIM's dual role
- **ADRs.md**: Index updated with ADR-036 and ADR-037 entries

Closes #883