### PR TITLE
fix: apply CORS, timeout, streaming, and error-handling policies to agent APIs (#958)

### DIFF
--- a/.infra/apim-policies/agent-api-policy.xml
+++ b/.infra/apim-policies/agent-api-policy.xml
@@ -1,0 +1,53 @@
+<policies>
+    <inbound>
+        <base />
+        <cors allow-credentials="false">
+            <allowed-origins>
+            {{cors-origins}}
+            </allowed-origins>
+            <allowed-methods preflight-result-max-age="300">
+                <method>*</method>
+            </allowed-methods>
+            <allowed-headers>
+                <header>*</header>
+            </allowed-headers>
+            <expose-headers>
+                <header>*</header>
+            </expose-headers>
+        </cors>
+    </inbound>
+    <backend>
+        <forward-request timeout="120" />
+    </backend>
+    <outbound>
+        <base />
+        <set-header name="Access-Control-Allow-Origin" exists-action="override">
+            <value>@(context.Request.Headers.GetValueOrDefault("Origin", "http://localhost:3000"))</value>
+        </set-header>
+        <set-header name="Access-Control-Allow-Methods" exists-action="override">
+            <value>GET,POST,OPTIONS</value>
+        </set-header>
+        <set-header name="Access-Control-Allow-Headers" exists-action="override">
+            <value>*</value>
+        </set-header>
+    </outbound>
+    <on-error>
+        <base />
+        <return-response>
+            <set-status code="502" reason="Bad Gateway" />
+            <set-header name="Access-Control-Allow-Origin" exists-action="override">
+                <value>@(context.Request.Headers.GetValueOrDefault("Origin", "http://localhost:3000"))</value>
+            </set-header>
+            <set-header name="Access-Control-Allow-Methods" exists-action="override">
+                <value>GET,POST,OPTIONS</value>
+            </set-header>
+            <set-header name="Access-Control-Allow-Headers" exists-action="override">
+                <value>*</value>
+            </set-header>
+            <set-header name="Content-Type" exists-action="override">
+                <value>application/json</value>
+            </set-header>
+            <set-body>{"detail":"APIM upstream error while routing to agent backend."}</set-body>
+        </return-response>
+    </on-error>
+</policies>

--- a/.infra/apim-policies/agent-stream-operation-policy.xml
+++ b/.infra/apim-policies/agent-stream-operation-policy.xml
@@ -1,0 +1,20 @@
+<policies>
+    <inbound>
+        <base />
+    </inbound>
+    <backend>
+        <forward-request timeout="180" buffer-response="false" />
+    </backend>
+    <outbound>
+        <base />
+        <set-header name="Cache-Control" exists-action="override">
+            <value>no-cache</value>
+        </set-header>
+        <set-header name="X-Accel-Buffering" exists-action="override">
+            <value>no</value>
+        </set-header>
+    </outbound>
+    <on-error>
+        <base />
+    </on-error>
+</policies>

--- a/.infra/azd/hooks/sync-apim-agents.ps1
+++ b/.infra/azd/hooks/sync-apim-agents.ps1
@@ -592,6 +592,8 @@ function Ensure-AgentApi {
                 Write-Host "[preview]   + operation: $($op.method) $($op.template) ($($op.name))"
             }
         }
+        Write-Host "[preview]   + API-level policy (CORS, timeout=120s, on-error)"
+        Write-Host "[preview]   + Operation-level streaming policy (invoke-stream, timeout=180s, buffer-response=false)"
         return
     }
 
@@ -691,6 +693,36 @@ function Ensure-AgentApi {
             az @createArgs *> $null
         }
         Write-Host "Registered $($serviceSpecificOperations[$Service].Count) extra operations for $Service"
