### PR TITLE
feat(ui): add generic useAgent<T>() hooks for typed agent invocations

### DIFF
--- a/apps/ui/lib/hooks/useAgent.ts
+++ b/apps/ui/lib/hooks/useAgent.ts
@@ -1,0 +1,143 @@
+/**
+ * Generic typed hooks for agent service communication.
+ *
+ * Provides useAgentQuery (GET) and useAgentMutation (POST) backed by
+ * @tanstack/react-query and the shared agentApiClient.
+ */
+
+import { useQuery, useMutation, type UseQueryResult, type UseMutationResult } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+
+import { agentApiClient } from '@/lib/api/agentClient';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface AgentError {
+  status: number;
+  message: string;
+  service: string;
+  endpoint: string;
+}
+
+export interface AgentQueryOptions<TResponse> {
+  /** Agent service name (e.g., 'ecommerce-catalog-search') */
+  service: string;
+  /** Endpoint path (e.g., '/search', '/recommendations') */
+  endpoint: string;
+  /** Optional query parameters */
+  params?: Record<string, string | number | boolean | undefined>;
+  /** TanStack Query options overrides */
+  enabled?: boolean;
+  staleTime?: number;
+  refetchInterval?: number | false;
+  /** Transform response data */
+  select?: (data: TResponse) => TResponse;
+}
+
+export interface AgentMutationOptions<TRequest, TResponse> {
+  /** Agent service name */
+  service: string;
+  /** Endpoint path */
+  endpoint: string;
+  /** Callbacks */
+  onSuccess?: (data: TResponse) => void;
+  onError?: (error: AgentError) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildUrl(service: string, endpoint: string): string {
+  if (endpoint.startsWith('/agents/')) {
+    return endpoint;
+  }
+  return `/${service}${endpoint}`;
+}
+
+function buildQueryKey(
+  service: string,
+  endpoint: string,
+  params?: Record<string, string | number | boolean | undefined>,
+): unknown[] {
+  const key: unknown[] = ['agent', service, endpoint];
+  if (params) {
+    const sorted = Object.entries(params)
+      .filter(([, v]) => v !== undefined)
+      .sort(([a], [b]) => a.localeCompare(b));
+    for (const [k, v] of sorted) {
+      key.push(k, v);
+    }
+  }
+  return key;
+}
+
+function toAgentError(error: unknown, service: string, endpoint: string): AgentError {
+  if (error instanceof AxiosError) {
+    return {
+      status: error.response?.status ?? 0,
+      message:
+        (error.response?.data as { detail?: string } | undefined)?.detail ??
+        error.message,
+      service,
+      endpoint,
+    };
+  }
+  return {
+    status: 0,
+    message: error instanceof Error ? error.message : 'Unknown error',
+    service,
+    endpoint,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Hooks
+// ---------------------------------------------------------------------------
+
+export function useAgentQuery<TResponse>(
+  options: AgentQueryOptions<TResponse>,
+): UseQueryResult<TResponse, AgentError> {
+  const { service, endpoint, params, enabled, staleTime, refetchInterval, select } = options;
+  const url = buildUrl(service, endpoint);
+
+  return useQuery<TResponse, AgentError>({
+    queryKey: buildQueryKey(service, endpoint, params),
+    queryFn: async () => {
+      try {
+        const response = await agentApiClient.get<TResponse>(url, {
+          params: params as Record<string, string>,
+        });
+        return response.data;
+      } catch (error) {
+        throw toAgentError(error, service, endpoint);
+      }
+    },
+    enabled,
+    staleTime,
+    refetchInterval,
+    select,
+  });
+}
+
+export function useAgentMutation<TRequest, TResponse>(
+  options: AgentMutationOptions<TRequest, TResponse>,
+): UseMutationResult<TResponse, AgentError, TRequest> {
+  const { service, endpoint, onSuccess, onError } = options;
+  const url = buildUrl(service, endpoint);
+
+  return useMutation<TResponse, AgentError, TRequest>({
+    mutationFn: async (payload: TRequest) => {
+      try {
+        const response = await agentApiClient.post<TResponse>(url, payload);
+        return response.data;
+      } catch (error) {
+        throw toAgentError(error, service, endpoint);
+      }
+    },
+    onSuccess,
+    onError,
+  });
+}

--- a/apps/ui/lib/hooks/useAgent.ts
+++ b/apps/ui/lib/hooks/useAgent.ts
@@ -36,7 +36,7 @@ export interface AgentQueryOptions<TResponse> {
   select?: (data: TResponse) => TResponse;
 }
 
-export interface AgentMutationOptions<TRequest, TResponse> {
+export interface AgentMutationOptions<TResponse> {
   /** Agent service name */
   service: string;
   /** Endpoint path */
@@ -123,7 +123,7 @@ export function useAgentQuery<TResponse>(
 }
 
 export function useAgentMutation<TRequest, TResponse>(
-  options: AgentMutationOptions<TRequest, TResponse>,
+  options: AgentMutationOptions<TResponse>,
 ): UseMutationResult<TResponse, AgentError, TRequest> {
   const { service, endpoint, onSuccess, onError } = options;
   const url = buildUrl(service, endpoint);

--- a/apps/ui/tests/unit/useAgent.test.ts
+++ b/apps/ui/tests/unit/useAgent.test.ts
@@ -136,7 +136,7 @@ describe('useAgentMutation', () => {
 
   it('posts data through agentApiClient and returns response', async () => {
     const onSuccess = jest.fn();
-    const opts: AgentMutationOptions<{ query: string }, { id: string }> = {
+    const opts: AgentMutationOptions<{ id: string }> = {
       service: 'ecommerce-catalog-search',
       endpoint: '/search',
       onSuccess,

--- a/apps/ui/tests/unit/useAgent.test.ts
+++ b/apps/ui/tests/unit/useAgent.test.ts
@@ -1,0 +1,188 @@
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { AxiosError, AxiosHeaders } from 'axios';
+import { agentApiClient } from '../../lib/api/agentClient';
+import {
+  useAgentQuery,
+  useAgentMutation,
+  type AgentError,
+  type AgentQueryOptions,
+  type AgentMutationOptions,
+} from '../../lib/hooks/useAgent';
+
+jest.mock('@tanstack/react-query', () => ({
+  useQuery: jest.fn(),
+  useMutation: jest.fn(),
+}));
+
+jest.mock('../../lib/api/agentClient', () => ({
+  agentApiClient: {
+    get: jest.fn(),
+    post: jest.fn(),
+  },
+}));
+
+const mockGet = agentApiClient.get as jest.Mock;
+const mockPost = agentApiClient.post as jest.Mock;
+
+// ---------------------------------------------------------------------------
+// useAgentQuery
+// ---------------------------------------------------------------------------
+
+describe('useAgentQuery', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useQuery as jest.Mock).mockReturnValue({ data: undefined, isLoading: true });
+  });
+
+  it('passes correct queryKey and calls agentApiClient.get', async () => {
+    const opts: AgentQueryOptions<{ items: string[] }> = {
+      service: 'ecommerce-catalog-search',
+      endpoint: '/search',
+      params: { q: 'shoes', limit: 10 },
+    };
+
+    useAgentQuery(opts);
+
+    const call = (useQuery as jest.Mock).mock.calls[0][0];
+    // Key includes sorted params
+    expect(call.queryKey).toEqual([
+      'agent',
+      'ecommerce-catalog-search',
+      '/search',
+      'limit', 10,
+      'q', 'shoes',
+    ]);
+
+    // Execute the queryFn to verify the GET call
+    mockGet.mockResolvedValue({ data: { items: ['a'] } });
+    const result = await call.queryFn();
+    expect(mockGet).toHaveBeenCalledWith('/ecommerce-catalog-search/search', {
+      params: { q: 'shoes', limit: 10 },
+    });
+    expect(result).toEqual({ items: ['a'] });
+  });
+
+  it('handles errors and maps to AgentError', async () => {
+    useAgentQuery({ service: 'svc', endpoint: '/ep' });
+
+    const call = (useQuery as jest.Mock).mock.calls[0][0];
+    const axiosErr = new AxiosError('timeout', 'ECONNABORTED', undefined, undefined, {
+      status: 504,
+      data: { detail: 'Gateway Timeout' },
+      statusText: 'Gateway Timeout',
+      headers: {},
+      config: { headers: new AxiosHeaders() },
+    });
+    mockGet.mockRejectedValue(axiosErr);
+
+    await expect(call.queryFn()).rejects.toEqual<AgentError>({
+      status: 504,
+      message: 'Gateway Timeout',
+      service: 'svc',
+      endpoint: '/ep',
+    });
+  });
+
+  it('respects the enabled flag', () => {
+    useAgentQuery({ service: 'svc', endpoint: '/ep', enabled: false });
+
+    const call = (useQuery as jest.Mock).mock.calls[0][0];
+    expect(call.enabled).toBe(false);
+  });
+
+  it('uses endpoint directly when it starts with /agents/', () => {
+    useAgentQuery({ service: 'svc', endpoint: '/agents/invoke' });
+
+    const call = (useQuery as jest.Mock).mock.calls[0][0];
+    mockGet.mockResolvedValue({ data: {} });
+    call.queryFn();
+    expect(mockGet).toHaveBeenCalledWith('/agents/invoke', { params: undefined });
+  });
+
+  it('forwards staleTime and refetchInterval', () => {
+    useAgentQuery({
+      service: 'svc',
+      endpoint: '/ep',
+      staleTime: 30_000,
+      refetchInterval: 5_000,
+    });
+
+    const call = (useQuery as jest.Mock).mock.calls[0][0];
+    expect(call.staleTime).toBe(30_000);
+    expect(call.refetchInterval).toBe(5_000);
+  });
+
+  it('filters undefined params from query key', () => {
+    useAgentQuery({
+      service: 'svc',
+      endpoint: '/ep',
+      params: { a: 'yes', b: undefined },
+    });
+
+    const call = (useQuery as jest.Mock).mock.calls[0][0];
+    expect(call.queryKey).toEqual(['agent', 'svc', '/ep', 'a', 'yes']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useAgentMutation
+// ---------------------------------------------------------------------------
+
+describe('useAgentMutation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useMutation as jest.Mock).mockReturnValue({ mutate: jest.fn() });
+  });
+
+  it('posts data through agentApiClient and returns response', async () => {
+    const onSuccess = jest.fn();
+    const opts: AgentMutationOptions<{ query: string }, { id: string }> = {
+      service: 'ecommerce-catalog-search',
+      endpoint: '/search',
+      onSuccess,
+    };
+
+    useAgentMutation(opts);
+
+    const call = (useMutation as jest.Mock).mock.calls[0][0];
+    mockPost.mockResolvedValue({ data: { id: '123' } });
+    const result = await call.mutationFn({ query: 'shoes' });
+
+    expect(mockPost).toHaveBeenCalledWith('/ecommerce-catalog-search/search', { query: 'shoes' });
+    expect(result).toEqual({ id: '123' });
+    expect(call.onSuccess).toBe(onSuccess);
+  });
+
+  it('handles errors and maps to AgentError', async () => {
+    const onError = jest.fn();
+    useAgentMutation({ service: 'svc', endpoint: '/ep', onError });
+
+    const call = (useMutation as jest.Mock).mock.calls[0][0];
+    const axiosErr = new AxiosError('bad', 'ERR_BAD_REQUEST', undefined, undefined, {
+      status: 400,
+      data: { detail: 'Validation failed' },
+      statusText: 'Bad Request',
+      headers: {},
+      config: { headers: new AxiosHeaders() },
+    });
+    mockPost.mockRejectedValue(axiosErr);
+
+    await expect(call.mutationFn({})).rejects.toEqual<AgentError>({
+      status: 400,
+      message: 'Validation failed',
+      service: 'svc',
+      endpoint: '/ep',
+    });
+    expect(call.onError).toBe(onError);
+  });
+
+  it('uses endpoint directly when it starts with /agents/', async () => {
+    useAgentMutation({ service: 'svc', endpoint: '/agents/invoke' });
+
+    const call = (useMutation as jest.Mock).mock.calls[0][0];
+    mockPost.mockResolvedValue({ data: {} });
+    await call.mutationFn({ payload: true });
+
+    expect(mockPost).toHaveBeenCalledWith('/agents/invoke', { payload: true });
+  });
+});


### PR DESCRIPTION
## Summary
Adds generic typed hooks for agent API invocations, reducing boilerplate when building new agent-powered features in the frontend.

## Changes
- **`lib/hooks/useAgent.ts`**: Exports `useAgentQuery<TResponse>` (GET) and `useAgentMutation<TRequest, TResponse>` (POST) hooks that route through `agentApiClient` with TanStack Query integration
- **`AgentError`** type for structured error handling (status, message, service, endpoint)
- Query key construction: `['agent', service, endpoint, ...sortedParams]`  
- URL routing: `/{service}{endpoint}` with `/agents/` prefix passthrough
- **9 unit tests** covering query/mutation success paths, error mapping, enabled flag, params handling

## Test Results
- 9/9 tests passing (2.5s)
- Existing hooks unmodified

Closes #885