### PR TITLE
fix: prevent azure-ai-projects SDK telemetry crash on NonRecordingSpan (#933)

### DIFF
--- a/lib/src/holiday_peak_lib/__init__.py
+++ b/lib/src/holiday_peak_lib/__init__.py
@@ -1,5 +1,26 @@
 """Holiday Peak Hub core micro-framework."""
 
+# --- Early SDK compatibility patch -------------------------------------------
+# azure-ai-projects <=2.1.0 telemetry instrumentor reads
+# span.span_instance.attributes, but OpenTelemetry NonRecordingSpan lacks that
+# attribute.  Patch the class *before* any SDK instrumentation runs.
+from opentelemetry.trace import NonRecordingSpan as _NRS  # noqa: E402
+
+if not hasattr(_NRS, "attributes"):
+    _NRS.attributes = None  # type: ignore[attr-defined]
+
+# Ensure a real TracerProvider is configured so NonRecordingSpan is never
+# produced at runtime.  If Azure Monitor is configured later it will override.
+from opentelemetry import trace as _trace  # noqa: E402
+from opentelemetry.sdk.trace import TracerProvider as _TracerProvider  # noqa: E402
+
+if not isinstance(_trace.get_tracer_provider(), _TracerProvider):
+    try:
+        _trace.set_tracer_provider(_TracerProvider())
+    except Exception:  # pragma: no cover – already set by another init path
+        pass
+# -----------------------------------------------------------------------------
+
 from holiday_peak_lib.app_factory import build_service_app, create_standard_app
 from holiday_peak_lib.utils.logging import configure_logging
 

--- a/lib/src/holiday_peak_lib/agents/foundry.py
+++ b/lib/src/holiday_peak_lib/agents/foundry.py
@@ -20,15 +20,11 @@ from azure.ai.projects.aio import AIProjectClient
 from azure.ai.projects.models import PromptAgentDefinition
 from azure.core.exceptions import HttpResponseError
 from azure.identity.aio import DefaultAzureCredential
-from opentelemetry.trace import NonRecordingSpan as _NRS
 
 from .base_agent import ModelTarget
 
-# Workaround: azure-ai-projects <=2.0.1 NonRecordingSpan bug.
-# The SDK instrumentor reads span.span_instance.attributes, but the OTel
-# no-op span lacks the property. Adding a falsy .attributes is safe.
-if not hasattr(_NRS, "attributes"):
-    _NRS.attributes = None  # type: ignore[attr-defined]
+# NOTE: NonRecordingSpan.attributes patch is now applied in holiday_peak_lib/__init__.py
+# to guarantee it executes before any SDK instrumentation regardless of import order.
 
 _FOUNDRY_PROJECT_HOST_SUFFIX = ".services.ai.azure.com"
 

--- a/lib/src/holiday_peak_lib/utils/telemetry.py
+++ b/lib/src/holiday_peak_lib/utils/telemetry.py
@@ -257,6 +257,19 @@ class FoundryTracer:
         os.environ.setdefault("AZURE_SDK_TRACING_IMPLEMENTATION", "opentelemetry")
 
         with _FOUNDRY_INSTRUMENTATION_LOCK:
+            # Guarantee a real TracerProvider exists so the SDK never encounters
+            # NonRecordingSpan (which lacks .attributes and crashes the
+            # _responses_instrumentor).  Azure Monitor may override this later.
+            from opentelemetry.sdk.trace import (
+                TracerProvider as _SdkTP,  # pylint: disable=import-outside-toplevel
+            )
+
+            if not isinstance(trace.get_tracer_provider(), _SdkTP):
+                try:
+                    trace.set_tracer_provider(_SdkTP())
+                except Exception:  # noqa: BLE001 – already set
+                    pass
+
             if self.connection_string and not _FOUNDRY_INSTRUMENTATION_STATE["azure_monitor"]:
                 try:
                     configure_azure_monitor(connection_string=self.connection_string)

--- a/lib/tests/test_telemetry.py
+++ b/lib/tests/test_telemetry.py
@@ -339,3 +339,38 @@ class TestOutcomeStatusInEvents:
         )
         event = tracer.get_traces(limit=1)[0]
         assert event["metadata"]["model_tier"] == "unknown"
+
+
+class TestNonRecordingSpanPatch:
+    """Regression tests for issue #933: SDK crash on NonRecordingSpan.attributes."""
+
+    def test_nonrecordingspan_has_attributes(self):
+        """NonRecordingSpan must have a falsy .attributes after lib init."""
+        from opentelemetry.trace import INVALID_SPAN_CONTEXT, NonRecordingSpan
+
+        span = NonRecordingSpan(INVALID_SPAN_CONTEXT)
+        # Must not raise AttributeError
+        assert span.attributes is None
+
+    def test_sdk_append_attribute_path_does_not_crash(self):
+        """The exact code path from azure-ai-projects _responses_instrumentor:561."""
+        from azure.core.tracing.ext.opentelemetry_span import OpenTelemetrySpan
+        from opentelemetry.trace import INVALID_SPAN_CONTEXT, NonRecordingSpan
+
+        nrs = NonRecordingSpan(INVALID_SPAN_CONTEXT)
+        wrapper = OpenTelemetrySpan(span=nrs)
+        # Reproduce SDK line 561 — must not raise
+        result = (
+            wrapper.span_instance.attributes.get("gen_ai.input.messages")
+            if wrapper.span_instance.attributes
+            else None
+        )
+        assert result is None
+
+    def test_real_tracer_provider_configured(self):
+        """A real TracerProvider should be set so NonRecordingSpan is avoided."""
+        from opentelemetry import trace
+        from opentelemetry.sdk.trace import TracerProvider
+
+        tp = trace.get_tracer_provider()
+        assert isinstance(tp, TracerProvider)


### PR DESCRIPTION
## Summary
Closes #933

### Root Cause
The azure-ai-projects SDK (v2.1.0) telemetry instrumentor at \_responses_instrumentor.py:561\ reads \span.span_instance.attributes.get(...)\, but OpenTelemetry's \NonRecordingSpan\ (produced when no real TracerProvider is configured) lacks the \.attributes\ property, causing \AttributeError\ → HTTP 500 on all 8 agents using the Foundry Responses API path.

A monkey-patch existed in \oundry.py\ (added April 15) but was fragile — it depended on import order and may not have been deployed to all pods.

### Fix (defense-in-depth)
1. **Belt** — Move \NonRecordingSpan.attributes = None\ patch to \holiday_peak_lib/__init__.py\ so it executes before ANY other code regardless of import order or worker process spawning
2. **Suspenders** — Configure a real \TracerProvider\ (from opentelemetry-sdk) at init time so \NonRecordingSpan\ is never produced. Azure Monitor overrides this later if a connection string is available
3. **Double-check** — Add TracerProvider guard inside \FoundryTracer._initialize_foundry_instrumentation()\ before calling \AIProjectInstrumentor().instrument()\

### Files Changed
- \lib/src/holiday_peak_lib/__init__.py\ — Early patch + TracerProvider fallback
- \lib/src/holiday_peak_lib/agents/foundry.py\ — Remove redundant patch (now handled at init level)
- \lib/src/holiday_peak_lib/utils/telemetry.py\ — TracerProvider guard in instrumentation
- \lib/tests/test_telemetry.py\ — 3 regression tests reproducing the exact SDK crash path

### Verification
- All 1316 lib tests pass (1313 existing + 3 new)
- Local reproduction of SDK code path confirms no crash
- isort + black pass