+    }
+
+    # --- Apply API-level policy ---
+    $subscriptionId = az account show --query id -o tsv 2>$null
+    if (-not $subscriptionId) {
+        throw "Failed to resolve Azure subscription id for agent API policy update ($Service)."
+    }
+
+    $agentPolicyPath = Join-Path $PSScriptRoot '..\..\apim-policies\agent-api-policy.xml'
+    if (Test-Path $agentPolicyPath) {
+        $corsOriginXml = Get-CorsOriginXml -OriginsCsv $ApimCorsAllowedOrigins
+        $agentPolicyXml = (Get-Content -Path $agentPolicyPath -Raw) -replace '\{\{cors-origins\}\}', $corsOriginXml
+        $policyPayload = @{ properties = @{ format = 'rawxml'; value = $agentPolicyXml } } | ConvertTo-Json -Depth 8
+        $policyTempFile = Join-Path ([System.IO.Path]::GetTempPath()) "apim-agent-policy-$Service.json"
+        Set-Content -Path $policyTempFile -Value $policyPayload -Encoding UTF8
+        $policyUrl = "https://management.azure.com/subscriptions/$subscriptionId/resourceGroups/$Rg/providers/Microsoft.ApiManagement/service/$Apim/apis/$apiId/policies/policy?api-version=2022-08-01"
+        az rest --method put --url $policyUrl --headers 'Content-Type=application/json' --body "@$policyTempFile" --only-show-errors *> $null
+        Write-Host "Applied API-level policy for $Service"
+    }
+
+    # --- Apply operation-level streaming policy for /invoke/stream ---
+    $streamPolicyPath = Join-Path $PSScriptRoot '..\..\apim-policies\agent-stream-operation-policy.xml'
+    if (Test-Path $streamPolicyPath) {
+        $streamPolicyXml = Get-Content -Path $streamPolicyPath -Raw
+        $streamPayload = @{ properties = @{ format = 'rawxml'; value = $streamPolicyXml } } | ConvertTo-Json -Depth 8
+        $streamTempFile = Join-Path ([System.IO.Path]::GetTempPath()) "apim-agent-stream-policy-$Service.json"
+        Set-Content -Path $streamTempFile -Value $streamPayload -Encoding UTF8
+        $streamOpUrl = "https://management.azure.com/subscriptions/$subscriptionId/resourceGroups/$Rg/providers/Microsoft.ApiManagement/service/$Apim/apis/$apiId/operations/invoke-stream/policies/policy?api-version=2022-08-01"
+        az rest --method put --url $streamOpUrl --headers 'Content-Type=application/json' --body "@$streamTempFile" --only-show-errors *> $null
+        Write-Host "Applied streaming operation policy for $Service"
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #958

## Root Cause

All 26 agent APIs in APIM had zero policies applied — only operations were registered. The CRUD API had a full policy suite (CORS, timeout, on-error), but \Ensure-AgentApi\ never applied any policies.

## Changes

1. **Created \.infra/apim-policies/agent-api-policy.xml\** — API-level policy with:
   - CORS (dynamic origins from \ApimCorsAllowedOrigins\ param)
   - Forward-request timeout = 120s (LLM-backed agents are slow)
   - Outbound CORS headers
   - On-error: structured JSON with CORS headers

2. **Created \.infra/apim-policies/agent-stream-operation-policy.xml\** — Operation-level policy for \/invoke/stream\ with:
   - Forward-request timeout = 180s
   - \uffer-response=false\ (critical for SSE streaming)
   - \Cache-Control: no-cache\ + \X-Accel-Buffering: no\`n
3. **Modified \.infra/azd/hooks/sync-apim-agents.ps1\** — After registering operations in \Ensure-AgentApi\:
   - Resolves subscription ID via \z account show\`n   - Reads and applies API-level policy (with dynamic CORS origin injection)
   - Reads and applies operation-level streaming policy to \invoke-stream\ operation
   - Preview mode shows policy application intent

## Verification

- Preview mode confirms all 26 agents show policy application messages
- Policy files use \{{cors-origins}}\ placeholder replaced at runtime by \Get-CorsOriginXml\`n- Pattern mirrors CRUD policy application (ARM REST PUT to policy endpoint)
- All local lint + test gates pass (1316 lib + 701 app tests)