### PR TITLE
fix: add invoke-stream operation to APIM sync script (#954)

### DIFF
--- a/.infra/azd/hooks/sync-apim-agents.ps1
+++ b/.infra/azd/hooks/sync-apim-agents.ps1
@@ -612,6 +612,7 @@ function Ensure-AgentApi {
         @{ id = 'health'; method = 'GET'; template = '/health'; name = 'Health' },
         @{ id = 'ready'; method = 'GET'; template = '/ready'; name = 'Ready' },
         @{ id = 'invoke'; method = 'POST'; template = '/invoke'; name = 'Invoke' },
+        @{ id = 'invoke-stream'; method = 'POST'; template = '/invoke/stream'; name = 'Invoke Stream' },
         @{ id = 'mcp-tool'; method = 'POST'; template = '/mcp/{tool}'; name = 'MCP Tool' },
         @{ id = 'agent-traces'; method = 'GET'; template = '/agent/traces'; name = 'Agent Traces' },
         @{ id = 'agent-metrics'; method = 'GET'; template = '/agent/metrics'; name = 'Agent Metrics' },


### PR DESCRIPTION
## Summary

Closes #954

## Root Cause

The APIM agent sync script (\.infra/azd/hooks/sync-apim-agents.ps1\) did not include a \/invoke/stream\ operation in the \\\ array. This meant APIM had no registered route for streaming invocations, returning 502 Bad Gateway for 25/26 agents.

## Changes

- Added \invoke-stream\ operation (\POST /invoke/stream\) to the operations array in \Ensure-AgentApi\ function

## Verification

- The backend endpoint already exists at \lib/src/holiday_peak_lib/app_factory_components/endpoints.py:514\`n- After running \sync-apim-agents.ps1\, all 26 agents will have the streaming operation registered
- Lint gates pass (isort, black, pylint — no new warnings from this change)

## Post-Merge

Re-run \.infra/azd/hooks/sync-apim-agents.ps1\ to propagate the new operation to APIM.