### PR TITLE
feat(mcp): add APIM MCP discovery client

### DIFF
--- a/lib/src/holiday_peak_lib/mcp/__init__.py
+++ b/lib/src/holiday_peak_lib/mcp/__init__.py
@@ -5,12 +5,22 @@ from holiday_peak_lib.mcp.ai_search_indexing import (
     build_ai_search_indexing_client_from_env,
     register_ai_search_indexing_tools,
 )
+from holiday_peak_lib.mcp.apim_client import (
+    ApimMcpClient,
+    McpInvocationResult,
+    McpToolDescriptor,
+    create_apim_mcp_client,
+)
 from holiday_peak_lib.mcp.server import FastAPIMCPServer, MCPToolSchemaRef
 
 __all__ = [
     "AISearchIndexingClient",
+    "ApimMcpClient",
     "build_ai_search_indexing_client_from_env",
-    "register_ai_search_indexing_tools",
+    "create_apim_mcp_client",
     "FastAPIMCPServer",
+    "McpInvocationResult",
+    "McpToolDescriptor",
     "MCPToolSchemaRef",
+    "register_ai_search_indexing_tools",
 ]

--- a/lib/src/holiday_peak_lib/mcp/apim_client.py
+++ b/lib/src/holiday_peak_lib/mcp/apim_client.py
@@ -1,0 +1,333 @@
+"""APIM MCP discovery client for agent-to-agent tool invocations.
+
+Follows ADR-031 (observability), ADR-035 (URL convention), and ADR-036 (governed interfaces).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from inspect import isawaitable
+from typing import Any, Awaitable, Callable
+
+import httpx
+from holiday_peak_lib.self_healing.models import FailureSignal, SurfaceType
+from holiday_peak_lib.utils.circuit_breaker import CircuitBreaker, CircuitBreakerOpenError
+from holiday_peak_lib.utils.correlation import CORRELATION_HEADER, get_correlation_id
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+FailureCallback = Callable[[FailureSignal], Awaitable[Any] | Any]
+
+
+class McpToolDescriptor(BaseModel):
+    """Describes a discovered MCP tool."""
+
+    service: str
+    tool_name: str
+    url: str
+
+
+class McpInvocationResult(BaseModel):
+    """Result of an MCP tool invocation."""
+
+    success: bool
+    status_code: int
+    data: dict[str, Any] | None = None
+    error: str | None = None
+    latency_ms: float = 0.0
+
+
+class ApimMcpClient:
+    """Client for discovering and invoking MCP tools via the APIM gateway.
+
+    Follows ADR-035 URL convention: ``POST /agents/{service}/mcp/{tool}``.
+
+    Each target service gets its own :class:`CircuitBreaker` so that one
+    failing agent does not block calls to others.
+    """
+
+    def __init__(
+        self,
+        *,
+        apim_base_url: str,
+        caller_service: str,
+        timeout: float = 10.0,
+        failure_threshold: int = 5,
+        recovery_timeout: float = 30.0,
+        on_failure: FailureCallback | None = None,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        self._apim_base_url = apim_base_url.rstrip("/")
+        self._caller_service = caller_service
+        self._timeout = timeout
+        self._failure_threshold = failure_threshold
+        self._recovery_timeout = recovery_timeout
+        self._on_failure = on_failure
+        self._transport = transport
+        self._breakers: dict[str, CircuitBreaker] = {}
+
+    def tool_url(self, service: str, tool_name: str) -> str:
+        """Build APIM MCP tool URL following ADR-035 convention."""
+        return f"{self._apim_base_url}/agents/{service}/mcp/{tool_name}"
+
+    def _get_breaker(self, service: str) -> CircuitBreaker:
+        """Get or create a circuit breaker for the target service."""
+        if service not in self._breakers:
+            self._breakers[service] = CircuitBreaker(
+                name=f"apim-mcp:{service}",
+                failure_threshold=self._failure_threshold,
+                recovery_timeout=self._recovery_timeout,
+            )
+        return self._breakers[service]
+
+    async def _emit_failure(
+        self,
+        *,
+        target_service: str,
+        tool_name: str,
+        status_code: int | None,
+        error: Exception,
+    ) -> None:
+        if self._on_failure is None:
+            return
+        signal = FailureSignal(
+            service_name=self._caller_service,
+            surface=SurfaceType.MCP,
+            component=f"apim-mcp:{target_service}/{tool_name}",
+            status_code=status_code,
+            error_type=type(error).__name__,
+            error_message=str(error),
+            metadata={
+                "caller_service": self._caller_service,
+                "target_service": target_service,
+                "tool_name": tool_name,
+            },
+        )
+        try:
+            result = self._on_failure(signal)
+            if isawaitable(result):
+                await result
+        except (AttributeError, TypeError, ValueError, RuntimeError):
+            return
+
+    async def invoke(
+        self,
+        service: str,
+        tool_name: str,
+        payload: dict[str, Any] | None = None,
+        *,
+        extra_headers: dict[str, str] | None = None,
+    ) -> McpInvocationResult:
+        """Invoke an MCP tool on a target agent via APIM.
+
+        Propagates correlation IDs, uses per-service circuit breakers,
+        emits self-healing ``FailureSignal`` on errors, and logs
+        structured observability fields per ADR-031.
+        """
+        url = self.tool_url(service, tool_name)
+        headers: dict[str, str] = {
+            "Content-Type": "application/json",
+            "X-Caller-Service": self._caller_service,
+        }
+        correlation_id = get_correlation_id()
+        if correlation_id:
+            headers[CORRELATION_HEADER] = correlation_id
+        if extra_headers:
+            headers.update(extra_headers)
+
+        breaker = self._get_breaker(service)
+        start = time.monotonic()
+
+        try:
+            result = await breaker.call(self._do_request, url, payload, headers)
+        except CircuitBreakerOpenError:
+            latency_ms = (time.monotonic() - start) * 1000
+            logger.warning(
+                "apim_mcp_invoke circuit_open"
+                " correlation_id=%s caller_service=%s target_service=%s"
+                " tool_name=%s latency_ms=%.1f status=503",
+                correlation_id,
+                self._caller_service,
+                service,
+                tool_name,
+                latency_ms,
+            )
+            return McpInvocationResult(
+                success=False,
+                status_code=503,
+                error=f"Circuit open for {service}",
+                latency_ms=latency_ms,
+            )
+        except httpx.TimeoutException:
+            latency_ms = (time.monotonic() - start) * 1000
+            logger.warning(
+                "apim_mcp_invoke timeout"
+                " correlation_id=%s caller_service=%s target_service=%s"
+                " tool_name=%s latency_ms=%.1f status=504",
+                correlation_id,
+                self._caller_service,
+                service,
+                tool_name,
+                latency_ms,
+            )
+            return McpInvocationResult(
+                success=False,
+                status_code=504,
+                error=f"Timeout invoking {service}/{tool_name}",
+                latency_ms=latency_ms,
+            )
+        except httpx.HTTPStatusError as exc:
+            latency_ms = (time.monotonic() - start) * 1000
+            logger.warning(
+                "apim_mcp_invoke http_error"
+                " correlation_id=%s caller_service=%s target_service=%s"
+                " tool_name=%s latency_ms=%.1f status=%d error=%s",
+                correlation_id,
+                self._caller_service,
+                service,
+                tool_name,
+                latency_ms,
+                exc.response.status_code,
+                str(exc),
+            )
+            return McpInvocationResult(
+                success=False,
+                status_code=exc.response.status_code,
+                error=str(exc),
+                latency_ms=latency_ms,
+            )
+        except httpx.HTTPError as exc:
+            latency_ms = (time.monotonic() - start) * 1000
+            logger.warning(
+                "apim_mcp_invoke transport_error"
+                " correlation_id=%s caller_service=%s target_service=%s"
+                " tool_name=%s latency_ms=%.1f status=502 error=%s",
+                correlation_id,
+                self._caller_service,
+                service,
+                tool_name,
+                latency_ms,
+                str(exc),
+            )
+            return McpInvocationResult(
+                success=False,
+                status_code=502,
+                error=str(exc),
+                latency_ms=latency_ms,
+            )
+
+        latency_ms = (time.monotonic() - start) * 1000
+        result.latency_ms = latency_ms
+
+        if result.success:
+            logger.info(
+                "apim_mcp_invoke ok"
+                " correlation_id=%s caller_service=%s target_service=%s"
+                " tool_name=%s latency_ms=%.1f status=%d",
+                correlation_id,
+                self._caller_service,
+                service,
+                tool_name,
+                latency_ms,
+                result.status_code,
+            )
+        else:
+            logger.warning(
+                "apim_mcp_invoke error"
+                " correlation_id=%s caller_service=%s target_service=%s"
+                " tool_name=%s latency_ms=%.1f status=%d error=%s",
+                correlation_id,
+                self._caller_service,
+                service,
+                tool_name,
+                latency_ms,
+                result.status_code,
+                result.error,
+            )
+        return result
+
+    async def _do_request(
+        self,
+        url: str,
+        payload: dict[str, Any] | None,
+        headers: dict[str, str],
+    ) -> McpInvocationResult:
+        """Execute the HTTP POST and convert the response."""
+        try:
+            async with httpx.AsyncClient(
+                timeout=self._timeout,
+                transport=self._transport,
+            ) as client:
+                response = await client.post(url, json=payload, headers=headers)
+        except httpx.TimeoutException as exc:
+            await self._emit_failure(
+                target_service=self._extract_service(url),
+                tool_name=self._extract_tool(url),
+                status_code=504,
+                error=exc,
+            )
+            raise
+        except httpx.HTTPError as exc:
+            await self._emit_failure(
+                target_service=self._extract_service(url),
+                tool_name=self._extract_tool(url),
+                status_code=502,
+                error=exc,
+            )
+            raise
+
+        if response.is_success:
+            return McpInvocationResult(
+                success=True,
+                status_code=response.status_code,
+                data=response.json(),
+            )
+
+        error_exc = httpx.HTTPStatusError(
+            message=f"HTTP {response.status_code}",
+            request=response.request,
+            response=response,
+        )
+        await self._emit_failure(
+            target_service=self._extract_service(url),
+            tool_name=self._extract_tool(url),
+            status_code=response.status_code,
+            error=error_exc,
+        )
+        raise error_exc
+
+    @staticmethod
+    def _extract_service(url: str) -> str:
+        """Extract service name from an APIM MCP URL."""
+        parts = url.split("/agents/")
+        if len(parts) > 1:
+            return parts[1].split("/")[0]
+        return "unknown"
+
+    @staticmethod
+    def _extract_tool(url: str) -> str:
+        """Extract tool name from an APIM MCP URL."""
+        parts = url.split("/mcp/")
+        if len(parts) > 1:
+            return parts[1].split("/")[0].split("?")[0]
+        return "unknown"
+
+
+def create_apim_mcp_client(
+    *,
+    caller_service: str,
+    apim_base_url: str | None = None,
+    on_failure: FailureCallback | None = None,
+) -> ApimMcpClient | None:
+    """Create client from environment. Returns ``None`` if APIM base URL is not configured."""
+    url = apim_base_url or os.environ.get("APIM_BASE_URL") or os.environ.get("AGENT_APIM_BASE_URL")
+    if not url:
+        return None
+    return ApimMcpClient(
+        apim_base_url=url,
+        caller_service=caller_service,
+        on_failure=on_failure,
+    )

--- a/lib/tests/test_apim_mcp_client.py
+++ b/lib/tests/test_apim_mcp_client.py
@@ -1,0 +1,384 @@
+"""Tests for ApimMcpClient — APIM MCP discovery client."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from holiday_peak_lib.mcp.apim_client import (
+    ApimMcpClient,
+    McpInvocationResult,
+    McpToolDescriptor,
+    create_apim_mcp_client,
+)
+from holiday_peak_lib.self_healing.models import FailureSignal
+from holiday_peak_lib.utils.correlation import clear_correlation_id, set_correlation_id
+
+APIM_BASE = "https://apim.example.com"
+CALLER = "crm-profile-aggregation"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_transport(
+    status_code: int = 200,
+    json_body: dict[str, Any] | None = None,
+    *,
+    raise_timeout: bool = False,
+) -> httpx.MockTransport:
+    """Return an httpx.MockTransport that returns a fixed response."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if raise_timeout:
+            raise httpx.ReadTimeout("simulated timeout")
+        body = json_body if json_body is not None else {}
+        return httpx.Response(status_code, json=body)
+
+    return httpx.MockTransport(handler)
+
+
+def _make_client(
+    transport: httpx.AsyncBaseTransport | None = None,
+    on_failure: Any = None,
+    **kwargs: Any,
+) -> ApimMcpClient:
+    defaults: dict[str, Any] = {
+        "apim_base_url": APIM_BASE,
+        "caller_service": CALLER,
+        "timeout": 5.0,
+        "failure_threshold": 3,
+        "recovery_timeout": 10.0,
+    }
+    defaults.update(kwargs)
+    return ApimMcpClient(
+        **defaults,
+        on_failure=on_failure,
+        transport=transport,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. URL construction
+# ---------------------------------------------------------------------------
+
+
+class TestToolUrl:
+    def test_basic_url(self) -> None:
+        client = _make_client()
+        url = client.tool_url("cart-intelligence", "get_recommendations")
+        assert url == f"{APIM_BASE}/agents/cart-intelligence/mcp/get_recommendations"
+
+    def test_trailing_slash_stripped(self) -> None:
+        client = _make_client(apim_base_url=f"{APIM_BASE}/")
+        url = client.tool_url("svc", "tool")
+        assert url == f"{APIM_BASE}/agents/svc/mcp/tool"
+
+
+# ---------------------------------------------------------------------------
+# 2. Successful invocation
+# ---------------------------------------------------------------------------
+
+
+class TestSuccessfulInvocation:
+    @pytest.mark.asyncio
+    async def test_returns_success_result(self) -> None:
+        body = {"items": [1, 2, 3]}
+        transport = _mock_transport(200, body)
+        client = _make_client(transport=transport)
+
+        result = await client.invoke("cart", "get_items", {"user_id": "u1"})
+
+        assert result.success is True
+        assert result.status_code == 200
+        assert result.data == body
+        assert result.error is None
+
+    @pytest.mark.asyncio
+    async def test_empty_payload_sends_null_json(self) -> None:
+        transport = _mock_transport(200, {"ok": True})
+        client = _make_client(transport=transport)
+
+        result = await client.invoke("svc", "tool")
+
+        assert result.success is True
+
+
+# ---------------------------------------------------------------------------
+# 3. HTTP error handling
+# ---------------------------------------------------------------------------
+
+
+class TestHttpErrorHandling:
+    @pytest.mark.asyncio
+    async def test_4xx_returns_failure(self) -> None:
+        transport = _mock_transport(422, {"detail": "bad payload"})
+        client = _make_client(transport=transport)
+
+        result = await client.invoke("svc", "validate", {"x": 1})
+
+        assert result.success is False
+        assert result.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_5xx_returns_failure(self) -> None:
+        transport = _mock_transport(500, {"error": "internal"})
+        client = _make_client(transport=transport)
+
+        result = await client.invoke("svc", "tool")
+
+        assert result.success is False
+        assert result.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# 4. Correlation ID propagation
+# ---------------------------------------------------------------------------
+
+
+class TestCorrelationId:
+    @pytest.mark.asyncio
+    async def test_correlation_id_included_in_headers(self) -> None:
+        captured_headers: dict[str, str] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured_headers.update(dict(request.headers))
+            return httpx.Response(200, json={})
+
+        transport = httpx.MockTransport(handler)
+        client = _make_client(transport=transport)
+
+        cid = set_correlation_id("test-cid-abc")
+        try:
+            await client.invoke("svc", "tool")
+        finally:
+            clear_correlation_id()
+
+        assert captured_headers.get("x-correlation-id") == cid
+
+    @pytest.mark.asyncio
+    async def test_no_correlation_header_when_unset(self) -> None:
+        captured_headers: dict[str, str] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured_headers.update(dict(request.headers))
+            return httpx.Response(200, json={})
+
+        transport = httpx.MockTransport(handler)
+        client = _make_client(transport=transport)
+
+        clear_correlation_id()
+        await client.invoke("svc", "tool")
+
+        assert "x-correlation-id" not in captured_headers
+
+
+# ---------------------------------------------------------------------------
+# 5. Circuit breaker integration
+# ---------------------------------------------------------------------------
+
+
+class TestCircuitBreaker:
+    @pytest.mark.asyncio
+    async def test_per_service_breakers(self) -> None:
+        transport = _mock_transport(200, {})
+        client = _make_client(transport=transport)
+
+        await client.invoke("svc-a", "tool")
+        await client.invoke("svc-b", "tool")
+
+        assert "svc-a" in client._breakers
+        assert "svc-b" in client._breakers
+        assert client._breakers["svc-a"] is not client._breakers["svc-b"]
+
+    @pytest.mark.asyncio
+    async def test_circuit_open_returns_503(self) -> None:
+        transport = _mock_transport(500, {"error": "fail"})
+        client = _make_client(transport=transport, failure_threshold=2)
+
+        # Trip the breaker
+        await client.invoke("svc", "tool")
+        await client.invoke("svc", "tool")
+
+        # Now circuit should be open
+        result = await client.invoke("svc", "tool")
+        assert result.success is False
+        assert result.status_code == 503
+        assert "Circuit open" in (result.error or "")
+
+
+# ---------------------------------------------------------------------------
+# 6. Self-healing signal emission
+# ---------------------------------------------------------------------------
+
+
+class TestSelfHealingSignal:
+    @pytest.mark.asyncio
+    async def test_failure_signal_emitted_on_http_error(self) -> None:
+        signals: list[FailureSignal] = []
+
+        def on_fail(sig: FailureSignal) -> None:
+            signals.append(sig)
+
+        transport = _mock_transport(500, {"error": "boom"})
+        client = _make_client(transport=transport, on_failure=on_fail)
+
+        result = await client.invoke("target-svc", "broken_tool")
+
+        assert result.success is False
+        assert len(signals) == 1
+        sig = signals[0]
+        assert sig.service_name == CALLER
+        assert sig.surface == "mcp"
+        assert "target-svc" in sig.component
+        assert "broken_tool" in sig.component
+        assert sig.status_code == 500
+
+    @pytest.mark.asyncio
+    async def test_async_failure_callback(self) -> None:
+        signals: list[FailureSignal] = []
+        callback = AsyncMock(side_effect=lambda sig: signals.append(sig))
+
+        transport = _mock_transport(500, {"error": "fail"})
+        client = _make_client(transport=transport, on_failure=callback)
+
+        await client.invoke("svc", "tool")
+
+        callback.assert_called_once()
+        assert len(signals) == 1
+
+
+# ---------------------------------------------------------------------------
+# 7. Timeout handling
+# ---------------------------------------------------------------------------
+
+
+class TestTimeoutHandling:
+    @pytest.mark.asyncio
+    async def test_timeout_returns_504(self) -> None:
+        transport = _mock_transport(raise_timeout=True)
+        client = _make_client(transport=transport)
+
+        result = await client.invoke("svc", "tool")
+
+        assert result.success is False
+        assert result.status_code == 504
+        assert "Timeout" in (result.error or "")
+        assert result.latency_ms > 0
+
+    @pytest.mark.asyncio
+    async def test_timeout_emits_failure_signal(self) -> None:
+        signals: list[FailureSignal] = []
+
+        def on_fail(sig: FailureSignal) -> None:
+            signals.append(sig)
+
+        transport = _mock_transport(raise_timeout=True)
+        client = _make_client(transport=transport, on_failure=on_fail)
+
+        result = await client.invoke("svc", "tool")
+
+        assert result.success is False
+        assert len(signals) == 1
+        assert signals[0].status_code == 504
+
+
+# ---------------------------------------------------------------------------
+# 8. Factory function
+# ---------------------------------------------------------------------------
+
+
+class TestFactory:
+    def test_returns_client_with_explicit_url(self) -> None:
+        client = create_apim_mcp_client(
+            caller_service=CALLER,
+            apim_base_url="https://gw.example.com",
+        )
+        assert client is not None
+        assert isinstance(client, ApimMcpClient)
+
+    def test_returns_none_without_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("APIM_BASE_URL", raising=False)
+        monkeypatch.delenv("AGENT_APIM_BASE_URL", raising=False)
+
+        client = create_apim_mcp_client(caller_service=CALLER)
+        assert client is None
+
+    def test_reads_apim_base_url_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("APIM_BASE_URL", "https://env.example.com")
+        monkeypatch.delenv("AGENT_APIM_BASE_URL", raising=False)
+
+        client = create_apim_mcp_client(caller_service=CALLER)
+        assert client is not None
+
+    def test_reads_agent_apim_base_url_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("APIM_BASE_URL", raising=False)
+        monkeypatch.setenv("AGENT_APIM_BASE_URL", "https://agent-env.example.com")
+
+        client = create_apim_mcp_client(caller_service=CALLER)
+        assert client is not None
+
+
+# ---------------------------------------------------------------------------
+# 9. Latency measurement
+# ---------------------------------------------------------------------------
+
+
+class TestLatency:
+    @pytest.mark.asyncio
+    async def test_latency_ms_populated(self) -> None:
+        transport = _mock_transport(200, {"ok": True})
+        client = _make_client(transport=transport)
+
+        result = await client.invoke("svc", "tool")
+
+        assert result.latency_ms > 0
+
+
+# ---------------------------------------------------------------------------
+# 10. Extra headers
+# ---------------------------------------------------------------------------
+
+
+class TestExtraHeaders:
+    @pytest.mark.asyncio
+    async def test_extra_headers_merged(self) -> None:
+        captured_headers: dict[str, str] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured_headers.update(dict(request.headers))
+            return httpx.Response(200, json={})
+
+        transport = httpx.MockTransport(handler)
+        client = _make_client(transport=transport)
+
+        await client.invoke(
+            "svc",
+            "tool",
+            extra_headers={"X-Custom": "value123"},
+        )
+
+        assert captured_headers.get("x-custom") == "value123"
+        assert captured_headers.get("x-caller-service") == CALLER
+
+
+# ---------------------------------------------------------------------------
+# 11. McpToolDescriptor model
+# ---------------------------------------------------------------------------
+
+
+class TestMcpToolDescriptor:
+    def test_serialization(self) -> None:
+        desc = McpToolDescriptor(
+            service="cart",
+            tool_name="get_items",
+            url="https://apim.example.com/agents/cart/mcp/get_items",
+        )
+        data = desc.model_dump()
+        assert data["service"] == "cart"
+        assert data["tool_name"] == "get_items"
+        assert "/agents/cart/mcp/get_items" in data["url"]

--- a/lib/tests/test_apim_mcp_client.py
+++ b/lib/tests/test_apim_mcp_client.py
@@ -9,7 +9,6 @@ import httpx
 import pytest
 from holiday_peak_lib.mcp.apim_client import (
     ApimMcpClient,
-    McpInvocationResult,
     McpToolDescriptor,
     create_apim_mcp_client,
 )


### PR DESCRIPTION
## Summary

Implements **ApimMcpClient** — a typed HTTP client for agent-to-agent MCP tool invocations via Azure API Management (APIM).

Closes #886

## What Changed

| File | Change |
|------|--------|
| \lib/src/holiday_peak_lib/mcp/apim_client.py\ | **New** — \ApimMcpClient\ class, Pydantic models, factory function |
| \lib/tests/test_apim_mcp_client.py\ | **New** — 21 unit tests (URL building, success/error handling, circuit breaker, self-healing, correlation, timeout, factory) |
| \lib/src/holiday_peak_lib/mcp/__init__.py\ | **Modified** — export new symbols |

## Key Features

- **APIM URL convention**: \{base}/agents/{service}/mcp/{tool}\ per gateway routing rules
- **Per-service circuit breakers**: configurable \ailure_threshold\ and \ecovery_timeout\
- **Self-healing integration**: emits \FailureSignal(SurfaceType.MCP)\ on failures for \SelfHealingKernel\ consumption
- **Correlation ID propagation**: reads from \ContextVar\, includes in request headers for distributed tracing
- **Structured logging**: caller_service, target_service, tool_name, latency_ms, status per ADR-031
- **Transport injection**: accepts \httpx.AsyncBaseTransport\ for deterministic testing (no mocking)
- **Factory function**: \create_apim_mcp_client()\ reads \APIM_BASE_URL\ / \AGENT_APIM_BASE_URL\ env vars

## Error Mapping

| Scenario | Status Code |
|----------|-------------|
| HTTP 4xx/5xx | Actual status code |
| Timeout | 504 |
| Circuit breaker open | 503 |
| Transport/network error | 502 |

## Testing

- 21 tests, all passing
- isort + black clean
- Uses \httpx.MockTransport\ for all HTTP interactions — no network calls