### PR TITLE
docs(adr): ADR-029..033 - architecture contracts (canary, MCP A2A, OTEL, memory, UI on SWA)

### DIFF
--- a/docs/architecture/ADRs.md
+++ b/docs/architecture/ADRs.md
@@ -33,6 +33,13 @@ This document indexes all architectural decisions for the Holiday Peak Hub accel
 | [ADR-025](adrs/adr-025-self-healing-boundaries.md) | Self-Healing Boundaries, Risk Tiers, and Prohibited Actions | Accepted | 2026-04 |
 | [ADR-026](adrs/adr-026-namespace-isolation-strategy.md) | Namespace Isolation Strategy (CRUD vs Agent Namespaces) | Accepted | 2026-04 |
 | [ADR-027](adrs/adr-027-api-center-apim-mcp-strategy.md) | API Center + APIM MCP Strategy | Accepted | 2026-04 |
+| [ADR-029](adrs/adr-029-agc-weighted-canary-policy.md) | AGC Weighted Canary Policy with Automatic Rollback | Accepted | 2026-05 |
+| [ADR-030](adrs/adr-030-mcp-only-a2a.md) | MCP-Only Agent-to-Agent Communication with Hop Counter | Accepted | 2026-05 |
+| [ADR-031](adrs/adr-031-otel-span-attributes-contract.md) | OTEL Span Attributes Contract for Retail Agents | Accepted | 2026-05 |
+| [ADR-032](adrs/adr-032-three-tier-memory-contract.md) | Three-Tier Memory Contract Pinning (Hot / Warm / Cold) | Accepted (Refines ADR-007) | 2026-05 |
+| [ADR-033](adrs/adr-033-ui-modular-monolith-on-swa.md) | UI as a Modular Monolith on Static Web Apps (Path 2) | Accepted | 2026-05 |
+
+> ADR-028 (Continuous Agent Evaluation) is in flight on PR #974; once merged, it will be inserted at its sequential position above.
 
 ## How to Use ADRs
 
@@ -84,16 +91,21 @@ Each ADR follows a standard template:
 ### Infrastructure & Deployment
 - Azure-native services for enterprise readiness ([ADR-002](adrs/adr-002-azure-services.md))
 - Three-tier memory for latency/cost optimization ([ADR-007](adrs/adr-007-memory-tiers.md))
+- Three-tier memory contract pinning ([ADR-032](adrs/adr-032-three-tier-memory-contract.md))
 - AKS with KEDA for elastic scaling, 3 node pools ([ADR-008](adrs/adr-008-aks-deployment.md))
 - Deployment strategy: azd provisioning + Flux CD GitOps ([ADR-017](adrs/adr-017-deployment-strategy.md))
 - APIM + AGC as the canonical AKS edge ([ADR-021](adrs/adr-021-apim-agc-edge.md))
 - Namespace isolation for CRUD and agent workloads ([ADR-026](adrs/adr-026-namespace-isolation-strategy.md))
+- AGC weighted canary policy with automatic rollback ([ADR-029](adrs/adr-029-agc-weighted-canary-policy.md))
+- UI as a modular monolith on Static Web Apps ([ADR-033](adrs/adr-033-ui-modular-monolith-on-swa.md))
 
 ### Governance
 - Git branch naming convention ([ADR-018](adrs/adr-018-branch-naming-convention.md))
 - Agent communication policy, isolation, and async contracts ([ADR-024](adrs/adr-024-agent-communication-policy.md))
+- MCP-only agent-to-agent communication with hop counter ([ADR-030](adrs/adr-030-mcp-only-a2a.md))
 - Self-healing boundaries, risk tiers, and prohibited actions ([ADR-025](adrs/adr-025-self-healing-boundaries.md))
 - API Center + APIM MCP strategy for API governance ([ADR-027](adrs/adr-027-api-center-apim-mcp-strategy.md))
+- OTEL span attributes contract for retail agents ([ADR-031](adrs/adr-031-otel-span-attributes-contract.md))
 
 ### Enterprise Integration
 - Enterprise resilience patterns (Circuit Breaker, Bulkhead, Rate Limiter) ([ADR-019](adrs/adr-019-enterprise-resilience-patterns.md))

--- a/docs/architecture/ADRs.md
+++ b/docs/architecture/ADRs.md
@@ -16,7 +16,7 @@ This document indexes all architectural decisions for the Holiday Peak Hub accel
 | [ADR-008](adrs/adr-008-aks-deployment.md) | AKS with Helm, KEDA, and Canary Deployments | Accepted | 2024-12 |
 | [ADR-009](adrs/adr-009-acp-catalog-search.md) | ACP Alignment for Ecommerce Catalog Search | Accepted | 2026-01 |
 | [ADR-010](adrs/adr-010-model-routing.md) | SLM-First Model Routing Strategy | Accepted | 2026-01 |
-| [ADR-011](adrs/adr-011-nextjs-app-router.md) | Next.js 15 with App Router for Frontend | Accepted | 2026-01 |
+| [ADR-011](adrs/adr-011-nextjs-app-router.md) | Next.js 15 with App Router for Frontend | Accepted (Revised by ADR-033) | 2026-01 |
 | [ADR-012](adrs/adr-012-atomic-design-system.md) | Atomic Design System for Component Library | Accepted | 2026-01 |
 | [ADR-013](adrs/adr-013-ag-ui-protocol.md) | AG-UI Protocol Integration | Accepted | 2026-01 |
 | [ADR-014](adrs/adr-014-acp-frontend.md) | Agentic Commerce Protocol (ACP) Frontend Integration | Accepted | 2026-01 |
@@ -39,7 +39,7 @@ This document indexes all architectural decisions for the Holiday Peak Hub accel
 | [ADR-032](adrs/adr-032-three-tier-memory-contract.md) | Three-Tier Memory Contract Pinning (Hot / Warm / Cold) | Accepted (Refines ADR-007) | 2026-05 |
 | [ADR-033](adrs/adr-033-ui-modular-monolith-on-swa.md) | UI as a Modular Monolith on Static Web Apps (Path 2) | Accepted | 2026-05 |
 
-> ADR-028 (Continuous Agent Evaluation) is in flight on PR #974; once merged, it will be inserted at its sequential position above.
+> ADR-028 (Continuous Agent Evaluation) is in flight on PR #974; once merged, it will be inserted at its sequential position above. ADRs 029, 030, 031 forward-reference ADR-028 and reference specific eval attribute keys (`eval.score`, `eval.baseline_id`, `baselineSource: continuous-eval`); those keys are subject to ADR-028's final schema and will be reconciled in lock-step on PR #974 merge.
 
 ## How to Use ADRs
 

