### PR TITLE
fix: add /integrations operation and use catch-all for MCP tool routing (#956)

### DIFF
--- a/.infra/azd/hooks/sync-apim-agents.ps1
+++ b/.infra/azd/hooks/sync-apim-agents.ps1
@@ -613,7 +613,8 @@ function Ensure-AgentApi {
         @{ id = 'ready'; method = 'GET'; template = '/ready'; name = 'Ready' },
         @{ id = 'invoke'; method = 'POST'; template = '/invoke'; name = 'Invoke' },
         @{ id = 'invoke-stream'; method = 'POST'; template = '/invoke/stream'; name = 'Invoke Stream' },
-        @{ id = 'mcp-tool'; method = 'POST'; template = '/mcp/{tool}'; name = 'MCP Tool' },
+        @{ id = 'integrations'; method = 'GET'; template = '/integrations'; name = 'Integrations' },
+        @{ id = 'mcp-tool'; method = 'POST'; template = '/mcp/{*tool}'; name = 'MCP Tool' },
         @{ id = 'agent-traces'; method = 'GET'; template = '/agent/traces'; name = 'Agent Traces' },
         @{ id = 'agent-metrics'; method = 'GET'; template = '/agent/metrics'; name = 'Agent Metrics' },
         @{ id = 'agent-evaluation-latest'; method = 'GET'; template = '/agent/evaluation/latest'; name = 'Agent Evaluation Latest' }
@@ -637,7 +638,7 @@ function Ensure-AgentApi {
             $createArgs += @(
                 '--template-parameters',
                 'name=tool',
-                'description=MCP tool name',
+                'description=MCP tool path (supports nested segments)',
                 'type=string',
                 'required=true'
             )


### PR DESCRIPTION
## Summary

Closes #956

## Root Cause

1. **\/integrations\ 502**: APIM \\\ array lacked the \/integrations\ route.
2. **\/mcp/{tool}\ 404**: Template \/mcp/{tool}\ only matches single path segments. Backend MCP tools use multi-segment paths (e.g., \/catalog/search\, \/campaign/contact-context\). Changed to \/mcp/{*tool}\ catch-all pattern (consistent with CRUD API's \/{*path}\ pattern).

## Changes

- Added \integrations\ operation (\GET /integrations\) to the operations array
- Changed MCP tool template from \/mcp/{tool}\ to \/mcp/{*tool}\ (catch-all)
- Updated template parameter description to clarify nested segment support

## Verification

- Preview mode confirms all 27 services recognized
- \mcp.mount()\ correctly includes the router at prefix \/mcp\ in \pp_factory.py:643\`n- Agents register tools via \mcp.add_tool()\ with multi-segment paths confirmed in spot-checks
- All local lint + test gates pass (1316 lib tests + 701 app tests)