### PR TITLE
fix(agc): add ApplicationLoadBalancer CRD for Gateway acceptance

### DIFF
--- a/.kubernetes/rendered/crud-service/all.yaml
+++ b/.kubernetes/rendered/crud-service/all.yaml
@@ -164,6 +164,18 @@ spec:
               memory: 256Mi
 ---
 # Source: holiday-peak-service/templates/agc-routing.yaml
+apiVersion: alb.networking.azure.io/v1
+kind: ApplicationLoadBalancer
+metadata:
+  name: holiday-peak-agc
+  namespace: holiday-peak-crud
+  labels:
+    app: crud-service
+spec:
+  associations:
+    - "/subscriptions/150e82e8-25db-4f1a-8e04-a2f6a77d26c4/resourceGroups/holidaypeakhub405-dev-rg/providers/Microsoft.Network/virtualNetworks/holidaypeakhub405-dev-vnet/subnets/agc"
+---
+# Source: holiday-peak-service/templates/agc-routing.yaml
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:


### PR DESCRIPTION
The Gateway was Accepted=False because the BYO annotations referenced an ALB CRD that did not exist in the cluster. This adds the ApplicationLoadBalancer resource with the agc subnet association so the ALB controller provisions the Azure Traffic Controller.