### PR TITLE
fix: set OTEL_SERVICE_NAME for App Insights service identification (#948)

### DIFF
--- a/lib/src/holiday_peak_lib/utils/logging.py
+++ b/lib/src/holiday_peak_lib/utils/logging.py
@@ -73,6 +73,9 @@ def configure_logging(
     if conn:
         from azure.monitor.opentelemetry import configure_azure_monitor
 
+        # Ensure OTEL_SERVICE_NAME is set so App Insights identifies the emitting service.
+        os.environ.setdefault("OTEL_SERVICE_NAME", resolved_app)
+
         try:
             configure_azure_monitor(connection_string=conn)
             base_logger.info("Azure Monitor logging enabled via configure_azure_monitor.")

--- a/lib/src/holiday_peak_lib/utils/telemetry.py
+++ b/lib/src/holiday_peak_lib/utils/telemetry.py
@@ -271,6 +271,8 @@ class FoundryTracer:
                     pass
 
             if self.connection_string and not _FOUNDRY_INSTRUMENTATION_STATE["azure_monitor"]:
+                # Ensure OTEL_SERVICE_NAME is set so App Insights identifies the emitting service.
+                os.environ.setdefault("OTEL_SERVICE_NAME", self.service_name)
                 try:
                     configure_azure_monitor(connection_string=self.connection_string)
                     _FOUNDRY_INSTRUMENTATION_STATE["azure_monitor"] = True

--- a/lib/tests/test_telemetry.py
+++ b/lib/tests/test_telemetry.py
@@ -374,3 +374,68 @@ class TestNonRecordingSpanPatch:
 
         tp = trace.get_tracer_provider()
         assert isinstance(tp, TracerProvider)
+
+
+class TestOtelServiceNamePropagation:
+    """Tests that OTEL_SERVICE_NAME is set for App Insights service identification."""
+
+    def test_configure_logging_sets_otel_service_name(self, monkeypatch):
+        """configure_logging should set OTEL_SERVICE_NAME when AppInsights is configured."""
+        import logging
+
+        from holiday_peak_lib.utils.logging import configure_logging
+
+        monkeypatch.setenv(
+            "APPLICATIONINSIGHTS_CONNECTION_STRING",
+            "InstrumentationKey=00000000-0000-0000-0000-000000000000",
+        )
+        monkeypatch.delenv("OTEL_SERVICE_NAME", raising=False)
+
+        # Clear existing handlers to force re-initialization
+        test_logger_name = "holiday-peak-lib.otel-svc-name-test"
+        logging.getLogger(test_logger_name).handlers.clear()
+
+        import os
+
+        configure_logging(app_name="otel-svc-name-test")
+        assert os.environ.get("OTEL_SERVICE_NAME") == "otel-svc-name-test"
+
+    def test_configure_logging_does_not_override_explicit_otel_service_name(self, monkeypatch):
+        """If OTEL_SERVICE_NAME is already set, configure_logging must not override it."""
+        import logging
+
+        from holiday_peak_lib.utils.logging import configure_logging
+
+        monkeypatch.setenv(
+            "APPLICATIONINSIGHTS_CONNECTION_STRING",
+            "InstrumentationKey=00000000-0000-0000-0000-000000000000",
+        )
+        monkeypatch.setenv("OTEL_SERVICE_NAME", "my-custom-service")
+
+        test_logger_name = "holiday-peak-lib.otel-no-override-test"
+        logging.getLogger(test_logger_name).handlers.clear()
+
+        import os
+
+        configure_logging(app_name="otel-no-override-test")
+        assert os.environ.get("OTEL_SERVICE_NAME") == "my-custom-service"
+
+    def test_foundry_tracer_sets_otel_service_name(self, monkeypatch):
+        """FoundryTracer should set OTEL_SERVICE_NAME when initializing Azure Monitor."""
+        monkeypatch.setenv(
+            "APPLICATIONINSIGHTS_CONNECTION_STRING",
+            "InstrumentationKey=00000000-0000-0000-0000-000000000000",
+        )
+        monkeypatch.delenv("OTEL_SERVICE_NAME", raising=False)
+        monkeypatch.setenv("FOUNDRY_TRACING_ENABLED", "true")
+
+        import os
+
+        from holiday_peak_lib.utils.telemetry import _FOUNDRY_INSTRUMENTATION_STATE, _TRACERS
+
+        # Reset state to force re-initialization
+        _FOUNDRY_INSTRUMENTATION_STATE["azure_monitor"] = False
+        _TRACERS.pop("otel-foundry-test", None)
+
+        FoundryTracer("otel-foundry-test")
+        assert os.environ.get("OTEL_SERVICE_NAME") == "otel-foundry-test"


### PR DESCRIPTION
Closes #948

## Problem

App Insights logs from all 26 agents appear as `unknown_service` — no way to filter by service.

## Root Cause

Neither `configure_logging()` nor `FoundryTracer._initialize_foundry_instrumentation()` set `OTEL_SERVICE_NAME` before calling `configure_azure_monitor()`. Azure Monitor SDK uses this standard OTEL env var to populate `service.name` on all telemetry.

## Fix

Added `os.environ.setdefault('OTEL_SERVICE_NAME', <service_name>)` in both paths before the `configure_azure_monitor()` call. Uses `setdefault` to never override explicit configuration.

## Changes

| File | Change |
|------|--------|
| `lib/src/holiday_peak_lib/utils/logging.py` | Set OTEL_SERVICE_NAME before configure_azure_monitor |
| `lib/src/holiday_peak_lib/utils/telemetry.py` | Same for FoundryTracer init path |
| `lib/tests/test_telemetry.py` | 3 new tests in TestOtelServiceNamePropagation |

## Verification

- 35/35 telemetry tests pass
- 30/30 app factory tests pass
- setdefault ensures no override of explicit values