### PR TITLE
feat(#936): implement agent mode classification in code artifacts

### DIFF
--- a/.github/skills/agent-e2e-validation/SKILL.md
+++ b/.github/skills/agent-e2e-validation/SKILL.md
@@ -77,14 +77,31 @@ If **any** pre-flight check fails, do NOT proceed to agent testing. Instead:
 
 ## Non-Functional Requirements
 
+### Sync Agents (11 — real-time, user-facing)
+
+Agents: ecommerce-catalog-search, ecommerce-cart-intelligence, ecommerce-checkout-support, ecommerce-order-status, ecommerce-product-detail-enrichment, crm-profile-aggregation, crm-support-assistance, inventory-reservation-validation, logistics-eta-computation, logistics-carrier-selection, logistics-returns-support.
+
 | Requirement | Target | Validation |
 |---|---|---|
 | Agent health response | < 2 seconds | `GET /agents/{service}/health` |
-| Invoke response (sync) | < 8 seconds (5s pipeline + 3s HTTP overhead) | `POST /agents/{service}/invoke` |
+| Invoke response P95 | < 8 seconds (5s pipeline + 3s HTTP overhead) | `POST /agents/{service}/invoke` |
 | Streaming response (SSE) | First token < 3 seconds | `POST /agents/{service}/invoke/stream` |
-| Event Hub processing | Event consumed within 30 seconds | Check agent logs after CRUD event publish |
 | MCP tool call | < 5 seconds round-trip | `POST /agents/{service}/mcp/{tool}` |
 | CRUD REST operations | < 500ms for reads, < 1s for writes | Standard REST calls |
+
+### Async Agents (15 — background, event-driven)
+
+Agents: crm-campaign-intelligence, crm-segmentation-personalization, inventory-alerts-triggers, inventory-health-check, inventory-jit-replenishment, logistics-route-issue-detection, product-management-acp-transformation, product-management-assortment-optimization, product-management-consistency-validation, product-management-normalization-classification, search-enrichment-agent, truth-ingestion, truth-enrichment, truth-hitl, truth-export.
+
+| Requirement | Target | Validation |
+|---|---|---|
+| Agent health response | < 2 seconds | `GET /agents/{service}/health` |
+| Event Hub processing | Event consumed within 30 seconds | Check agent logs after CRUD event publish |
+| Consumer lag | < 10 minutes behind head | Event Hubs consumer group lag metric |
+| Throughput (batch window) | Process ≥ 95% of events per 15-min window | Log Analytics query on processed vs received |
+| MCP tool call | < 5 seconds round-trip | `POST /agents/{service}/mcp/{tool}` |
+
+> **Note:** Async agents do NOT have an invoke latency SLA. Their `/invoke` endpoint (if present) is used for manual testing only and is not subject to the 8-second target.
 
 ## Architecture Overview
 

--- a/.infra/modules/monitoring/monitoring.bicep
+++ b/.infra/modules/monitoring/monitoring.bicep
@@ -1123,5 +1123,184 @@ resource uiProxyCritical502Alert 'Microsoft.Insights/scheduledQueryRules@2023-12
   }
 }
 