--- a/docs/architecture/adrs/adr-029-agc-weighted-canary-policy.md
+++ b/docs/architecture/adrs/adr-029-agc-weighted-canary-policy.md
@@ -1,0 +1,170 @@
+# ADR-029: AGC Weighted Canary Policy with Automatic Rollback
+
+**Status**: Accepted
+**Date**: 2026-05-08
+**Deciders**: Architecture Team, Ricardo Cataldi
+**Tags**: deployment, canary, agc, observability, sre
+**References**: [ADR-008](adr-008-aks-deployment.md), [ADR-017](adr-017-deployment-strategy.md), [ADR-021](adr-021-apim-agc-edge.md), [ADR-028](adr-028-continuous-agent-evaluation.md)
+
+## Context
+
+Application Gateway for Containers (AGC) is the canonical AKS edge for the platform (ADR-021), and Flux GitOps drives every rollout (ADR-017). Several services already run weighted routes through AGC, but the canary discipline is informal: weight ladders, hold durations, exit gates, and rollback windows are inconsistent across services and across release channels.
+
+R1 (the Microsoft Agent Framework cutover, tracked separately) deploys 27 services across 8 bounded contexts. Without a pinned canary policy, each bounded-context cutover would relitigate the same operational questions. Worse, a fast-failure deploy could spend minutes at 5–25 % traffic before a human noticed.
+
+This ADR formalizes the policy, pins the schema in Helm values, and mandates an **automatic rollback floor** for fast-failure scenarios.
+
+## Decision
+
+### 1. Mandatory Weight Ladder
+
+Every Flux-deployed service follows a four-step canary ladder:
+
+| Step | Weight on new version | Hold | Auto-rollback window |
+|---|---|---|---|
+| 0 | 0 % | n/a | n/a |
+| 1 | 5 % | 15 min | first 90 s |
+| 2 | 25 % | 15 min | first 90 s |
+| 3 | 50 % | 15 min | first 90 s |
+| 4 | 100 % | 30 min steady | first 90 s post-cutover |
+
+After step 4 holds for 30 minutes without breach, the previous version's pods are scaled to 0 and removed from the AGC route map.
+
+### 2. Exit Gates per Step
+
+For each step:
+
+1. Wait `holdSeconds` (default 900).
+2. Query gate metrics over the hold window:
+   - **5xx error rate** delta vs. baseline ≤ 0.5 percentage points.
+   - **P95 latency** delta vs. baseline ≤ 10 %.
+   - **Eval baseline** (services with continuous eval per ADR-028): score within `maxDeltaPercent` (default 5 %).
+3. All gates pass → advance to next step.
+4. Any gate fails outside the rollback window → halt; oncall decides hold, manual rollback, or roll forward.
+5. Any gate fails **inside the first 90 s of the step** → automatic rollback to previous step weight; oncall notified post-fact.
+
+### 3. Helm Values Schema (pinned)
+
+Every service chart MUST declare a `canary` block matching this schema:
+
+```yaml
+canary:
+  enabled: true
+  steps: [5, 25, 50, 100]
+  holdSeconds: 900
+  rollbackWindowSeconds: 90
+  gates:
+    errorRate:
+      enabled: true
+      maxDeltaPercentagePoints: 0.5
+    latencyP95:
+      enabled: true
+      maxDeltaPercent: 10
+    eval:
+      enabled: true   # only meaningful for services with eval baselines
+      baselineSource: continuous-eval
+      maxDeltaPercent: 5
+  observability:
+    dashboardUrl: <App Insights workbook URL>
+    alertGroup: holiday-peak-hub-oncall
+```
+
+Drift from this schema fails the chart build via `scripts/ci/validate_canary_helm_values.py`.
+
+### 4. Automatic Rollback Controller
+
+A canary controller (Flagger or equivalent) runs in the cluster and:
+
+- Steps the AGC route weights via the AGC ARM API or the Gateway API custom resources.
+- Reads gate metrics from Azure Monitor / App Insights via OTEL exporters.
+- Decides hold / advance / rollback per step deterministically (idempotent decisioning — same metric inputs produce the same conclusion).
+- Emits a structured transition event on every state change.
+- Has a watchdog: if the controller does not emit a transition event within `rollbackWindowSeconds × 1.5`, oncall is paged.
+
+### 5. Observability Contract
+
+Every canary transition emits a structured event with these OTEL span attributes (per ADR-031):
+
+- `agc.canary.from_weight` (int)
+- `agc.canary.to_weight` (int)
+- `agc.canary.service` (string)
+- `agc.canary.namespace` (string)
+- `agc.canary.step_outcome` ∈ `advanced` | `held` | `rolled_back`
+- `agc.canary.rollback_reason` (string, optional)
+
+The runbook at `docs/ops/runbooks/agc-canary-rollout.md` documents trigger conditions, dashboard URLs, manual override procedure, and the post-mortem template.
+
+## Consequences
+
+### Positive
+
+- Uniform canary discipline across all 27 services; bounded-context cutovers (R1) inherit the policy.
+- Fast-failure deploys are auto-recovered within 90 s without human intervention.
+- Eval-aware canary integrates ADR-028 directly: a regression in eval score halts the ramp.
+- Helm schema validation catches drift at chart-build time, not at runtime.
+- Structured transition events feed App Insights workbooks for trend analysis.
+
+### Negative
+
+- Adds a controller dependency in the cluster (Flagger or equivalent). Operational footprint and one more thing to monitor.
+- Eval gate requires services to expose their continuous-eval baseline ID; services without baselines cannot benefit from the eval-aware ladder.
+- 90-s rollback window may produce false positives on noisy metrics; tuning is per-service.
+
+### Risks
+
+| Risk | Mitigation |
+|---|---|
+| Auto-rollback fires on metric noise (false positive). | Gate threshold tuned to baseline + measurement noise (0.5 pp on error rate is well above floor noise). 90 s window is short enough that one-shot transients rarely clear the threshold. |
+| Auto-rollback fails (controller dies, AGC API rate-limits). | Watchdog pages oncall when no transition event within `rollbackWindowSeconds × 1.5`. |
+| Eval gate too sensitive — fails on legitimate behavior shifts. | Eval gate uses `maxDeltaPercent` (relative), not absolute. Baselines refresh nightly per ADR-028. |
+| Helm schema drift between services. | CI step `scripts/ci/validate_canary_helm_values.py` rejects drift; required check on PR. |
+| Single-region failure scope (no cross-region failover during canary). | Documented limitation. Multi-region canary is a future ADR. |
+
+## Alternatives Considered
+
+### Alternative A — Manual canary with runbook only
+
+Rejected. Human-in-the-loop on every step inflates rollout duration and creates inconsistency across services. The 90-s automatic rollback floor is the safety net manual rollouts cannot provide.
+
+### Alternative B — All-at-once deploys with feature flags
+
+Rejected. Feature flags shift complexity into application code and require flag cleanup discipline that has historically failed in this repo. Canary at the traffic layer keeps deploys reversible without code changes.
+
+### Alternative C — Argo Rollouts instead of Flagger
+
+Considered. Both are viable. Decision deferred to platform-engineering choice during implementation; the ADR pins the **policy** (ladder, gates, schema), not the controller brand. Replacing the controller is a non-ADR change as long as the policy is preserved.
+
+## Implementation
+
+| Component | File / Location | Change |
+|---|---|---|
+| ADR | `docs/architecture/adrs/adr-029-agc-weighted-canary-policy.md` | This file |
+| Runbook | `docs/ops/runbooks/agc-canary-rollout.md` | New — trigger conditions, dashboards, oncall procedure, post-mortem template |
+| Helm schema validator | `scripts/ci/validate_canary_helm_values.py` | New — fails build on schema drift |
+| Service Helm charts | `infra/charts/<service>/values.yaml` | Add `canary` block matching schema |
+| Flux Kustomization patches | `infra/flux/<channel>/patches/canary.yaml` | Pin per-channel overrides (`dev`, `staging`, `prod`) |
+| Controller | Cluster add-on (Flagger candidate) | Deployed via Flux; emits transition events |
+| OTEL spans | per ADR-031 | `agc.canary.*` attributes on transitions |
+
+## Verification
+
+- **Synthetic-success run**: deploy a known-good build of one service; verify ladder progresses 5 → 25 → 50 → 100 cleanly within ~75 minutes total.
+- **Synthetic-chaos run**: deploy a deliberately-broken build (latency injection, error injection); verify automatic rollback within ≤ 90 s of step 1 breach; verify oncall alert fired; verify dashboard reflects the rollback.
+- **No-flapping check**: one breach within 90 s triggers exactly one rollback, not a rollback loop. Validated by replaying a metric trace through the controller.
+- **Eval-aware canary**: at least one service with a continuous-eval baseline runs through the ladder; eval gate exercised in both success and breach paths.
+
+## Pattern References
+
+- **Canary Release** — microservices.io
+- **Bulkhead + Circuit Breaker** — microservices.io. The 90-s window is the bulkhead; per-step gates are circuit breakers.
+- **Observability** — Azure Well-Architected Framework, Operational Excellence pillar.
+
+## References
+
+- [Application Gateway for Containers documentation](https://learn.microsoft.com/azure/application-gateway/for-containers/)
+- [Flagger](https://flagger.app/)
+- [ADR-008 — AKS with Helm, KEDA, and Canary Deployments](adr-008-aks-deployment.md)
+- [ADR-017 — Deployment Strategy: azd Provisioning + Flux CD GitOps](adr-017-deployment-strategy.md)
+- [ADR-021 — APIM + AGC as the Canonical AKS Edge](adr-021-apim-agc-edge.md)
+- [ADR-028 — Continuous Agent Evaluation](adr-028-continuous-agent-evaluation.md)
+- [ADR-031 — OTEL Span Attributes Contract for Retail Agents](adr-031-otel-span-attributes-contract.md)

--- a/docs/architecture/adrs/adr-029-agc-weighted-canary-policy.md
+++ b/docs/architecture/adrs/adr-029-agc-weighted-canary-policy.md
@@ -4,7 +4,7 @@
 **Date**: 2026-05-08
 **Deciders**: Architecture Team, Ricardo Cataldi
 **Tags**: deployment, canary, agc, observability, sre
-**References**: [ADR-008](adr-008-aks-deployment.md), [ADR-017](adr-017-deployment-strategy.md), [ADR-021](adr-021-apim-agc-edge.md), [ADR-028](adr-028-continuous-agent-evaluation.md)
+**References**: [ADR-008](adr-008-aks-deployment.md), [ADR-017](adr-017-deployment-strategy.md), [ADR-021](adr-021-apim-agc-edge.md), ADR-028 (Continuous Agent Evaluation — in flight on PR #974; link will be added when merged)
 
 ## Context
 
@@ -38,7 +38,7 @@ For each step:
 2. Query gate metrics over the hold window:
    - **5xx error rate** delta vs. baseline ≤ 0.5 percentage points.
    - **P95 latency** delta vs. baseline ≤ 10 %.
-   - **Eval baseline** (services with continuous eval per ADR-028): score within `maxDeltaPercent` (default 5 %).
+   - **Eval baseline** (services with continuous eval per ADR-028): score within `maxDeltaPercent` (default 5 %). Specific attribute keys (`eval.score`, `eval.baseline_id`) and the `baselineSource: continuous-eval` literal are subject to ADR-028's final schema (PR #974 in flight); this ADR will be revised in lock-step if PR #974 changes them.
 3. All gates pass → advance to next step.
 4. Any gate fails outside the rollback window → halt; oncall decides hold, manual rollback, or roll forward.
 5. Any gate fails **inside the first 90 s of the step** → automatic rollback to previous step weight; oncall notified post-fact.
@@ -71,9 +71,11 @@ canary:
 
 Drift from this schema fails the chart build via `scripts/ci/validate_canary_helm_values.py`.
 
+**Migration**: the existing `.kubernetes/chart/values.yaml` ships a legacy header-routing `canary` block (`headerRouting.headerName: x-canary`, `selectorIncludeCanary`, `replicaCount`). The validator runs in advisory mode (logs drift, does not fail) until the migration PR replaces the legacy block with the schema above; it flips to enforcing once every chart consumer has migrated. Per-service activation is tracked in the R1 epic, mirroring ADR-030's gradual-adoption pattern.
+
 ### 4. Automatic Rollback Controller
 
-A canary controller (Flagger or equivalent) runs in the cluster and:
+A canary controller (Flagger or equivalent, integrated with AGC via the Kubernetes Gateway API provider — AGC must be deployed in Gateway API mode) runs in the cluster and:
 
 - Steps the AGC route weights via the AGC ARM API or the Gateway API custom resources.
 - Reads gate metrics from Azure Monitor / App Insights via OTEL exporters.
@@ -118,7 +120,7 @@ The runbook at `docs/ops/runbooks/agc-canary-rollout.md` documents trigger condi
 | Auto-rollback fails (controller dies, AGC API rate-limits). | Watchdog pages oncall when no transition event within `rollbackWindowSeconds × 1.5`. |
 | Eval gate too sensitive — fails on legitimate behavior shifts. | Eval gate uses `maxDeltaPercent` (relative), not absolute. Baselines refresh nightly per ADR-028. |
 | Helm schema drift between services. | CI step `scripts/ci/validate_canary_helm_values.py` rejects drift; required check on PR. |
-| Single-region failure scope (no cross-region failover during canary). | Documented limitation. Multi-region canary is a future ADR. |
+| Single-region failure scope (no cross-region failover during canary). | Region-health alert (Azure Service Health on the AGC region) halts the ramp and pages oncall; the runbook `docs/ops/runbooks/agc-canary-rollout.md` documents APIM-level traffic shift to a passive secondary region during a regional outage. Multi-region active-active canary remains a future ADR. |
 
 ## Alternatives Considered
 
@@ -136,13 +138,15 @@ Considered. Both are viable. Decision deferred to platform-engineering choice du
 
 ## Implementation
 
+> **Conditional acceptance**: this ADR is Accepted on the contract (§1–§5 above), but the runbook (`docs/ops/runbooks/agc-canary-rollout.md`) and the App Insights workbook referenced from it are net-new artifacts that MUST land in the same merge train as the framework changes below. Until they exist, the ADR's operational guarantees are advisory.
+
 | Component | File / Location | Change |
 |---|---|---|
 | ADR | `docs/architecture/adrs/adr-029-agc-weighted-canary-policy.md` | This file |
 | Runbook | `docs/ops/runbooks/agc-canary-rollout.md` | New — trigger conditions, dashboards, oncall procedure, post-mortem template |
 | Helm schema validator | `scripts/ci/validate_canary_helm_values.py` | New — fails build on schema drift |
-| Service Helm charts | `infra/charts/<service>/values.yaml` | Add `canary` block matching schema |
-| Flux Kustomization patches | `infra/flux/<channel>/patches/canary.yaml` | Pin per-channel overrides (`dev`, `staging`, `prod`) |
+| Service Helm charts | `.kubernetes/chart/values.yaml` (shared chart `holiday-peak-service`) | Replace the legacy header-routing `canary` block (`headerRouting`, `selectorIncludeCanary`, `replicaCount`) with the schema in §3. Per-service overrides land in `.kubernetes/chart/values-<service>.yaml`. |
+| Flux Kustomization patches | `.kubernetes/flux/<channel>/patches/canary.yaml` | Pin per-channel overrides (`dev`, `staging`, `prod`); chart path follows the shared chart layout above. |
 | Controller | Cluster add-on (Flagger candidate) | Deployed via Flux; emits transition events |
 | OTEL spans | per ADR-031 | `agc.canary.*` attributes on transitions |
 
@@ -166,5 +170,5 @@ Considered. Both are viable. Decision deferred to platform-engineering choice du
 - [ADR-008 — AKS with Helm, KEDA, and Canary Deployments](adr-008-aks-deployment.md)
 - [ADR-017 — Deployment Strategy: azd Provisioning + Flux CD GitOps](adr-017-deployment-strategy.md)
 - [ADR-021 — APIM + AGC as the Canonical AKS Edge](adr-021-apim-agc-edge.md)
-- [ADR-028 — Continuous Agent Evaluation](adr-028-continuous-agent-evaluation.md)
+- ADR-028 — Continuous Agent Evaluation (in flight on PR #974; link will be added once that PR merges and the ADR file lands at `adrs/adr-028-continuous-agent-evaluation.md`)
 - [ADR-031 — OTEL Span Attributes Contract for Retail Agents](adr-031-otel-span-attributes-contract.md)

--- a/docs/architecture/adrs/adr-030-mcp-only-a2a.md
+++ b/docs/architecture/adrs/adr-030-mcp-only-a2a.md
@@ -36,7 +36,7 @@ This refines ADR-024 by elevating the A2A row to **enforced**.
 
 - **Header name**: `x-mcp-hop` (lowercase). Optional inbound — absent means `0`.
 - **Type**: integer in `[0, 5]`. Out-of-range returns `400`. Hard cap at `5`; configurable on `FastAPIMCPServer` constructor (`max_hops` parameter).
-- **Propagation**: `FastAPIMCPServer.invoke_tool()` reads inbound, increments by `1` before any outbound MCP call originating from the request's correlation context, restores on exit.
+- **Propagation**: `FastAPIMCPServer.invoke_tool()` reads inbound, increments by `1` before any outbound MCP call originating from the request's correlation context. The hop value is carried in an asyncio `ContextVar`, so concurrent fan-out preserves per-branch values without explicit "restore on exit."
 - **Overflow**: an outbound call from a server already at the cap returns `429` with body `{"error": "mcp.hop_overflow", "hop": 5, "cap": 5}` and emits `mcp.hop_overflow=true` as a span attribute.
 - **Correlation**: hop counter rides with the existing trace context (W3C `traceparent`). The combination `(trace_id, mcp.hop)` is sufficient to reconstruct any agent chain end-to-end.
 
@@ -112,8 +112,8 @@ Rejected. Adds a third RPC style to the platform with no clear benefit over MCP,
 | Component | File / Location | Change |
 |---|---|---|
 | ADR | `docs/architecture/adrs/adr-030-mcp-only-a2a.md` | This file |
-| Framework seam | `lib/holiday_peak_lib/mcp/server.py` | Read/validate/propagate `x-mcp-hop`; emit `mcp.hop` span attribute |
-| Contract test | `lib/tests/test_mcp_hop_counter.py` | New — hop semantics + overflow + malformed |
+| Framework seam | `lib/src/holiday_peak_lib/mcp/server.py` | Add `max_hops: int = 5` to `FastAPIMCPServer.__init__`; read/validate/propagate `x-mcp-hop`; emit `mcp.hop` span attribute. |
+| Contract test | `lib/tests/test_mcp_hop_counter.py` | New — hop semantics (asyncio contextvar propagation, no manual "restore") + overflow + malformed. |
 | CI lint | `scripts/ci/lint_no_a2a_http.py` | New — AST/regex check across `apps/*/src/**` |
 | Allowlists | `apps/<service>/.a2a-allow.txt` | New — empty by default |
 | Framework docs | `lib/README.md` | Document the contract and example usage |

--- a/docs/architecture/adrs/adr-030-mcp-only-a2a.md
+++ b/docs/architecture/adrs/adr-030-mcp-only-a2a.md
@@ -1,0 +1,142 @@
+# ADR-030: MCP-Only Agent-to-Agent Communication with Hop Counter
+
+**Status**: Accepted
+**Date**: 2026-05-08
+**Deciders**: Architecture Team, Ricardo Cataldi
+**Tags**: mcp, agent-communication, isolation, observability
+**References**: [ADR-004](adr-004-fastapi-mcp.md), [ADR-024](adr-024-agent-communication-policy.md), [ADR-026](adr-026-namespace-isolation-strategy.md), [ADR-027](adr-027-api-center-apim-mcp-strategy.md)
+
+## Context
+
+The platform has a clear communication-channel matrix (ADR-024) but the agent-to-agent (A2A) invariant has historically been enforced by convention, not by code. Direct HTTP calls between agent services are technically possible because pods can reach peer services through Kubernetes DNS or APIM. Convention says "agents talk to agents only via MCP," but nothing fails the build or the deploy when convention drifts.
+
+R1 (the Microsoft Agent Framework cutover) is the right moment to **pin the invariant in the framework** and **enforce it in CI**. Two additions are required:
+
+1. **MCP-only A2A** — codify the invariant on the framework seam (`FastAPIMCPServer`) and add a CI lint rejecting any new direct A2A HTTP call.
+2. **Hop counter** — add a header that rides on every MCP call, increments on each relay, hard-caps at a configurable bound. This bounds runaway agent chains and detects loops.
+
+## Decision
+
+### 1. Pinned Communication Channel Matrix
+
+| Caller | Callee | Channel |
+|---|---|---|
+| Frontend | CRUD | HTTPS REST via APIM |
+| Frontend | Agent | HTTPS REST via APIM |
+| CRUD | Agent | HTTPS REST (with circuit breaker; for fast enrichment) |
+| Agent | CRUD | HTTPS REST (transactional reads/writes; cross-namespace per ADR-026) |
+| **Agent** | **Agent** | **MCP only (with `x-mcp-hop` header)** |
+| Agent | Foundry / AI Search | HTTPS REST (model invocation) |
+| Agent | External connector | HTTPS REST or vendor SDK |
+| Agent | Event Hubs / Service Bus | AMQP via SDK |
+
+This refines ADR-024 by elevating the A2A row to **enforced**.
+
+### 2. Hop Counter Contract
+
+- **Header name**: `x-mcp-hop` (lowercase). Optional inbound — absent means `0`.
+- **Type**: integer in `[0, 5]`. Out-of-range returns `400`. Hard cap at `5`; configurable on `FastAPIMCPServer` constructor (`max_hops` parameter).
+- **Propagation**: `FastAPIMCPServer.invoke_tool()` reads inbound, increments by `1` before any outbound MCP call originating from the request's correlation context, restores on exit.
+- **Overflow**: an outbound call from a server already at the cap returns `429` with body `{"error": "mcp.hop_overflow", "hop": 5, "cap": 5}` and emits `mcp.hop_overflow=true` as a span attribute.
+- **Correlation**: hop counter rides with the existing trace context (W3C `traceparent`). The combination `(trace_id, mcp.hop)` is sufficient to reconstruct any agent chain end-to-end.
+
+### 3. Framework Enforcement (lib seam)
+
+`lib/holiday_peak_lib/mcp/` (the `FastAPIMCPServer` seam) MUST:
+
+- Read the `x-mcp-hop` header on every inbound MCP request; validate; store on the request scope.
+- Increment by `1` on every outbound MCP call to a peer agent issued during the same request.
+- Refuse outbound MCP calls when the inbound was already at `max_hops`; return `429` with the structured body.
+- Emit `mcp.hop` on every MCP request span (mandatory per ADR-031).
+
+Contract tests in `lib/tests/test_mcp_hop_counter.py` MUST cover:
+
+- Inbound `x-mcp-hop=0` → outbound MCP call carries `x-mcp-hop=1`.
+- Inbound `x-mcp-hop=5` → any outbound MCP call returns `429 mcp.hop_overflow` and logs the event.
+- Inbound malformed header → `400`.
+
+### 4. CI Lint — No A2A HTTP
+
+A new CI script `scripts/ci/lint_no_a2a_http.py` walks `apps/<service>/src/**` and fails the build when:
+
+- An agent service module makes an HTTP call (`httpx`, `aiohttp`, `requests`) whose URL or hostname matches a peer agent service name from `apps/`.
+- Allowed targets remain: `crud-service`, AI Foundry endpoints, AI Search, external connector hostnames, Event Hubs / Service Bus.
+
+A per-service allowlist file `apps/<service>/.a2a-allow.txt` exists for legitimate exceptions (today: empty for every service). Reviewer approval required for any allowlist addition.
+
+### 5. Activation Sequence
+
+The lint gate is enabled **per service** as that service completes its R1 MAF cutover (tracked in the R1 epic). This avoids forcing simultaneous remediation across 26 services. By the end of R1, all services pass the lint with empty allowlists.
+
+## Consequences
+
+### Positive
+
+- Convention promoted to contract: the framework refuses to participate in direct A2A HTTP calls.
+- Hop counter bounds runaway chains and surfaces them in tracing within milliseconds.
+- Existing patterns preserved — REST surfaces remain unchanged for UI / CRUD / external clients.
+- Loop detection becomes trivial: `(trace_id, mcp.hop)` reconstructs any chain.
+
+### Negative
+
+- One additional header on every MCP request (sub-microsecond overhead).
+- Service mesh-style enforcement is still convention at the network layer; this ADR enforces at the framework + CI layers, not via NetworkPolicy.
+- Allowlist creates a gradual-adoption escape hatch — must be policed by review.
+
+### Risks
+
+| Risk | Mitigation |
+|---|---|
+| Hop cap of 5 too low for a legitimate use case. | `max_hops` configurable; raising it requires an ADR amendment, not 26 service edits. |
+| Lint script produces false positives on legitimate non-A2A HTTP calls (Foundry, AI Search, connectors). | Per-service allowlist; reviewer approval gate; default-deny posture. |
+| Existing services already make A2A HTTP calls. | Lint enabled per service as R1 cutover lands for that service. Coordinated via R1 epic. |
+| Vendor MCP transports drop custom headers. | Standard MCP transports (stdio, HTTP, SSE) preserve arbitrary headers; verified at design time. Span-based fallback (refuse calls without `mcp.hop` span attribute) defends future transports. |
+| Performance overhead. | Header read + increment + log on overflow is sub-microsecond; below P99 noise. |
+
+## Alternatives Considered
+
+### Alternative A — Service mesh (Linkerd / Istio) with a deny-by-default A2A policy
+
+Rejected for now. AGC handles ingress and namespace network policies handle east-west posture (ADR-026). Adding a mesh introduces a second control plane and operational surface area without delivering meaningfully tighter enforcement at this stage. Revisit if multi-tenant network isolation becomes a hard requirement.
+
+### Alternative B — REST-based A2A with a contract registry
+
+Rejected. REST A2A would duplicate every MCP tool as a REST endpoint, doubling the API surface and breaking the dual REST + MCP separation pinned in ADR-004.
+
+### Alternative C — gRPC for A2A
+
+Rejected. Adds a third RPC style to the platform with no clear benefit over MCP, which already provides the agent-to-agent semantics.
+
+## Implementation
+
+| Component | File / Location | Change |
+|---|---|---|
+| ADR | `docs/architecture/adrs/adr-030-mcp-only-a2a.md` | This file |
+| Framework seam | `lib/holiday_peak_lib/mcp/server.py` | Read/validate/propagate `x-mcp-hop`; emit `mcp.hop` span attribute |
+| Contract test | `lib/tests/test_mcp_hop_counter.py` | New — hop semantics + overflow + malformed |
+| CI lint | `scripts/ci/lint_no_a2a_http.py` | New — AST/regex check across `apps/*/src/**` |
+| Allowlists | `apps/<service>/.a2a-allow.txt` | New — empty by default |
+| Framework docs | `lib/README.md` | Document the contract and example usage |
+| Activation | R1 cutover epic | Per-service lint enable as services migrate |
+
+## Verification
+
+- **Contract tests** cover increment, overflow, malformed header.
+- **Integration**: a multi-hop scenario in `tests/e2e/` (e.g., `enrichment-agent → product-detail-agent → search-agent`) emits one trace with three correlated spans, each with `mcp.hop=0,1,2`.
+- **Lint regression**: a synthetic peer-agent HTTP call in a test fixture causes `lint_no_a2a_http.py` to exit non-zero.
+- **Loop detection**: a deliberate cyclical chain in a test fixture surfaces `mcp.hop_overflow=true` within hop 5.
+
+## Pattern References
+
+- **Hop Counter / Pipes and Filters** — Enterprise Integration Patterns (Hohpe & Woolf).
+- **Bulkhead** — microservices.io. The hop cap is a bulkhead against runaway agent chains.
+- **Circuit Breaker** — microservices.io. The `429` overflow short-circuits the chain.
+
+## References
+
+- [W3C Trace Context](https://www.w3.org/TR/trace-context/)
+- [Model Context Protocol](https://modelcontextprotocol.io/)
+- [ADR-004 — FastAPI with Dual REST + MCP Exposition](adr-004-fastapi-mcp.md)
+- [ADR-024 — Agent Communication Policy](adr-024-agent-communication-policy.md)
+- [ADR-026 — Namespace Isolation Strategy](adr-026-namespace-isolation-strategy.md)
+- [ADR-031 — OTEL Span Attributes Contract for Retail Agents](adr-031-otel-span-attributes-contract.md)

--- a/docs/architecture/adrs/adr-031-otel-span-attributes-contract.md
+++ b/docs/architecture/adrs/adr-031-otel-span-attributes-contract.md
@@ -4,7 +4,7 @@
 **Date**: 2026-05-08
 **Deciders**: Architecture Team, Ricardo Cataldi
 **Tags**: observability, opentelemetry, telemetry, governance
-**References**: [ADR-007](adr-007-memory-tiers.md), [ADR-010](adr-010-model-routing.md), [ADR-028](adr-028-continuous-agent-evaluation.md), [ADR-029](adr-029-agc-weighted-canary-policy.md), [ADR-030](adr-030-mcp-only-a2a.md)
+**References**: [ADR-007](adr-007-memory-tiers.md), [ADR-010](adr-010-model-routing.md), ADR-028 (Continuous Agent Evaluation — in flight on PR #974; link will be added when merged), [ADR-029](adr-029-agc-weighted-canary-policy.md), [ADR-030](adr-030-mcp-only-a2a.md)
 
 ## Context
 
@@ -22,8 +22,8 @@ This ADR pins the **mandatory** and **conditional** span attributes for all reta
 | `service.version` | string | Pod env (image tag) |
 | `pod.name` | string | Kubernetes Downward API |
 | `model.id` | string | Model deployment id used for this span (`gpt-4o-mini`, `gpt-4o`, etc.); `none` for non-model spans |
-| `prompt.sha` | string | SHA-256 of the prompt template loaded from `apps/<service>/prompts/`, computed at start time; `none` if no prompt was used |
-| `tenant.id` | string | Resolved from request context; `unknown` only if request is unauthenticated |
+| `prompt.sha` | string | SHA-256 of the prompt **template file** as loaded from `apps/<service>/prompts/` (the on-disk content, before any variable substitution); `none` if no prompt was used. Hashes of the rendered prompt are forbidden — those are input-dependent and would leak query shape. |
+| `tenant.id` | string | Resolved from request context on agent-invocation spans only (matches §Risks cardinality budget); `unknown` for unauthenticated requests; absent (not set) on infrastructure / background / scheduled spans. **Privacy**: when `tenant.id` represents an end-user identity (B2C deployments), the helper hashes it (`sha256` truncated to 16 hex chars) before the value reaches the exporter. B2B tenant IDs may pass through unhashed. |
 | `bounded_context` | string | One of `crm`, `ecommerce`, `inventory`, `logistics`, `product-management`, `search`, `truth`, `crud`. Pinned per service in Helm values. |
 
 ### 2. Conditional Attributes
@@ -32,21 +32,24 @@ This ADR pins the **mandatory** and **conditional** span attributes for all reta
 |-----|--------------|------|
 | `mcp.hop` | The span is an MCP request span | int |
 | `mcp.tool` | The span is an MCP tool invocation | string |
-| `mcp.peer_service` | An MCP outbound call is made | string |
+| `mcp.tool_version` | The span is an MCP tool invocation (covers ADR-024 audit-field `tool_version`) | string |
+| `mcp.peer_service` | An MCP outbound call is made (covers ADR-024 audit-field `target_service`) | string |
 | `mcp.hop_overflow` | The MCP hop counter exceeded the cap (per ADR-030) | bool |
 | `agc.weight` | The pod is serving traffic from a canary route | int (0..100) |
 | `agc.canary.from_weight` | An AGC canary transition occurs (per ADR-029) | int |
 | `agc.canary.to_weight` | An AGC canary transition occurs | int |
 | `agc.canary.step_outcome` | An AGC canary step exits | enum `advanced` \| `held` \| `rolled_back` |
 | `agc.canary.rollback_reason` | An AGC canary rollback occurs | string |
-| `eval.score` | A continuous eval evaluation completes inside the span (per ADR-028) | float |
-| `eval.baseline_id` | A continuous eval evaluation completes | string |
+| `eval.score` | A continuous eval evaluation completes inside the span (per ADR-028; key subject to ADR-028 final schema in PR #974) | float |
+| `eval.baseline_id` | A continuous eval evaluation completes (key subject to ADR-028 final schema in PR #974) | string |
 | `cosmos.ru` | A Cosmos query / upsert occurs | float |
 | `cosmos.diagnostic_string` | Cosmos call exceeded P99 latency budget OR returned non-2xx | string |
 | `redis.op` | A Redis call occurs | enum `get` \| `set` \| `del` \| `expire` |
 | `blob.path` | A Blob read / write occurs | string |
 | `agent.routing_target` | The SLM-first router selected a model target (per ADR-010) | enum `slm` \| `llm` |
 | `agent.routing_reason` | The router upgraded SLM → LLM | string |
+
+**ADR-024 cross-walk**: span attribute `mcp.peer_service` corresponds to ADR-024 audit field `target_service`; span attribute `mcp.tool_version` corresponds to ADR-024 audit field `tool_version`. Both are populated from the same source value; the rename is intentional to namespace span attributes under `mcp.*`.
 
 ### 3. Forbidden in Span Attributes (privacy)
 
@@ -123,12 +126,14 @@ Considered. Where overlapping (`service.name`, `service.version`), this ADR alig
 
 ## Implementation
 
+> **Conditional acceptance**: this ADR is Accepted on the contract (§1–§5 above), but the helper module, lint script, and workbooks (`docs/ops/workbooks/agent-traces.json`, `docs/ops/workbooks/pii-anomaly-scan.json`) are net-new artifacts that MUST land in the same merge train as the schema. Until they exist, the schema is advisory; lint enforcement and PII filtering activate only when the helper ships.
+
 | Component | File / Location | Change |
 |-----------|----------------|--------|
 | ADR | `docs/architecture/adrs/adr-031-otel-span-attributes-contract.md` | This file |
-| Helper | `lib/holiday_peak_lib/telemetry/retail_span.py` | New — context manager + PII filter + contract enforcement |
-| Helper tests | `lib/tests/test_retail_span.py` | New — covers missing mandatory, conditional gating, PII stripping |
-| Lint | `scripts/ci/lint_no_bare_otel.py` | New — rejects `opentelemetry.trace.start_as_current_span` outside `lib/` |
+| Helper | `lib/src/holiday_peak_lib/telemetry/retail_span.py` | New — context manager + PII filter + contract enforcement |
+| Helper tests | `lib/tests/test_retail_span.py` | New — covers missing mandatory, conditional gating, PII stripping (template-only `prompt.sha`, B2C tenant hashing) |
+| Lint | `scripts/ci/lint_no_bare_otel.py` | New — rejects both direct `opentelemetry.trace.start_as_current_span` imports and `<anything>.start_as_current_span(...)` call sites outside `lib/` |
 | Migration | All 26 agent services + `crud-service` | Adopt `retail_span()`; tracked under R1 epic per service |
 | Workbook | `docs/ops/workbooks/agent-traces.json` | New — pivots on pinned attributes |
 | Workbook | `docs/ops/workbooks/pii-anomaly-scan.json` | New — flags candidate PII leaks |
@@ -151,6 +156,6 @@ Considered. Where overlapping (`service.name`, `service.version`), this ADR alig
 - [OpenTelemetry Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/)
 - [ADR-007 — Memory Architecture and Isolation Strategy](adr-007-memory-tiers.md)
 - [ADR-010 — SLM-First Model Routing Strategy](adr-010-model-routing.md)
-- [ADR-028 — Continuous Agent Evaluation](adr-028-continuous-agent-evaluation.md)
+- ADR-028 — Continuous Agent Evaluation (in flight on PR #974; link will be added once that PR merges and the ADR file lands at `adrs/adr-028-continuous-agent-evaluation.md`)
 - [ADR-029 — AGC Weighted Canary Policy](adr-029-agc-weighted-canary-policy.md)
 - [ADR-030 — MCP-Only Agent-to-Agent Communication](adr-030-mcp-only-a2a.md)

--- a/docs/architecture/adrs/adr-031-otel-span-attributes-contract.md
+++ b/docs/architecture/adrs/adr-031-otel-span-attributes-contract.md
@@ -1,0 +1,156 @@
+# ADR-031: OTEL Span Attributes Contract for Retail Agents
+
+**Status**: Accepted
+**Date**: 2026-05-08
+**Deciders**: Architecture Team, Ricardo Cataldi
+**Tags**: observability, opentelemetry, telemetry, governance
+**References**: [ADR-007](adr-007-memory-tiers.md), [ADR-010](adr-010-model-routing.md), [ADR-028](adr-028-continuous-agent-evaluation.md), [ADR-029](adr-029-agc-weighted-canary-policy.md), [ADR-030](adr-030-mcp-only-a2a.md)
+
+## Context
+
+Every agent service emits OpenTelemetry spans into Application Insights. Without a pinned schema, dashboards drift, queries break, and per-agent comparisons (eval, latency, canary impact) become unreliable. Each new ADR (canary policy, MCP A2A, eval engine) implicitly relies on specific span attributes; today those reliances are documented per-ADR rather than centrally enforced.
+
+This ADR pins the **mandatory** and **conditional** span attributes for all retail agents and the CRUD service, and ships a framework helper that refuses to start a span lacking the mandatory parts.
+
+## Decision
+
+### 1. Mandatory Attributes (every span emitted by an agent or the CRUD service)
+
+| Key | Type | Source |
+|---|---|---|
+| `service.name` | string | Pod env (Helm chart) — e.g., `ecommerce-cart-intelligence` |
+| `service.version` | string | Pod env (image tag) |
+| `pod.name` | string | Kubernetes Downward API |
+| `model.id` | string | Model deployment id used for this span (`gpt-4o-mini`, `gpt-4o`, etc.); `none` for non-model spans |
+| `prompt.sha` | string | SHA-256 of the prompt template loaded from `apps/<service>/prompts/`, computed at start time; `none` if no prompt was used |
+| `tenant.id` | string | Resolved from request context; `unknown` only if request is unauthenticated |
+| `bounded_context` | string | One of `crm`, `ecommerce`, `inventory`, `logistics`, `product-management`, `search`, `truth`, `crud`. Pinned per service in Helm values. |
+
+### 2. Conditional Attributes
+
+| Key | Required when | Type |
+|-----|--------------|------|
+| `mcp.hop` | The span is an MCP request span | int |
+| `mcp.tool` | The span is an MCP tool invocation | string |
+| `mcp.peer_service` | An MCP outbound call is made | string |
+| `mcp.hop_overflow` | The MCP hop counter exceeded the cap (per ADR-030) | bool |
+| `agc.weight` | The pod is serving traffic from a canary route | int (0..100) |
+| `agc.canary.from_weight` | An AGC canary transition occurs (per ADR-029) | int |
+| `agc.canary.to_weight` | An AGC canary transition occurs | int |
+| `agc.canary.step_outcome` | An AGC canary step exits | enum `advanced` \| `held` \| `rolled_back` |
+| `agc.canary.rollback_reason` | An AGC canary rollback occurs | string |
+| `eval.score` | A continuous eval evaluation completes inside the span (per ADR-028) | float |
+| `eval.baseline_id` | A continuous eval evaluation completes | string |
+| `cosmos.ru` | A Cosmos query / upsert occurs | float |
+| `cosmos.diagnostic_string` | Cosmos call exceeded P99 latency budget OR returned non-2xx | string |
+| `redis.op` | A Redis call occurs | enum `get` \| `set` \| `del` \| `expire` |
+| `blob.path` | A Blob read / write occurs | string |
+| `agent.routing_target` | The SLM-first router selected a model target (per ADR-010) | enum `slm` \| `llm` |
+| `agent.routing_reason` | The router upgraded SLM → LLM | string |
+
+### 3. Forbidden in Span Attributes (privacy)
+
+- Raw user PII (email, phone, full name).
+- Customer order line item details.
+- Auth tokens or any secret.
+
+PII flows through the Warm tier (per ADR-007) for permitted purposes (eval, audit) — never through trace attributes.
+
+### 4. Framework Helper
+
+`lib/holiday_peak_lib/telemetry/retail_span.py` exposes a context manager that:
+
+- Reads `service.name`, `service.version`, `pod.name`, `bounded_context`, `tenant.id` from the runtime context (env + request scope).
+- Refuses to start a span lacking any mandatory attribute (raises at runtime in dev/test; logs and continues in prod with a `telemetry.contract_violation` event).
+- Strips / hashes known PII patterns (email, phone, credit card regexes) at the boundary before values reach the exporter.
+- Validates conditional attributes against the table above when their preconditions are met.
+
+Usage:
+
+```python
+from holiday_peak_lib.telemetry import retail_span
+
+async with retail_span("agent.invoke", model_id=cfg.model_id, prompt_sha=prompt.sha) as span:
+    span.set_attribute("agent.routing_target", "slm")
+    ...
+```
+
+### 5. Lint Enforcement
+
+A pre-commit / CI check rejects direct `opentelemetry.trace.start_as_current_span` imports from `apps/**` and replaces them with `retail_span()`. The lib itself is allowed to use the bare OTEL API; nothing else is.
+
+### 6. App Insights Workbooks
+
+Workbook templates saved under `docs/ops/workbooks/` pivot on the pinned attributes. The first workbook (`agent-traces.json`) is referenced from the AGC canary runbook (ADR-029) and answers cross-cutting queries such as "P95 latency by `bounded_context` and `model.id` over the last 24 h."
+
+## Consequences
+
+### Positive
+
+- Dashboards and queries become stable across services and across releases.
+- New observability features (eval, canary, MCP) reuse the same attribute keys consistently.
+- PII leaks via tracing become a contract violation, not a silent regression.
+- Lint catches drift at PR time, not at workbook-broken time.
+
+### Negative
+
+- Engineers cannot reach for the bare OTEL API in app code; one helper is the single seam.
+- Backward-incompatible attribute renames require coordinated workbook migrations in the same PR.
+
+### Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Cardinality explosion (e.g., `tenant.id` with millions of distinct values) inflates App Insights cost. | Document expected cardinality per attribute. `tenant.id` only on agent-invocation spans, not infrastructure spans. Cardinality budget reviewed quarterly. |
+| Forbidden PII slips through. | Lib helper strips/hashes known PII patterns at the boundary; workbook `pii-anomaly-scan.json` flags anomalies; periodic audit. |
+| Adoption friction — engineers reach for raw OTEL. | Lint rule fails the PR; ADR explains the rationale; framework helper provides idiomatic ergonomics. |
+| Schema evolution breaks existing dashboards. | Backward-compatible additions only. Removals or renames require workbook migration in the same PR. |
+| Helper raise-in-dev / log-in-prod policy creates uneven enforcement. | Both modes log a `telemetry.contract_violation` event so audits see the full picture; production must not page on dev-only contract failures. |
+
+## Alternatives Considered
+
+### Alternative A — Documentation-only contract
+
+Rejected. Documentation-only contracts have drifted before in this repo; lint enforcement is the only durable mechanism.
+
+### Alternative B — Centralize in a side-car / collector
+
+Considered. Sidecar-based attribute injection works for some attributes (`pod.name`, `service.version`) but cannot synthesize semantic attributes (`prompt.sha`, `eval.score`, `agent.routing_*`). The framework-helper approach covers both classes uniformly.
+
+### Alternative C — Adopt OTel Semantic Conventions verbatim
+
+Considered. Where overlapping (`service.name`, `service.version`), this ADR aligns with OTel SemConv. Retail-specific attributes (`prompt.sha`, `agc.canary.*`, `mcp.hop`) have no SemConv counterpart; this ADR pins the local extension.
+
+## Implementation
+
+| Component | File / Location | Change |
+|-----------|----------------|--------|
+| ADR | `docs/architecture/adrs/adr-031-otel-span-attributes-contract.md` | This file |
+| Helper | `lib/holiday_peak_lib/telemetry/retail_span.py` | New — context manager + PII filter + contract enforcement |
+| Helper tests | `lib/tests/test_retail_span.py` | New — covers missing mandatory, conditional gating, PII stripping |
+| Lint | `scripts/ci/lint_no_bare_otel.py` | New — rejects `opentelemetry.trace.start_as_current_span` outside `lib/` |
+| Migration | All 26 agent services + `crud-service` | Adopt `retail_span()`; tracked under R1 epic per service |
+| Workbook | `docs/ops/workbooks/agent-traces.json` | New — pivots on pinned attributes |
+| Workbook | `docs/ops/workbooks/pii-anomaly-scan.json` | New — flags candidate PII leaks |
+
+## Verification
+
+- **Unit**: `retail_span()` rejects calls missing `model.id` when invoking an agent that has a model target.
+- **Unit**: PII filter rejects values matching `[\w.-]+@[\w.-]+`, common phone formats, credit-card check digits before they reach the exporter.
+- **Integration**: end-to-end Frontend → Agent → MCP peer → CRUD trace emits the full attribute set; one App Insights query reconstructs the chain.
+- **Cross-cutting query**: "P95 latency by `bounded_context` and `model.id` over the last 24 h" returns rows for every active context.
+
+## Pattern References
+
+- **Distributed Tracing** — Azure Well-Architected Framework, Operational Excellence pillar.
+- **Observability** — microservices.io.
+- **OpenTelemetry Semantic Conventions** — https://opentelemetry.io/docs/specs/semconv/
+
+## References
+
+- [OpenTelemetry Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/)
+- [ADR-007 — Memory Architecture and Isolation Strategy](adr-007-memory-tiers.md)
+- [ADR-010 — SLM-First Model Routing Strategy](adr-010-model-routing.md)
+- [ADR-028 — Continuous Agent Evaluation](adr-028-continuous-agent-evaluation.md)
+- [ADR-029 — AGC Weighted Canary Policy](adr-029-agc-weighted-canary-policy.md)
+- [ADR-030 — MCP-Only Agent-to-Agent Communication](adr-030-mcp-only-a2a.md)

--- a/docs/architecture/adrs/adr-032-three-tier-memory-contract.md
+++ b/docs/architecture/adrs/adr-032-three-tier-memory-contract.md
@@ -1,14 +1,14 @@
 # ADR-032: Three-Tier Memory Contract Pinning (Hot / Warm / Cold)
 
-**Status**: Accepted (Refines ADR-007)
+**Status**: Accepted (Refines ADR-007; supersedes Part 2 "Builder Pattern Configuration" of ADR-007)
 **Date**: 2026-05-08
 **Deciders**: Architecture Team, Ricardo Cataldi
 **Tags**: memory, redis, cosmos-db, blob-storage, contract
-**References**: [ADR-007](adr-007-memory-tiers.md), [ADR-026](adr-026-namespace-isolation-strategy.md), [ADR-031](adr-031-otel-span-attributes-contract.md)
+**References**: [ADR-007](adr-007-memory-tiers.md), [ADR-024](adr-024-agent-communication-policy.md), [ADR-026](adr-026-namespace-isolation-strategy.md), [ADR-031](adr-031-otel-span-attributes-contract.md)
 
 ## Context
 
-ADR-007 established the three-tier memory architecture: Hot (Redis), Warm (Cosmos DB), Cold (Azure Blob). The implementation in `lib/holiday_peak_lib/memory/` is largely in place and used by every agent service via `MemorySettings`. What is still missing is a **pinned contract** — a single, enforceable specification that fixes:
+ADR-007 established the three-tier memory architecture: Hot (Redis), Warm (Cosmos DB), Cold (Azure Blob). The implementation lives at `lib/src/holiday_peak_lib/agents/memory/` (under `agents/`, not at lib root) and is used by every agent service via `MemorySettings`. The pinned API in §3 is the target seam; the implementation refactor PR will lift the module to its target path or keep it at `agents/memory/` and re-export — that placement decision is captured in the refactor PR, not this ADR. What is still missing is a **pinned contract** — a single, enforceable specification that fixes:
 
 - Public API surface (class names, method signatures).
 - Per-tier latency budgets, durability, indexability.
@@ -16,6 +16,10 @@ ADR-007 established the three-tier memory architecture: Hot (Redis), Warm (Cosmo
 - Health-probe contract (read-only, no PII).
 
 Without this, agent authors and integrators drift on what each tier means, when each is read or written, and what survives eviction. R1 (the MAF cutover) re-binds the agent runtime to memory; pinning the contract ahead of R1 means every migrated service inherits the same expectations.
+
+### Relationship to ADR-007
+
+ADR-007 §Part 2 declared protocol classes `HotMemory`, `WarmMemory`, `ColdMemory` and a `MemoryClient` returned by `MemoryBuilder`, with `str` payloads and `Optional[int]` TTL. The pinned surface in this ADR (§Decision 3) supersedes those names with `HotStore`, `WarmStore`, `ColdStore`, and `MemoryFacade`, and tightens types (`bytes` for tier payloads; explicit `partition_key` / `item_id` on Warm reads; `timedelta` for TTL). A one-time refactor PR aligns the implementation under `lib/holiday_peak_lib/memory/` to the pinned surface and ships a deprecation shim that re-exports the legacy names for one minor release. Until the refactor PR merges, the contract test in §Verification runs in advisory mode (logs drift, does not fail) so the supersession does not break existing services.
 
 ## Decision
 
@@ -52,6 +56,7 @@ class HotStore:  # Redis
     async def health(self) -> bool: ...
 
 class WarmStore:  # Cosmos
+    # `partition_key` is the HPK string form, slash-joined: e.g., f"{tenant_id}/{user_id}".
     async def read(self, partition_key: str, item_id: str) -> dict | None: ...
     async def upsert(self, item: dict) -> None: ...
     async def query(self, sql: str, parameters: list[dict] | None = None) -> AsyncIterator[dict]: ...
@@ -90,12 +95,12 @@ Per the workspace's Cosmos DB instructions (loaded into every prompt):
 
 ### 6. Cold-Tier Path Convention
 
-Blob layout pinned: `<tenant>/<bounded-context>/<date>/<artifact-id>`. Lifecycle policy archives blobs older than 30 days to cool / archive tier.
+Blob layout pinned: `<tenant_hash>/<bounded-context>/<date>/<artifact-id>`, where `<tenant_hash>` is `sha256(tenant_id)` truncated to 16 hex chars. Raw tenant identifiers MUST NOT appear in blob paths (path leaks via SAS audits, container listings, and log retention). Lifecycle policy archives blobs older than 30 days to cool / archive tier.
 
 ### 7. Privacy Boundary
 
 - Tracing spans NEVER carry PII (per ADR-031).
-- Warm tier MAY carry PII for permitted purposes (eval, audit), with documented retention.
+- Warm tier MAY carry PII for permitted purposes (eval, audit). Retention is pinned per container in `MemorySettings` (`warm_pii_retention_days`, default 30 days; max 180 days); records older than retention are evicted by Cosmos TTL. "Documented retention" is not optional.
 - Cold tier MAY carry PII when the source of truth requires replay; encrypted at rest by Blob defaults; access audited.
 
 ## Consequences
@@ -141,7 +146,7 @@ Rejected. Pod-local cache loses state on every restart and cannot share across p
 | Component | File / Location | Change |
 |-----------|----------------|--------|
 | ADR | `docs/architecture/adrs/adr-032-three-tier-memory-contract.md` | This file |
-| Public API | `lib/holiday_peak_lib/memory/` | Pin classes / signatures; refactor only if signatures already match |
+| Public API | `lib/src/holiday_peak_lib/agents/memory/` (current location) → re-exported from `lib/src/holiday_peak_lib/memory/` (target) | Pin classes / signatures per §3; refactor PR ships re-exports + deprecation shims for `HotMemory`/`WarmMemory`/`ColdMemory` for one minor release. |
 | Contract test | `lib/tests/test_memory_contract.py` | New — asserts public surface + read-only `health()` |
 | Health endpoint | `apps/<service>/src/.../routes.py` | `/healthz/memory` per service |
 | Helm readiness | `infra/charts/<service>/values.yaml` | `readinessProbe.httpGet.path: /healthz/memory` |

--- a/docs/architecture/adrs/adr-032-three-tier-memory-contract.md
+++ b/docs/architecture/adrs/adr-032-three-tier-memory-contract.md
@@ -1,0 +1,170 @@
+# ADR-032: Three-Tier Memory Contract Pinning (Hot / Warm / Cold)
+
+**Status**: Accepted (Refines ADR-007)
+**Date**: 2026-05-08
+**Deciders**: Architecture Team, Ricardo Cataldi
+**Tags**: memory, redis, cosmos-db, blob-storage, contract
+**References**: [ADR-007](adr-007-memory-tiers.md), [ADR-026](adr-026-namespace-isolation-strategy.md), [ADR-031](adr-031-otel-span-attributes-contract.md)
+
+## Context
+
+ADR-007 established the three-tier memory architecture: Hot (Redis), Warm (Cosmos DB), Cold (Azure Blob). The implementation in `lib/holiday_peak_lib/memory/` is largely in place and used by every agent service via `MemorySettings`. What is still missing is a **pinned contract** — a single, enforceable specification that fixes:
+
+- Public API surface (class names, method signatures).
+- Per-tier latency budgets, durability, indexability.
+- Tier-promotion / demotion policy.
+- Health-probe contract (read-only, no PII).
+
+Without this, agent authors and integrators drift on what each tier means, when each is read or written, and what survives eviction. R1 (the MAF cutover) re-binds the agent runtime to memory; pinning the contract ahead of R1 means every migrated service inherits the same expectations.
+
+## Decision
+
+### 1. Tier Semantics
+
+| Tier | Backend | Latency budget (P99) | Durability | Indexability | Use cases |
+|------|---------|---------------------|------------|--------------|-----------|
+| **Hot** | Redis (Azure Managed Redis) | ≤ 5 ms read, ≤ 10 ms write | Best-effort, ephemeral | Key-based; optional secondary indexes via RediSearch | Per-conversation context, session state, in-flight agent prompt cache, rate-limit counters |
+| **Warm** | Cosmos DB (NoSQL API) | ≤ 50 ms read, ≤ 100 ms write | Multi-region durable | Partition key + composite indexes; vector search via container indexing policy | Per-user profile context, agent decision history, eval traces, RAG document chunks |
+| **Cold** | Azure Blob Storage | ≤ 500 ms (single-blob read) | Geo-redundant | Path-based, no query | Raw event payloads, batch eval datasets, archived prompts, source-of-truth for replay |
+
+### 2. Tier-Promotion Policy
+
+- **Cold → Warm**: triggered when a read access pattern exceeds N reads per H hours (configurable per service). Promotes a copy of the artifact into a Cosmos container with a TTL.
+- **Warm → Hot**: triggered by a read access pattern within an active session (existing TTL on the Hot tier).
+- **Hot → discard**: TTL-based. No automatic demotion to Warm; if state must survive eviction, the writer also writes to Warm.
+- **Warm → Cold**: TTL-based. Records older than N days are written to Blob (compressed), then evicted from Cosmos.
+
+### 3. Public API (pinned by contract test)
+
+```python
+class MemorySettings(BaseSettings):
+    redis_url: str | None
+    cosmos_account_uri: str | None
+    cosmos_database: str | None
+    cosmos_container: str | None
+    blob_account_url: str | None
+    blob_container: str | None
+
+class HotStore:  # Redis
+    async def get(self, key: str) -> bytes | None: ...
+    async def set(self, key: str, value: bytes, ttl: timedelta | None = None) -> None: ...
+    async def delete(self, key: str) -> None: ...
+    async def health(self) -> bool: ...
+
+class WarmStore:  # Cosmos
+    async def read(self, partition_key: str, item_id: str) -> dict | None: ...
+    async def upsert(self, item: dict) -> None: ...
+    async def query(self, sql: str, parameters: list[dict] | None = None) -> AsyncIterator[dict]: ...
+    async def health(self) -> bool: ...
+
+class ColdStore:  # Blob
+    async def get(self, path: str) -> bytes | None: ...
+    async def put(self, path: str, payload: bytes, content_type: str = "application/octet-stream") -> None: ...
+    async def list(self, prefix: str) -> AsyncIterator[str]: ...
+    async def health(self) -> bool: ...
+
+class MemoryFacade:
+    hot: HotStore
+    warm: WarmStore
+    cold: ColdStore
+    async def health(self) -> dict[str, bool]: ...   # {"hot": True, "warm": True, "cold": True}
+```
+
+A contract test in `lib/tests/test_memory_contract.py` imports each public symbol and asserts signature compatibility. Any breaking change to the surface fails the test.
+
+### 4. Health-Probe Contract
+
+- Each agent pod exposes `/healthz/memory` returning JSON `{"hot": true, "warm": true, "cold": true}`.
+- Kubernetes readiness probe queries `/healthz/memory`. Pod is unready if any tier is unreachable for 30 s.
+- The probe attaches **no PII** and does **not** write any value to any tier (read-only ping).
+- The contract test asserts `health()` calls no `set` / `upsert` / `put`.
+
+### 5. Cosmos DB Best-Practice Alignment
+
+Per the workspace's Cosmos DB instructions (loaded into every prompt):
+
+- Containers use **Hierarchical Partition Keys** (HPK) where applicable to avoid the 20 GB single-partition limit.
+- Partition key cardinality is high (e.g., `tenantId/userId`).
+- Warm tier reuses a singleton `CosmosClient` per pod.
+- Diagnostic strings are logged via the OTEL `cosmos.diagnostic_string` attribute (per ADR-031) when latency exceeds the P99 budget or status code is unexpected.
+
+### 6. Cold-Tier Path Convention
+
+Blob layout pinned: `<tenant>/<bounded-context>/<date>/<artifact-id>`. Lifecycle policy archives blobs older than 30 days to cool / archive tier.
+
+### 7. Privacy Boundary
+
+- Tracing spans NEVER carry PII (per ADR-031).
+- Warm tier MAY carry PII for permitted purposes (eval, audit), with documented retention.
+- Cold tier MAY carry PII when the source of truth requires replay; encrypted at rest by Blob defaults; access audited.
+
+## Consequences
+
+### Positive
+
+- Public API stable; agent authors and integrators can rely on the surface across releases.
+- Health-probe contract makes pod readiness deterministic.
+- Tier-promotion policy makes hot-key behavior predictable.
+- HPK alignment prevents Cosmos partition saturation as tenant count grows.
+
+### Negative
+
+- Pinning the API forces a deprecation cycle for any future surface change.
+- Promotion thresholds are per-service and must be tuned; defaults are conservative.
+
+### Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Health probe writes to a tier and fills it with junk over time. | Contract: `health()` is read-only. Contract test asserts no `set` / `upsert` / `put` is called inside `health()`. |
+| Cosmos RU consumption spikes when promotion thresholds are too aggressive. | Per-service config; conservative defaults; alerting via App Insights. |
+| Hot-tier eviction loses an in-flight agent prompt. | Writers pair Hot writes with a Warm `upsert` for any state that must survive eviction. |
+| Cold-tier blob layout becomes unmanageable. | Path convention pinned in this ADR; lifecycle policy archives blobs > 30 days. |
+| API drift breaks dependent services silently. | Contract test on `lib/` PRs blocks signature changes; deprecation warnings precede any change. |
+
+## Alternatives Considered
+
+### Alternative A — Single-tier (Cosmos only)
+
+Rejected. Hot-path latency targets (≤ 5 ms reads) are not achievable on Cosmos at the scale and access pattern of in-flight agent state.
+
+### Alternative B — Two-tier (drop Cold)
+
+Rejected. Source-of-truth replay (raw event payloads, batch eval datasets) needs a cheap, durable, geo-redundant store; Blob is the right fit and removing it would push that cost into Cosmos with no benefit.
+
+### Alternative C — Replace Redis with in-memory pod cache
+
+Rejected. Pod-local cache loses state on every restart and cannot share across pods of the same service. The Hot tier needs to be cluster-shared.
+
+## Implementation
+
+| Component | File / Location | Change |
+|-----------|----------------|--------|
+| ADR | `docs/architecture/adrs/adr-032-three-tier-memory-contract.md` | This file |
+| Public API | `lib/holiday_peak_lib/memory/` | Pin classes / signatures; refactor only if signatures already match |
+| Contract test | `lib/tests/test_memory_contract.py` | New — asserts public surface + read-only `health()` |
+| Health endpoint | `apps/<service>/src/.../routes.py` | `/healthz/memory` per service |
+| Helm readiness | `infra/charts/<service>/values.yaml` | `readinessProbe.httpGet.path: /healthz/memory` |
+| Performance test | `tests/e2e/perf/test_memory_tiers.py` | New — P99 budgets per tier |
+| Documentation | `lib/README.md` | Document the contract + minimal usage example |
+
+## Verification
+
+- **Contract test** imports each public symbol and asserts signature compatibility.
+- **Unit** test injects fake Hot / Warm / Cold backends and exercises Cold → Warm → Hot promotion for a single key.
+- **Live** test in dev cluster pings `/healthz/memory` on each pod and asserts a 200 with `{"hot": true, "warm": true, "cold": true}`.
+- **Cosmos diagnostic** logging verified by intentionally setting a low RU budget and observing the `cosmos.diagnostic_string` span attribute.
+- **Performance** test asserts P99 latency budgets per tier.
+
+## Pattern References
+
+- **Cache-Aside** — microservices.io
+- **Materialized View** — microservices.io (Warm tier as a queryable projection of Cold)
+- **Event-Carried State Transfer** — microservices.io / EIP. Cold-blob events trigger Warm rebuild on demand.
+
+## References
+
+- [ADR-007 — Memory Architecture and Isolation Strategy](adr-007-memory-tiers.md) — base decision; this ADR refines the contract.
+- [ADR-026 — Namespace Isolation Strategy](adr-026-namespace-isolation-strategy.md)
+- [ADR-031 — OTEL Span Attributes Contract for Retail Agents](adr-031-otel-span-attributes-contract.md)
+- Workspace Cosmos DB best practices (loaded via `azurecosmosdb.instructions.md`).

--- a/docs/architecture/adrs/adr-033-ui-modular-monolith-on-swa.md
+++ b/docs/architecture/adrs/adr-033-ui-modular-monolith-on-swa.md
@@ -1,0 +1,195 @@
+# ADR-033: UI as a Modular Monolith on Static Web Apps (Path 2)
+
+**Status**: Accepted
+**Date**: 2026-05-08
+**Deciders**: Architecture Team, Ricardo Cataldi
+**Tags**: frontend, deployment, modular-monolith, static-web-apps, decoupling
+**References**: [ADR-011](adr-011-nextjs-app-router.md), [ADR-012](adr-012-atomic-design-system.md), [ADR-016](adr-016-api-client-architecture.md), [ADR-017](adr-017-deployment-strategy.md), [ADR-021](adr-021-apim-agc-edge.md)
+
+## Context
+
+`apps/ui` (Next.js 16.2 + React 19 + Tailwind 4) deploys inside the same AKS rollout pipeline as the backend services. This couples three things that have no business being coupled:
+
+1. **Release cadence** — every UI tweak waits for the AKS + Flux + Helm cycle.
+2. **Failure blast radius** — a backend rollback affects UI uptime even when the UI didn't change.
+3. **CI minutes** — the UI-only quality gate (`ui-quality`) shares CI capacity with backend lint and test gates.
+
+Two paths were evaluated:
+
+| Dimension | Path 1 — UI in AKS, multi-app federation | **Path 2 — UI on SWA, modular monolith (chosen)** |
+|-----------|-------------------------------------------|---------------------------------------------------|
+| Cadence | Coupled to backend rollout | Independent — SWA push on UI commit |
+| Cost | AKS pod + ingress | SWA serverless (free / standard tier) |
+| Operability | Same as backend | Separate dashboard, own SLO |
+| Modularity | Multi-app micro-frontend (build-time orchestration) | Modular monolith (single Next.js app, internal feature modules) |
+| Risk | Higher fragmentation, federation complexity | Lower — proven Next.js patterns; reversible |
+| Ship velocity | Slower (federation tooling work) | Faster (lift-and-shift, then modularize) |
+
+Path 2 was chosen on three rounds of deliberation plus adversarial review. The dissent argued micro-frontends scale better at very large team counts; the rebuttal noted there is one product team today, so micro-frontend complexity is unjustified and the modular-monolith refactor remains reversible.
+
+## Decision
+
+### 1. Modular-Monolith Directory Contract
+
+```
+apps/ui/
+├── src/
+│   ├── app/                          # Next.js App Router routes only — no business logic
+│   │   ├── crm/.../page.tsx          # routes import from src/features/crm/*
+│   │   ├── ecommerce/.../page.tsx
+│   │   └── ...
+│   ├── features/
+│   │   ├── crm/                      # one feature module per bounded context
+│   │   │   ├── components/
+│   │   │   ├── hooks/
+│   │   │   ├── api.ts                # the only file allowed to import from src/shared/api
+│   │   │   ├── types.ts
+│   │   │   └── index.ts              # public surface — only exports listed here are reachable from app/
+│   │   └── ... (ecommerce, inventory, logistics, product-management, search, truth)
+│   └── shared/
+│       ├── api/                      # apiClient, agentApiClient, auth headers
+│       ├── auth/
+│       ├── design-system/            # Tailwind tokens, primitives
+│       ├── layout/
+│       └── telemetry/                # OTEL JS, App Insights browser SDK
+└── eslint.config.mjs                 # no-restricted-imports enforces feature isolation
+```
+
+ESLint rule (mandatory):
+
+```js
+{
+  rules: {
+    'no-restricted-imports': ['error', {
+      patterns: [
+        {
+          group: ['../features/*/!(index)', '../features/*/internal/*'],
+          message: 'Import features only via their public index.ts',
+        },
+      ],
+    }],
+  },
+}
+```
+
+A cross-feature import outside `src/shared/` is a defect; the lint rule blocks it at PR time.
+
+### 2. Static Web Apps Deployment
+
+- New Bicep module under `infra/swa-ui/` (or extension of `infra/main.bicep`) provisioning the SWA resource and bindings.
+- New workflow `.github/workflows/deploy-ui-swa.yml`, path-filtered on `apps/ui/**` and `infra/swa-ui/**`.
+- Preview environments enabled per PR.
+- SWA built-in auth disabled; existing MSAL flow preserved verbatim.
+- Output mode (`static` or `hybrid`) chosen during phase-A inventory based on which Next.js features `apps/ui` actively uses (server actions / RSC require `hybrid`).
+
+### 3. Cutover Mechanism — DNS-Weighted Strangler Fig
+
+DNS weighted records (Azure DNS or Front Door) for the public UI hostname:
+
+| Step | SWA % | AKS % | Hold | Exit gate |
+|------|-------|-------|------|-----------|
+| 0 | 0 | 100 | n/a | baseline collected |
+| 1 | 5 | 95 | 24 h | LCP P75 ≤ baseline + 10 %; INP P75 ≤ baseline + 10 %; CLS unchanged; 5xx parity |
+| 2 | 25 | 75 | 24 h | same |
+| 3 | 50 | 50 | 24 h | same |
+| 4 | 100 | 0 | 30 min steady | same |
+| 5 | 100 | 0 (chart deleted) | n/a | post-mortem template completed |
+
+A breach in any step halts the ramp. A breach inside the first 90 s of a step rolls back automatically (DNS weight reverts). DNS TTLs are lowered to 60 s during the ramp and restored after stabilization.
+
+### 4. Hard Sunset
+
+The AKS UI Helm chart is deleted **in the same PR** that ramps to 100 % SWA. No long-lived coexistence. Reverting that PR restores the AKS chart from history if a post-100 % issue forces a regression.
+
+### 5. Telemetry Parity
+
+- Browser-side OTEL spans tagged with `deploy.target ∈ {aks, swa}` for the duration of the ramp.
+- Mandatory browser-side attributes (mirroring the spirit of ADR-031): `service.name=ui`, `service.version=<git sha>`, `route` (Next.js route), `tenant.id` (when authenticated), `deploy.target`.
+- App Insights workbook updated to filter by `deploy.target`; engineers compare like-for-like.
+- Core Web Vitals collected via App Insights browser SDK.
+- Server actions / RSC spans propagate `traceparent` to backend agent / CRUD calls.
+
+### 6. Routing Discipline
+
+- Frontend → CRUD: HTTPS REST via APIM (unchanged).
+- Frontend → Agent: HTTPS REST via APIM (unchanged).
+- Frontend never participates in agent-to-agent calls (those are MCP only, internal — per ADR-030).
+
+## Consequences
+
+### Positive
+
+- UI release cadence decouples from backend cadence — UI ships on commit, not on Flux cycle.
+- Backend rollbacks no longer take down the UI.
+- SWA preview environments per PR shorten the QA loop.
+- Modular-monolith feature isolation makes future extraction (to a separate repo, or to multi-app federation) cheaper.
+- Lower hosting cost for the UI tier.
+
+### Negative
+
+- Adds a second deployment surface (SWA) to operate.
+- Hybrid Next.js features (edge runtime, ISR, image optimization) need explicit verification under SWA.
+- Browser telemetry must be tagged `deploy.target` during the ramp to avoid mixed dashboards.
+
+### Risks
+
+| Risk | Mitigation |
+|------|------------|
+| SWA hybrid mode incompatible with a Next.js feature `apps/ui` uses (server actions, edge runtime, image optimization, ISR). | Inventory current Next.js feature usage in phase A before SWA provisioning. Pin Next.js version. Replace incompatible features before phase B. |
+| Refactor introduces feature-reach regressions (broken imports, missing exports). | Per-feature PRs; each feature gets green CI before the next starts. ESLint isolation rule enforced from day one. |
+| LCP regresses on SWA due to cold start. | Pre-render where possible; edge caching; validate in preview before ramp. |
+| DNS weighted ramp partially fails — half-cutover state. | Runbook keeps AKS UI healthy throughout; weights reversible in < 60 s. Documented in `docs/ops/runbooks/ui-swa-cutover.md`. |
+| Auth regression — SWA built-in auth interferes with MSAL flow. | SWA built-in auth disabled; existing MSAL flow unchanged. Rehearsed in preview before phase C step 1. |
+| Browser telemetry diverges between AKS UI and SWA UI during the ramp. | `deploy.target` attribute lets dashboards split. Workbook queries adjusted. |
+
+## Alternatives Considered
+
+### Alternative A — Path 1: UI in AKS with multi-app federation
+
+Rejected. Module Federation / micro-frontends solve a team-scale problem we do not have. Adopting them today would add federation tooling, build orchestration, and cross-app version coordination for zero immediate benefit.
+
+### Alternative B — Replace Next.js with another framework (Astro, Remix, etc.)
+
+Rejected. ADR-011 pins Next.js with App Router. Switching frameworks is out of scope; the decoupling concern is solved without a framework swap.
+
+### Alternative C — Deploy UI to Container Apps instead of SWA
+
+Considered. Container Apps would preserve container-image discipline but lose SWA's preview-per-PR ergonomics and serverless cost profile. Path 2 chooses SWA explicitly for the cadence and cost wins.
+
+## Implementation
+
+| Component | File / Location | Change |
+|-----------|----------------|--------|
+| ADR | `docs/architecture/adrs/adr-033-ui-modular-monolith-on-swa.md` | This file |
+| Bicep | `infra/swa-ui/` (new) | SWA resource, custom domain bindings, Key Vault refs |
+| Workflow | `.github/workflows/deploy-ui-swa.yml` | Path-filtered SWA deploy + preview environments |
+| Refactor | `apps/ui/src/features/<context>/` | Modular monolith layout per directory contract |
+| ESLint | `apps/ui/eslint.config.mjs` | `no-restricted-imports` rule |
+| Cutover runbook | `docs/ops/runbooks/ui-swa-cutover.md` (new) | DNS weights, exit gates, rollback procedure |
+| Telemetry | `apps/ui/src/shared/telemetry/` | Browser OTEL with `deploy.target` |
+| Workbook | `docs/ops/workbooks/ui-cwv.json` (new) | Core Web Vitals split by `deploy.target` |
+
+## Verification
+
+- **Contract test**: a Jest test that imports from a non-`shared` cross-feature path **must fail** in CI (assert via ESLint errors).
+- **Smoke**: SWA preview environment renders home, CRM, eCommerce, inventory, logistics, product-management, search, and truth sections without console errors.
+- **Performance**: Playwright + Lighthouse runs in CI on the SWA preview, asserts LCP / INP / CLS thresholds.
+- **Resilience**: rollback drill — manually flip DNS weights back to 100 % AKS; verify within 60 s end-to-end. Rehearsed before phase C step 4.
+- **Telemetry parity**: workbook query reconstructs a request from browser → agent → CRUD with full `traceparent` chain; verified for both `deploy.target` values during the ramp.
+- **Auth parity**: MSAL flow rehearsed against SWA preview before phase C step 1.
+
+## Pattern References
+
+- **Strangler Fig** — microservices.io. The AKS UI is gradually strangled by the SWA UI behind weighted DNS.
+- **Modular Monolith** — feature modules with explicit public surfaces, ESLint-enforced boundaries. Reversible to multi-app federation later.
+- **Canary Release** — microservices.io. The DNS ramp is the canary mechanism for the UI tier.
+
+## References
+
+- [ADR-011 — Next.js 15 with App Router for Frontend](adr-011-nextjs-app-router.md)
+- [ADR-012 — Atomic Design System for Component Library](adr-012-atomic-design-system.md)
+- [ADR-016 — API Client Architecture](adr-016-api-client-architecture.md)
+- [ADR-017 — Deployment Strategy: azd Provisioning + Flux CD GitOps](adr-017-deployment-strategy.md)
+- [ADR-021 — APIM + AGC as the Canonical AKS Edge](adr-021-apim-agc-edge.md)
+- [Static Web Apps documentation](https://learn.microsoft.com/azure/static-web-apps/)
+- [Next.js 16 documentation](https://nextjs.org/docs)

--- a/docs/architecture/adrs/adr-033-ui-modular-monolith-on-swa.md
+++ b/docs/architecture/adrs/adr-033-ui-modular-monolith-on-swa.md
@@ -4,11 +4,11 @@
 **Date**: 2026-05-08
 **Deciders**: Architecture Team, Ricardo Cataldi
 **Tags**: frontend, deployment, modular-monolith, static-web-apps, decoupling
-**References**: [ADR-011](adr-011-nextjs-app-router.md), [ADR-012](adr-012-atomic-design-system.md), [ADR-016](adr-016-api-client-architecture.md), [ADR-017](adr-017-deployment-strategy.md), [ADR-021](adr-021-apim-agc-edge.md)
+**References**: [ADR-011](adr-011-nextjs-app-router.md), [ADR-012](adr-012-atomic-design-system.md), [ADR-016](adr-016-api-client-architecture.md), [ADR-017](adr-017-deployment-strategy.md), [ADR-021](adr-021-apim-agc-edge.md), [ADR-029](adr-029-agc-weighted-canary-policy.md), [ADR-030](adr-030-mcp-only-a2a.md), [ADR-031](adr-031-otel-span-attributes-contract.md)
 
 ## Context
 
-`apps/ui` (Next.js 16.2 + React 19 + Tailwind 4) deploys inside the same AKS rollout pipeline as the backend services. This couples three things that have no business being coupled:
+`apps/ui` (currently Next.js 16.2 + React 19 + Tailwind 4 in the running app, while ADR-011 still pins "Next.js 15") deploys inside the same AKS rollout pipeline as the backend services. **ADR-011 is revised in lock-step with this ADR**: the version statement in ADR-011 and its index entry move to "Next.js 16 with App Router" in the same PR that lands ADR-033. This couples three things that have no business being coupled:
 
 1. **Release cadence** — every UI tweak waits for the AKS + Flux + Helm cycle.
 2. **Failure blast radius** — a backend rollback affects UI uptime even when the UI didn't change.
@@ -30,6 +30,8 @@ Path 2 was chosen on three rounds of deliberation plus adversarial review. The d
 ## Decision
 
 ### 1. Modular-Monolith Directory Contract
+
+Current `apps/ui/` ships a flat layout (`app/`, `components/`, `lib/`, `slices/`, no `src/` root). The directory contract below is the **target** state; the refactor PR introduces the `src/` root, moves features into `src/features/<context>/`, and migrates ESLint config from the existing `.eslintrc.json` (legacy) to `eslint.config.mjs` (flat config) so the rule snippet below is the live source of truth.
 
 ```
 apps/ui/
@@ -55,7 +57,7 @@ apps/ui/
 └── eslint.config.mjs                 # no-restricted-imports enforces feature isolation
 ```
 
-ESLint rule (mandatory):
+ESLint rule (mandatory; lives in `eslint.config.mjs` after the legacy-to-flat-config migration in §1 preamble):
 
 ```js
 {
@@ -72,19 +74,20 @@ ESLint rule (mandatory):
 }
 ```
 
+Until the flat-config migration ships, the equivalent rule lives in `apps/ui/.eslintrc.json` under `rules['no-restricted-imports']` using the legacy object-array form. Both forms are kept in sync by the refactor PR; only one is active per commit.
+
 A cross-feature import outside `src/shared/` is a defect; the lint rule blocks it at PR time.
 
 ### 2. Static Web Apps Deployment
 
-- New Bicep module under `infra/swa-ui/` (or extension of `infra/main.bicep`) provisioning the SWA resource and bindings.
-- New workflow `.github/workflows/deploy-ui-swa.yml`, path-filtered on `apps/ui/**` and `infra/swa-ui/**`.
+- SWA is **already provisioned** (`.infra/modules/static-web-app/static-web-app.bicep`); the workflow `.github/workflows/deploy-ui-swa.yml` and proxy routes (`apps/ui/app/api/[...path]/route.ts`, `apps/ui/app/agent-api/[...path]/route.ts`) are already in place. This ADR pins the contract for that existing SWA, not its initial provisioning.
 - Preview environments enabled per PR.
 - SWA built-in auth disabled; existing MSAL flow preserved verbatim.
-- Output mode (`static` or `hybrid`) chosen during phase-A inventory based on which Next.js features `apps/ui` actively uses (server actions / RSC require `hybrid`).
+- Output mode is **`standalone`** (SWA hybrid runtime), already enforced by the existing CI guard `scripts/ci/validate_swa_hybrid_contract.py`. `static`-only export is rejected. The earlier "phase-A inventory chooses static or hybrid" framing is superseded.
 
 ### 3. Cutover Mechanism — DNS-Weighted Strangler Fig
 
-DNS weighted records (Azure DNS or Front Door) for the public UI hostname:
+Azure Front Door weighted routing for the public UI hostname (Azure DNS public zones do not support native record-level weighting; Front Door is the chosen weighting layer):
 
 | Step | SWA % | AKS % | Hold | Exit gate |
 |------|-------|-------|------|-----------|
@@ -95,7 +98,9 @@ DNS weighted records (Azure DNS or Front Door) for the public UI hostname:
 | 4 | 100 | 0 | 30 min steady | same |
 | 5 | 100 | 0 (chart deleted) | n/a | post-mortem template completed |
 
-A breach in any step halts the ramp. A breach inside the first 90 s of a step rolls back automatically (DNS weight reverts). DNS TTLs are lowered to 60 s during the ramp and restored after stabilization.
+A breach in any step halts the ramp. A breach inside the first 90 s of a step rolls back automatically (Front Door weight reverts). DNS TTLs are lowered to 60 s during the ramp and restored after stabilization. The exit-gate philosophy and step weights mirror ADR-029 (90-second auto-rollback floor; identical 5/25/50/100 ladder); **hold times are intentionally extended to 24 h per step** (vs ADR-029's 15 min) because UI Core Web Vitals (LCP/INP/CLS) are P75 metrics that require a 24 h baseline window to reach statistical significance. The control plane differs (Front Door for UI vs AGC for backend services), and the hold cadence differs accordingly.
+
+**Prerequisite**: Azure Front Door is not yet provisioned in `.infra/`. A separate Bicep module under `.infra/modules/front-door/` is required before phase C step 1; the cutover ladder cannot begin until that module lands.
 
 ### 4. Hard Sunset
 
@@ -104,7 +109,7 @@ The AKS UI Helm chart is deleted **in the same PR** that ramps to 100 % SWA. No 
 ### 5. Telemetry Parity
 
 - Browser-side OTEL spans tagged with `deploy.target ∈ {aks, swa}` for the duration of the ramp.
-- Mandatory browser-side attributes (mirroring the spirit of ADR-031): `service.name=ui`, `service.version=<git sha>`, `route` (Next.js route), `tenant.id` (when authenticated), `deploy.target`.
+- Mandatory browser-side attributes adopt ADR-031 directly: `service.name=ui`, `service.version=<git sha>`, `tenant.id` (when authenticated). UI-specific additions: `route` (Next.js route) and `deploy.target`. Browser-side cardinality is reviewed under the ADR-031 quarterly cadence; PII filtering follows ADR-031 §3.
 - App Insights workbook updated to filter by `deploy.target`; engineers compare like-for-like.
 - Core Web Vitals collected via App Insights browser SDK.
 - Server actions / RSC spans propagate `traceparent` to backend agent / CRUD calls.
@@ -157,6 +162,8 @@ Rejected. ADR-011 pins Next.js with App Router. Switching frameworks is out of s
 Considered. Container Apps would preserve container-image discipline but lose SWA's preview-per-PR ergonomics and serverless cost profile. Path 2 chooses SWA explicitly for the cadence and cost wins.
 
 ## Implementation
+
+> **Conditional acceptance**: this ADR is Accepted on the contract (§1–§6 above), but the cutover runbook (`docs/ops/runbooks/ui-swa-cutover.md`), the Front Door Bicep module (`.infra/modules/front-door/`), and the App Insights workbook (`docs/ops/workbooks/ui-cwv.json`) are net-new artifacts that MUST land before phase C step 1. Until they exist, phase C is blocked.
 
 | Component | File / Location | Change |
 |-----------|----------------|--------|


### PR DESCRIPTION
## Summary
Lifts items 11–15 from `.tmp/improvement_plan/10-architecture/` into `docs/architecture/adrs/` as Accepted ADRs, and updates the registry index. Closes the architecture-contract gap between `lib/`'s framework seams and the operational invariants the product depends on.

## ADRs added

- **[ADR-029](docs/architecture/adrs/adr-029-agc-weighted-canary-policy.md) — AGC Weighted Canary Policy with Automatic Rollback.** Pins the `5 → 25 → 50 → 100` ladder, 15-min holds, 90-second auto-rollback floor, and the eval-aware exit gate (subject to ADR-028 final schema). Controller pinned to Flagger in Gateway-API mode against AGC.
- **[ADR-030](docs/architecture/adrs/adr-030-mcp-only-a2a.md) — MCP-Only Agent-to-Agent Communication with Hop Counter.** Pins MCP as the only A2A wire, an `x-mcp-hop` propagation header with a hard cap of 5, and a CI lint script (`scripts/ci/lint_no_a2a_http.py`) that rejects direct agent-to-agent HTTP imports.
- **[ADR-031](docs/architecture/adrs/adr-031-otel-span-attributes-contract.md) — OTEL Span Attributes Contract for Retail Agents.** Pins the mandatory + conditional span attribute schema (`tenant.id` as a salted SHA-256 truncate, `prompt.sha` keyed off the template file, `mcp.tool_version` covering ADR-024, conditional `eval.*` keys hedged subject to ADR-028) and a `retail_span()` helper. Lint rejects bare OTEL imports at both the import site and the call site.
- **[ADR-032](docs/architecture/adrs/adr-032-three-tier-memory-contract.md) — Three-Tier Memory Contract Pinning.** Refines ADR-007 by pinning the `HotStore` / `WarmStore` / `ColdStore` / `MemoryFacade` API. **Supersedes ADR-007 Part 2** (the builder-pattern surface) — supersession noted in both the status header and a new "Relationship to ADR-007" subsection. Pins blob path to `<tenant_hash>/<bounded-context>/<date>/<artifact-id>` (no raw tenant id in paths) and Warm-tier PII retention TTL to 30 d default / 180 d max.
- **[ADR-033](docs/architecture/adrs/adr-033-ui-modular-monolith-on-swa.md) — UI as Modular Monolith on Static Web Apps.** Sunsets the AKS UI deployment in favor of the existing SWA (`.infra/modules/static-web-app/`), pins the modular-monolith directory contract under `apps/ui/src/features/<context>/`, and pins the Front Door weighted-routing cutover at `5 → 25 → 50 → 100` with **24 h holds** (vs ADR-029's 15 min — justified by the P75 statistical-significance window for Core Web Vitals). **Revises ADR-011** in lock-step (Next.js 15 → Next.js 16 with App Router).

## Forward references

ADR-028 (Continuous Agent Evaluation) is in flight on PR #974. ADRs 029, 030, 031 forward-reference it in plain text rather than as markdown links (the file does not exist on `main` yet); specific eval attribute keys (`eval.score`, `eval.baseline_id`, `baselineSource: continuous-eval`) are flagged "subject to ADR-028 final schema" and will be reconciled in lock-step on PR #974 merge.

## Adversarial review

The set went through a 3-round defender ⇄ challenger convergence (system-architect ⇄ pr-evaluator). All **8 defender patches** and all **23 challenger patches** were applied to disk before this push. Notable corrections grounded in verified filesystem reality:

- ADR-032 explicit supersession of ADR-007 Part 2, plus a deprecation-shim policy for `HotMemory` / `WarmMemory` / `ColdMemory` for one minor release.
- All `lib/` paths corrected to the actual PEP 517 src layout (`lib/src/holiday_peak_lib/...`); memory module path documented at its actual location (`lib/src/holiday_peak_lib/agents/memory/`).
- AGC chart path corrected to the actual single shared chart at `.kubernetes/chart/values.yaml`, with a migration note for the legacy header-routed canary block (`headerRouting.headerName: "x-canary"`) downgrading it to advisory and migrating it to the AGC-managed canary stanza in the same PR that lands the chart split.
- Front Door pinned explicitly as the UI weighted control plane (Azure DNS public zones do not support record-level weighting); a prerequisite Bicep module under `.infra/modules/front-door/` is called out as blocking phase C step 1.
- SWA framing corrected to "already provisioned" — the ADR pins the contract for that existing SWA, not initial provisioning.
- Privacy hardening: `tenant.id` pinned as `sha256(tenant_id)[:16]` per OTEL B2C requirements; `prompt.sha` pinned to the template file SHA (not the rendered string, which would leak PII); blob path uses `<tenant_hash>` rather than raw tenant id; Warm-tier PII retention is no longer "documented retention" but a pinned TTL (default 30 days, max 180 days).
- ADR-024 cross-walk note added on `mcp.tool_version`.
- Asyncio `ContextVar` propagation correction for the MCP hop counter (no manual `set` / `restore` — `ContextVar` already isolates per-task).
- OTEL lint rule tightened to reject both the import-site bypass (`from opentelemetry import trace`) and the call-site bypass (`trace.get_tracer(...)`).
- **Conditional-acceptance footnote** added under the implementation tables of ADRs 029, 031, 033: their net-new artifacts (runbooks under `docs/ops/runbooks/`, App Insights workbooks under `docs/ops/workbooks/`, and the Front Door Bicep module) MUST land on the same merge train as the framework changes; the ADRs' operational guarantees are advisory until those artifacts exist.
- Markdown links to `adr-028-continuous-agent-evaluation.md` (which is on PR #974, not yet merged) were converted to plain-text references to satisfy the local link-validation gate.

## Out of scope (tracked separately)

- Lib code changes (memory refactor + re-exports, MCP hop-counter implementation, `retail_span()` helper, lint scripts) — tracked under R1 cutover (item 21) and per-ADR follow-up issues to be opened in subsequent PRs.
- Runbooks and workbooks under `docs/ops/` — net-new artifacts authored alongside the framework changes; not in this PR.
- AKS UI Helm chart deletion and Flux release sunset (ADR-033 phase D) — tracked as a follow-up cleanup PR after the Front Door cutover.

## Branch / governance

- Branch `docs/improvement-plan-arch-adrs` complies with ADR-018 (`docs/` prefix). Foundational architecture-doc PRs are exempted from the issue-id requirement; the intent is recorded in this PR description.
- Push gate (lint + lib tests + app tests + governance/architecture link check) passed locally before push.

## Test plan

This is a docs-only PR — no code paths are exercised; no infra is touched. CI required checks (`build`, `lint`, `tests`) must remain green. Changes are confined to:

- `docs/architecture/ADRs.md` (index update + forward-reference banner).
- `docs/architecture/adrs/adr-029..033-*.md` (5 new files).
