### PR TITLE
fix: suppress azure-ai-projects SDK tracing crash on NonRecordingSpan (#946)

### DIFF
--- a/lib/src/holiday_peak_lib/app_factory.py
+++ b/lib/src/holiday_peak_lib/app_factory.py
@@ -251,6 +251,14 @@ def build_service_app(
 
     tracer = get_foundry_tracer(service_name)
 
+    # Suppress azure-ai-projects SDK internal telemetry instrumentor when
+    # no real OpenTelemetry exporter is configured. The SDK crashes with
+    # AttributeError on NonRecordingSpan.attributes (GH-946).
+    if not os.getenv("APPLICATIONINSIGHTS_CONNECTION_STRING") and not os.getenv(
+        "AZURE_TRACING_ENABLED"
+    ):
+        os.environ.setdefault("AZURE_TRACING_ENABLED", "false")
+
     configured_foundry_roles = tuple(
         role for role, config in (("fast", slm_config), ("rich", llm_config)) if config is not None
     )

--- a/lib/tests/test_app_factory.py
+++ b/lib/tests/test_app_factory.py
@@ -953,3 +953,78 @@ class TestAppFactoryIntegration:
         client = TestClient(app)
         response = client.post("/invoke", json={"test": "data"})
         assert response.json()["custom"] is True
+
+
+class TestAzureTracingGuard:
+    """Tests for the AZURE_TRACING_ENABLED env-var guard (GH-946)."""
+
+    def test_guard_sets_env_when_no_appinsights_and_no_tracing_var(
+        self, mock_hot_memory, mock_warm_memory, mock_cold_memory, monkeypatch
+    ):
+        """When neither APPLICATIONINSIGHTS_CONNECTION_STRING nor AZURE_TRACING_ENABLED is set,
+        build_service_app should set AZURE_TRACING_ENABLED=false to prevent SDK crash."""
+        monkeypatch.setenv("PROJECT_ENDPOINT", TEST_PROJECT_ENDPOINT)
+        monkeypatch.setenv("FOUNDRY_AGENT_ID_FAST", "agent-fast-123")
+        monkeypatch.setenv("MODEL_DEPLOYMENT_NAME_FAST", "gpt-4o-mini")
+        monkeypatch.delenv("APPLICATIONINSIGHTS_CONNECTION_STRING", raising=False)
+        monkeypatch.delenv("AZURE_TRACING_ENABLED", raising=False)
+
+        import os
+
+        build_service_app(
+            service_name="guard-test",
+            agent_class=SampleServiceAgent,
+            hot_memory=mock_hot_memory,
+            warm_memory=mock_warm_memory,
+            cold_memory=mock_cold_memory,
+        )
+
+        assert os.environ.get("AZURE_TRACING_ENABLED") == "false"
+
+    def test_guard_does_not_override_explicit_tracing_enabled(
+        self, mock_hot_memory, mock_warm_memory, mock_cold_memory, monkeypatch
+    ):
+        """When AZURE_TRACING_ENABLED is already set, the guard must not override it."""
+        monkeypatch.setenv("PROJECT_ENDPOINT", TEST_PROJECT_ENDPOINT)
+        monkeypatch.setenv("FOUNDRY_AGENT_ID_FAST", "agent-fast-123")
+        monkeypatch.setenv("MODEL_DEPLOYMENT_NAME_FAST", "gpt-4o-mini")
+        monkeypatch.delenv("APPLICATIONINSIGHTS_CONNECTION_STRING", raising=False)
+        monkeypatch.setenv("AZURE_TRACING_ENABLED", "true")
+
+        import os
+
+        build_service_app(
+            service_name="guard-test-no-override",
+            agent_class=SampleServiceAgent,
+            hot_memory=mock_hot_memory,
+            warm_memory=mock_warm_memory,
+            cold_memory=mock_cold_memory,
+        )
+
+        assert os.environ.get("AZURE_TRACING_ENABLED") == "true"
+
+    def test_guard_does_not_activate_when_appinsights_configured(
+        self, mock_hot_memory, mock_warm_memory, mock_cold_memory, monkeypatch
+    ):
+        """When APPLICATIONINSIGHTS_CONNECTION_STRING is set, the guard should not fire."""
+        monkeypatch.setenv("PROJECT_ENDPOINT", TEST_PROJECT_ENDPOINT)
+        monkeypatch.setenv("FOUNDRY_AGENT_ID_FAST", "agent-fast-123")
+        monkeypatch.setenv("MODEL_DEPLOYMENT_NAME_FAST", "gpt-4o-mini")
+        monkeypatch.setenv(
+            "APPLICATIONINSIGHTS_CONNECTION_STRING",
+            "InstrumentationKey=00000000-0000-0000-0000-000000000000",
+        )
+        monkeypatch.delenv("AZURE_TRACING_ENABLED", raising=False)
+
+        import os
+
+        build_service_app(
+            service_name="guard-test-appinsights",
+            agent_class=SampleServiceAgent,
+            hot_memory=mock_hot_memory,
+            warm_memory=mock_warm_memory,
+            cold_memory=mock_cold_memory,
+        )
+
+        # Guard should NOT set the variable when AppInsights is present
+        assert os.environ.get("AZURE_TRACING_ENABLED") is None


### PR DESCRIPTION
## Summary

Closes #946

### Root Cause

The \zure-ai-projects\ SDK's internal telemetry instrumentor (\_responses_instrumentor.py:561\) accesses \span.span_instance.attributes\ on a \NonRecordingSpan\ from OpenTelemetry's no-op tracer provider. \NonRecordingSpan\ does not expose \.attributes\, causing an \AttributeError\ that crashes all \/invoke\ calls.

### Fix

Added an env-var guard in \uild_service_app()\ (\pp_factory.py\) that sets \AZURE_TRACING_ENABLED=false\ when:
- \APPLICATIONINSIGHTS_CONNECTION_STRING\ is NOT set (no real exporter configured)
- \AZURE_TRACING_ENABLED\ is NOT already explicitly configured

This suppresses the SDK's broken instrumentor without affecting environments where real Application Insights telemetry is configured.

### Changes

| File | Change |
|------|--------|
| \lib/src/holiday_peak_lib/app_factory.py\ | Added env-var guard after \get_foundry_tracer()\ call |
| \lib/tests/test_app_factory.py\ | 3 new tests in \TestAzureTracingGuard\ class |

### Verification

- All 33 app factory tests pass (including 3 new guard tests)
- Guard activates only when no AppInsights is configured
- Guard does not override explicit \AZURE_TRACING_ENABLED\ values
- No regressions in existing functionality
