### PR TITLE
fix(ui): resolve ESLint --max-warnings 0 failures in ui-quality

### DIFF
--- a/apps/ui/app/order/[id]/page.tsx
+++ b/apps/ui/app/order/[id]/page.tsx
@@ -80,7 +80,6 @@ export default function OrderTrackingPage() {
     () => returns.filter((item) => item.order_id === orderId),
     [returns, orderId],
   );
-  const hasReturnSignals = orderReturns.length > 0 || createReturnMutation.isSuccess;
   const returnFlowActive = Boolean(returnReason.trim())
     || createReturnMutation.isPending
     || createReturnMutation.isSuccess

--- a/apps/ui/components/demo/AgentProfileDrawer.tsx
+++ b/apps/ui/components/demo/AgentProfileDrawer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { TraceWaterfall } from '@/components/admin/TraceWaterfall';
 import { AgentRobot } from '@/components/organisms/AgentRobot';
 import {
@@ -60,7 +60,7 @@ export function AgentProfileDrawer({
     traceExplorerOpen ? selectedTraceId : '',
     DEFAULT_AGENT_MONITOR_RANGE,
   );
-  const recentTraces = recentTracesQuery.data ?? [];
+  const recentTraces = useMemo(() => recentTracesQuery.data ?? [], [recentTracesQuery.data]);
 
   useEffect(() => {
     if (!open || !profile) {

--- a/apps/ui/components/organisms/AgentRobot.tsx
+++ b/apps/ui/components/organisms/AgentRobot.tsx
@@ -231,6 +231,11 @@ function PixelFace({ personality, state, size, gazeX = 0 }: PixelFaceProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const animFrameRef = useRef<number>(0);
   const blinkTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const gazeXRef = useRef(gazeX);
+
+  useEffect(() => {
+    gazeXRef.current = gazeX;
+  }, [gazeX]);
 
   const visorW = Math.round(size * 0.65);
   const visorH = Math.round(size * 0.38);
@@ -317,7 +322,7 @@ function PixelFace({ personality, state, size, gazeX = 0 }: PixelFaceProps) {
       const eyePattern = getEyePattern();
       const mouthPattern = getMouthPattern();
       const color = personality.visorColor;
-      const horizontalLookOffset = Math.round(Math.max(-1, Math.min(1, gazeX)) * 1.2);
+      const horizontalLookOffset = Math.round(Math.max(-1, Math.min(1, gazeXRef.current)) * 1.2);
 
       const eyeBlockW = 5 * (pixelSize + gap);
       const eyeGapPx = Math.round(visorW * 0.12);


### PR DESCRIPTION
## Summary

Follow-up to PR #937: the `ui-quality` GitHub Action runs `eslint . --max-warnings 0` (ie. warnings are errors), and three issues were tripping it on `main`.

### Failures fixed

- `apps/ui/app/order/[id]/page.tsx:83` — `'hasReturnSignals' is assigned a value but never used` (`@typescript-eslint/no-unused-vars`). The local was orphaned; the live copy lives in `apps/ui/app/orders/page.tsx`. Removed.
- `apps/ui/components/demo/AgentProfileDrawer.tsx:63` — `'recentTraces' could make the dependencies of useEffect Hook (line 110) change on every render` (`react-hooks/exhaustive-deps`). Wrapped the array fallback in `useMemo(() => recentTracesQuery.data ?? [], [recentTracesQuery.data])`.
- `apps/ui/components/organisms/AgentRobot.tsx:385` — `React Hook useEffect has a missing dependency: 'gazeX'`. Adding `gazeX` to deps would tear down/restart the rAF animation loop on every gaze update; instead, store the latest value in a `gazeXRef` updated via a small effect and read `gazeXRef.current` inside the render closure.

### Validation

- `yarn lint` clean (0 errors, 0 warnings) — same command + flags as CI.
- `yarn type-check` clean.
- Pre-push gate: pylint 9.89/10, mypy clean, isort/black clean, 1316 lib + 701 app tests passing.