### PR TITLE
fix(ui): unblock ui-quality unit tests after Navigation/usePathname changes

### DIFF
--- a/apps/ui/tests/unit/Navigation.test.tsx
+++ b/apps/ui/tests/unit/Navigation.test.tsx
@@ -38,9 +38,9 @@ describe('Navigation', () => {
   beforeEach(() => {
     usePathnameMock.mockReturnValue('/');
     useAuthMock.mockReturnValue({
-      isAuthenticated: false,
+      isAuthenticated: true,
       loginAsMockRole: jest.fn(),
-      user: null,
+      user: { roles: ['staff'] },
     });
     useAgentGlobalHealthMock.mockReturnValue({
       data: 'healthy',
@@ -64,7 +64,7 @@ describe('Navigation', () => {
       expect(within(mobileMenu).getByRole('link', { name: link.label })).toBeInTheDocument();
     }
 
-    expect(within(mobileMenu).getByRole('link', { name: 'Pipeline status' })).toBeInTheDocument();
+    expect(within(mobileMenu).getByRole('link', { name: 'Pipeline healthy' })).toBeInTheDocument();
     expect(within(mobileMenu).getByRole('link', { name: 'Open Agent Popup' })).toBeInTheDocument();
   });
 

--- a/apps/ui/tests/unit/SearchPage.test.tsx
+++ b/apps/ui/tests/unit/SearchPage.test.tsx
@@ -12,6 +12,7 @@ jest.mock('next/navigation', () => ({
   useSearchParams: () => ({
     get: getParam,
   }),
+  usePathname: () => '/search',
 }));
 
 const mockUseIntelligentSearch = jest.fn();

--- a/apps/ui/tests/unit/checkoutFlow.test.tsx
+++ b/apps/ui/tests/unit/checkoutFlow.test.tsx
@@ -10,6 +10,7 @@ const mockUseReservationOutcomeQueries = jest.fn();
 
 jest.mock('next/navigation', () => ({
   useRouter: () => ({ push }),
+  usePathname: () => '/checkout',
 }));
 
 jest.mock('../../lib/hooks/useCart', () => ({

--- a/apps/ui/tests/unit/pagesRender.test.tsx
+++ b/apps/ui/tests/unit/pagesRender.test.tsx
@@ -35,6 +35,7 @@ jest.mock('next/navigation', () => ({
   useParams: () => ({ id: 'ORD-2026-0123', entityId: 'prod-001' }),
   useRouter: () => ({ push: jest.fn() }),
   useSearchParams: () => useSearchParamsMock(),
+  usePathname: () => '/',
 }));
 
 jest.mock('../../lib/hooks/useCategories', () => ({


### PR DESCRIPTION
## Summary

Follow-up to #937 + #938. ESLint is now green but the `ui-quality` workflow still fails because several Jest tests render the real `Navigation` (which uses `usePathname` from `next/navigation`) without mocking it. This PR makes the navigation-related unit tests pass again.

### Changes

- Add `usePathname` to `next/navigation` Jest mocks in the affected test files so `Navigation` can render under jsdom.
- Update `Navigation.test.tsx` to seed a staff role in the mocked auth context (the Pipeline Status pill is now correctly gated behind `canViewAgentHealth`).

### Out of scope (tracked separately)

Three unrelated unit-test failures pre-date this PR series and are not navigation-related:
- `test_product_service.py` async-mock drift
- `apiClientMockAuth` mock client behaviour
- 3 page-level smoke tests (Deals/Catalog) needing fixture refresh

### Validation

- `yarn lint` clean.
- `yarn type-check` clean.
- Pre-push gate: pylint 9.89/10, mypy clean, 1316 lib + 701 app tests passing.
- Affected Jest tests pass locally.