+// ─── Agent Mode-Aware Alert Rules (ADR-024 Part 4) ────────────────────────────
+
+var syncAgentP95Query = '''
+let syncServices = dynamic([
+  "ecommerce-catalog-search",
+  "ecommerce-cart-intelligence",
+  "ecommerce-checkout-support",
+  "ecommerce-order-status",
+  "ecommerce-product-detail-enrichment",
+  "crm-profile-aggregation",
+  "crm-support-assistance",
+  "inventory-reservation-validation",
+  "logistics-eta-computation",
+  "logistics-carrier-selection",
+  "logistics-returns-support"
+]);
+let agentRequests =
+  union isfuzzy=true
+    (AppRequests | project eventTime = TimeGenerated, name = tostring(Name), duration = DurationMs),
+    (requests | project eventTime = timestamp, name = tostring(name), duration = toint(duration));
+agentRequests
+| where eventTime > ago(15m)
+| extend serviceName = extract(@"/agents/([^/]+)/invoke", 1, name)
+| where isnotempty(serviceName) and serviceName in~ (syncServices)
+| summarize p95_ms = percentile(duration, 95) by serviceName
+| where p95_ms > 8000
+| extend breach = 1
+'''
+
+var asyncConsumerLagQuery = '''
+let asyncServices = dynamic([
+  "crm-campaign-intelligence",
+  "crm-segmentation-personalization",
+  "inventory-alerts-triggers",
+  "inventory-health-check",
+  "inventory-jit-replenishment",
+  "logistics-route-issue-detection",
+  "product-management-acp-transformation",
+  "product-management-assortment-optimization",
+  "product-management-consistency-validation",
+  "product-management-normalization-classification",
+  "search-enrichment-agent",
+  "truth-ingestion",
+  "truth-enrichment",
+  "truth-hitl",
+  "truth-export"
+]);
+AzureMetrics
+| where TimeGenerated > ago(15m)
+| where ResourceProvider == "MICROSOFT.EVENTHUB"
+| where MetricName == "OutgoingMessages"
+| extend consumerGroup = tostring(split(Resource, "/")[2])
+| extend serviceName = iif(consumerGroup has_any (asyncServices), consumerGroup, "")
+| where isnotempty(serviceName)
+| summarize totalOutgoing = sum(Total) by serviceName
+| join kind=inner (
+    AzureMetrics
+    | where TimeGenerated > ago(15m)
+    | where ResourceProvider == "MICROSOFT.EVENTHUB"
+    | where MetricName == "IncomingMessages"
+    | summarize totalIncoming = sum(Total) by Resource
+  ) on $left.serviceName == $right.Resource
+| extend lagEstimate = totalIncoming - totalOutgoing
+| where lagEstimate > 600
+| extend breach = 1
+'''
+
+resource syncAgentLatencyAlert 'Microsoft.Insights/scheduledQueryRules@2023-12-01' = {
+  name: '${projectName}-${environment}-sync-agent-p95-latency'
+  location: location
+  kind: 'LogAlert'
+  properties: {
+    description: 'Sync agent invoke P95 latency exceeds 8 seconds over 15-minute window. Per ADR-024 Part 4, only sync (user-facing) agents are subject to invoke latency SLA.'
+    displayName: '${projectName}-${environment} sync agent P95 latency breach'
+    enabled: true
+    severity: 2
+    evaluationFrequency: 'PT5M'
+    windowSize: 'PT15M'
+    scopes: [
+      monitoringWorkspaceResourceId
+    ]
+    targetResourceTypes: [
+      'Microsoft.OperationalInsights/workspaces'
+    ]
+    criteria: {
+      allOf: [
+        {
+          query: syncAgentP95Query
+          timeAggregation: 'Maximum'
+          metricMeasureColumn: 'breach'
+          operator: 'GreaterThan'
+          threshold: 0
+          failingPeriods: {
+            numberOfEvaluationPeriods: 3
+            minFailingPeriodsToAlert: 2
+          }
+          dimensions: [
+            {
+              name: 'serviceName'
+              operator: 'Include'
+              values: [
+                '*'
+              ]
+            }
+          ]
+        }
+      ]
+    }
+    autoMitigate: true
+    skipQueryValidation: false
+    actions: {
+      actionGroups: [
+        actionGroup.id
+      ]
+      customProperties: {
+        agentClass: 'sync'
+        slaTarget: 'P95 < 8s'
+        adr: 'ADR-024-Part4'
+      }
+    }
+  }
+}
+
+resource asyncAgentConsumerLagAlert 'Microsoft.Insights/scheduledQueryRules@2023-12-01' = {
+  name: '${projectName}-${environment}-async-agent-consumer-lag'
+  location: location
+  kind: 'LogAlert'
+  properties: {
+    description: 'Async agent consumer lag exceeds 10-minute threshold. Per ADR-024 Part 4, async agents are measured on throughput and lag, not invoke latency.'
+    displayName: '${projectName}-${environment} async agent consumer lag breach'
+    enabled: true
+    severity: 3
+    evaluationFrequency: 'PT5M'
+    windowSize: 'PT15M'
+    scopes: [
+      monitoringWorkspaceResourceId
+    ]
+    targetResourceTypes: [
+      'Microsoft.OperationalInsights/workspaces'
+    ]
+    criteria: {
+      allOf: [
+        {
+          query: asyncConsumerLagQuery
+          timeAggregation: 'Maximum'
+          metricMeasureColumn: 'breach'
+          operator: 'GreaterThan'
+          threshold: 0
+          failingPeriods: {
+            numberOfEvaluationPeriods: 3
+            minFailingPeriodsToAlert: 2
+          }
+          dimensions: [
+            {
+              name: 'serviceName'
+              operator: 'Include'
+              values: [
+                '*'
+              ]
+            }
+          ]
+        }
+      ]
+    }
+    autoMitigate: true
+    skipQueryValidation: false
+    actions: {
+      actionGroups: [
+        actionGroup.id
+      ]
+      customProperties: {
+        agentClass: 'async'
+        slaTarget: 'consumer lag < 10min'
+        adr: 'ADR-024-Part4'
+      }
+    }
+  }
+}
+
 output actionGroupId string = actionGroup.id
 output actionGroupName string = actionGroup.name

--- a/apps/ui/lib/agents/profiles.ts
+++ b/apps/ui/lib/agents/profiles.ts
@@ -7,6 +7,8 @@ export type AgentProfileDomain =
   | 'search'
   | 'truth-layer';
 
+export type AgentPrimaryMode = 'sync' | 'async';
+
 export type AgentProfileSlug = (typeof ALL_AGENT_SLUGS)[number];
 
 export interface AgentProductivityGain {
@@ -40,6 +42,7 @@ export interface AgentProfile {
   displayName: string;
   domain: AgentProfileDomain;
   domainLabel: string;
+  primaryMode: AgentPrimaryMode;
   oneLiner: string;
   fitFor: string[];
   retailProblem: string;
@@ -157,6 +160,40 @@ const TRACE_EXPLORER_HREF_BY_SLUG: Record<AgentProfileSlug, string> = {
   'truth-enrichment': '/admin/truth-analytics',
   'truth-hitl': '/staff/review',
   'truth-export': '/admin/workflows',
+};
+
+/**
+ * Agent primary mode classification per ADR-024 Part 4.
+ * Sync agents serve real-time user-facing requests; async agents process
+ * background event-driven workloads.
+ */
+const PRIMARY_MODE_BY_SLUG: Record<AgentProfileSlug, AgentPrimaryMode> = {
+  'crm-campaign-intelligence': 'async',
+  'crm-profile-aggregation': 'sync',
+  'crm-segmentation-personalization': 'async',
+  'crm-support-assistance': 'sync',
+  'ecommerce-catalog-search': 'sync',
+  'ecommerce-cart-intelligence': 'sync',
+  'ecommerce-checkout-support': 'sync',
+  'ecommerce-order-status': 'sync',
+  'ecommerce-product-detail-enrichment': 'sync',
+  'inventory-health-check': 'async',
+  'inventory-alerts-triggers': 'async',
+  'inventory-jit-replenishment': 'async',
+  'inventory-reservation-validation': 'sync',
+  'logistics-carrier-selection': 'sync',
+  'logistics-eta-computation': 'sync',
+  'logistics-returns-support': 'sync',
+  'logistics-route-issue-detection': 'async',
+  'product-management-acp-transformation': 'async',
+  'product-management-assortment-optimization': 'async',
+  'product-management-consistency-validation': 'async',
+  'product-management-normalization-classification': 'async',
+  'search-enrichment-agent': 'async',
+  'truth-ingestion': 'async',
+  'truth-enrichment': 'async',
+  'truth-hitl': 'async',
+  'truth-export': 'async',
 };
 
 type DomainPreset = Pick<
@@ -922,6 +959,7 @@ function buildProfile(slug: (typeof ALL_AGENT_SLUGS)[number]): AgentProfile {
     slug,
     domain,
     domainLabel: preset.domainLabel,
+    primaryMode: PRIMARY_MODE_BY_SLUG[slug],
     displayName: override?.displayName ?? prettifySlug(slug),
     oneLiner:
       override?.oneLiner ??


### PR DESCRIPTION
## Summary

Implements the code-level artifacts for the dual-class agent model defined in ADR-024 Part 4 (merged in PR #940).

## Changes

### 1. Agent Profiles (`apps/ui/lib/agents/profiles.ts`)
- Added `AgentPrimaryMode` type (`'sync' | 'async'`)
- Added `primaryMode` field to `AgentProfile` interface
- Added `PRIMARY_MODE_BY_SLUG` classification map covering all 26 agents
- Each profile now exposes its mode for UI dashboards and filtering

### 2. E2E Validation Skill (`.github/skills/agent-e2e-validation/SKILL.md`)
- Split the uniform NFR table into two class-specific sections:
  - **Sync agents (11):** P95 invoke < 8s, first token < 3s
  - **Async agents (15):** Consumer lag < 10min, throughput >= 95% per window
- Async agents explicitly documented as NOT subject to invoke latency SLA

### 3. Monitoring Bicep (`.infra/modules/monitoring/monitoring.bicep`)
- Added `syncAgentLatencyAlert` scheduled query rule: fires when any sync agent P95 invoke exceeds 8s
- Added `asyncAgentConsumerLagAlert` scheduled query rule: fires when any async agent consumer lag exceeds 10 minutes
- Both alerts reference ADR-024 Part 4 in custom properties

## Classification (per ADR-024 Part 4)

| Class | Agents | SLA Focus |
|-------|--------|-----------|
| Sync (11) | catalog-search, cart, checkout, order-status, product-detail, profile-aggregation, support, reservation-validation, eta, carrier-selection, returns-support | P95 invoke < 8s |
| Async (15) | campaign, segmentation, alerts, health-check, jit-replenishment, route-issue, acp-transform, assortment, consistency, normalization, search-enrichment, truth-* | Consumer lag < 10min |

Closes #936