### PR TITLE
chore(ui): fix 6 stale Jest tests so ui-quality is green

### DIFF
--- a/apps/ui/app/api/_shared/base-url-resolver.ts
+++ b/apps/ui/app/api/_shared/base-url-resolver.ts
@@ -195,7 +195,17 @@ export function resolveAgentApiBaseUrl(env?: EnvMap): ResolutionResult {
 }
 
 function inferRuntimeKind(env: EnvMap = process.env): RuntimeKind {
-  if (env.NODE_ENV === 'test' || typeof env.JEST_WORKER_ID === 'string') {
+  // Explicit NODE_ENV=test always wins. When NODE_ENV is unset, fall back to
+  // JEST_WORKER_ID detection so jest runs without an explicit NODE_ENV still
+  // resolve to the test-runtime defaults. When NODE_ENV is explicitly
+  // 'development' or 'production', honor that intent so jest tests can
+  // simulate browser/server runtime by setting NODE_ENV before importing the
+  // module under test.
+  const nodeEnv = env.NODE_ENV;
+  if (nodeEnv === 'test') {
+    return 'test';
+  }
+  if (!nodeEnv && typeof env.JEST_WORKER_ID === 'string') {
     return 'test';
   }
 

--- a/apps/ui/lib/services/productService.ts
+++ b/apps/ui/lib/services/productService.ts
@@ -125,17 +125,15 @@ export const productService = {
       baseProduct = null;
     }
 
-    if (!baseProduct) {
-      try {
-        const response = await agentApiClient.post('/ecommerce-product-detail-enrichment/invoke', {
-          sku: id,
-        });
-        recordAgentInvocationTelemetry('ecommerce-product-detail-enrichment', response.data);
-        const payload = response.data || {};
-        enrichment = (payload.enriched_product || payload) as AgentEnrichmentPayload;
-      } catch {
-        enrichment = null;
-      }
+    try {
+      const response = await agentApiClient.post('/ecommerce-product-detail-enrichment/invoke', {
+        sku: id,
+      });
+      recordAgentInvocationTelemetry('ecommerce-product-detail-enrichment', response.data);
+      const payload = response.data || {};
+      enrichment = (payload.enriched_product || payload) as AgentEnrichmentPayload;
+    } catch {
+      enrichment = null;
     }
 
     if (!baseProduct && !enrichment) {

--- a/apps/ui/tests/unit/pagesRender.test.tsx
+++ b/apps/ui/tests/unit/pagesRender.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 import HomePage from '../../app/page';
 import { CategoryPageClient } from '../../app/category/CategoryPageClient';
@@ -231,6 +231,13 @@ jest.mock('../../lib/hooks/useCart', () => ({
     },
     isLoading: false,
     isError: false,
+  }),
+  useAddToCart: () => ({
+    mutate: jest.fn(),
+    mutateAsync: jest.fn().mockResolvedValue(undefined),
+    isPending: false,
+    isError: false,
+    isSuccess: false,
   }),
 }));
 
@@ -641,17 +648,21 @@ describe('Page rendering smoke tests', () => {
     expect(screen.getByText('My Profile')).toBeInTheDocument();
     expect(screen.getByText('Demo User')).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('tab', { name: 'Addresses' }));
-    expect(screen.getByText('Addresses are not available in the current API contract.')).toBeInTheDocument();
+    // Addresses, Payment Methods, Security, and Preferences tabs are rendered
+    // as disabled placeholders ('(Soon)' suffix) until the API contract supports
+    // them. They cannot be activated, so we assert their presence and disabled
+    // state instead of the panel content.
+    const addressesTab = screen.getByRole('tab', { name: /Addresses/ });
+    expect(addressesTab).toBeDisabled();
 
-    fireEvent.click(screen.getByRole('tab', { name: 'Payment Methods' }));
-    expect(screen.getByText('Payment methods are not available in the current API contract.')).toBeInTheDocument();
+    const paymentTab = screen.getByRole('tab', { name: /Payment Methods/ });
+    expect(paymentTab).toBeDisabled();
 
-    fireEvent.click(screen.getByRole('tab', { name: 'Security' }));
-    expect(screen.getByText('Security settings are not available in the current API contract.')).toBeInTheDocument();
+    const securityTab = screen.getByRole('tab', { name: /Security/ });
+    expect(securityTab).toBeDisabled();
 
-    fireEvent.click(screen.getByRole('tab', { name: 'Preferences' }));
-    expect(screen.getByText('Preferences are not available in the current API contract.')).toBeInTheDocument();
+    const preferencesTab = screen.getByRole('tab', { name: /Preferences/ });
+    expect(preferencesTab).toBeDisabled();
 
     expect(screen.queryByText('123 Main St')).not.toBeInTheDocument();
     expect(screen.queryByText('456 Office Plaza')).not.toBeInTheDocument();
@@ -668,7 +679,9 @@ describe('Page rendering smoke tests', () => {
   it('renders deals page', () => {
     render(<DealsPage />);
     expect(screen.getByText('Deals')).toBeInTheDocument();
-    expect(screen.getByText('Campaign-selected offers likely to convert right now.')).toBeInTheDocument();
+    expect(
+      screen.getByText('Discounted catalog products surfaced from the live feed.'),
+    ).toBeInTheDocument();
   });
 
   it('renders dashboard page', () => {


### PR DESCRIPTION
## Summary

Clears the `ui-quality` baseline so R2 (UI decoupling onto SWA per ADR-033) starts from a green baseline. Six failing Jest tests in `apps/ui` were preventing `ui-quality` from passing on PRs (most recently visible on PR #976). Five of those failures are stale tests against renamed labels / updated copy / missing mocks. One is a real product regression in `productService.getEnriched` where the enrichment agent stopped being called when a base product was successfully fetched.

After this PR: `42 test suites passed, 216 tests passed, 0 failed`.

## Per-test decision table

| File:line | Test name | Decision | One-line reason |
|---|---|---|---|
| `apps/ui/tests/unit/apiClientMockAuth.test.ts:37` | `uses browser CRUD proxy base URL in browser runtime` | **STALE TEST** (+ minor product enhancement) | Test sets `NODE_ENV=development` to simulate browser, but the resolver short-circuited any jest run to `'test'` runtime via `JEST_WORKER_ID`, returning `'http://localhost:8000'` instead of `''`. Resolver now respects an explicit `NODE_ENV` override. Test assertion was already correct. |
| `apps/ui/tests/unit/apiClientMockAuth.test.ts:46` | `keeps browser CRUD proxy base URL when no public CRUD URL is configured` | **STALE TEST** (same root cause) | Same `NODE_ENV` override path as above; once the resolver honors `NODE_ENV=development`, the assertion `''` holds. |
| `apps/ui/tests/unit/productService.test.ts:62` | `records backend telemetry for enrichment-backed product loads` | **PRODUCT REGRESSION** | `getEnriched` only invoked the enrichment agent when CRUD failed (`if (!baseProduct)`), so the success path silently skipped enrichment AND telemetry. The return statement always composed both base + enrichment fields, confirming the original contract was "always enrich, then merge". Restored to always call the enrichment agent. |
| `apps/ui/tests/unit/pagesRender.test.tsx` "renders product detail page" | **STALE TEST** | `useCart` mock did not export `useAddToCart`, which `ProductPageClient` requires. Added the missing mock. |
| `apps/ui/tests/unit/pagesRender.test.tsx` "renders profile page" | **STALE TEST** | Profile tabs were renamed to `'Addresses (Soon)'`, `'Payment Methods (Soon)'`, etc. and marked `disabled: true` (panels never render for inactive disabled tabs). Updated assertions to use regex matchers and verify the disabled state instead of clicking and reading panel content. |
| `apps/ui/tests/unit/pagesRender.test.tsx` "renders deals page" | **STALE TEST** | Page subtitle copy was rewritten from `Campaign-selected offers likely to convert right now.` to `Discounted catalog products surfaced from the live feed.`. Updated assertion to match current copy. |

## Production code changes

| File | Lines | What changed | Why |
|---|---|---|---|
| `apps/ui/app/api/_shared/base-url-resolver.ts` | `inferRuntimeKind` (≈195–215) | Honor explicit `NODE_ENV=development` or `production` over `JEST_WORKER_ID` when deciding runtime kind. Only fall through to `JEST_WORKER_ID` detection when `NODE_ENV` is unset. `NODE_ENV='test'` still wins. | Lets jest tests opt-in to simulating browser/server runtime by setting `NODE_ENV` before importing the module under test. Default behavior unchanged: jest with no `NODE_ENV` still resolves to `'test'`. The resolver contract test (`baseUrlResolverContract.test.ts`) is unaffected — it always passes an explicit `runtime` parameter. |
| `apps/ui/lib/services/productService.ts` | `getEnriched` (≈125–143) | Removed the `if (!baseProduct)` guard around the enrichment fetch. The enrichment agent is now invoked unconditionally and its payload merged with the base product, matching what the return statement already composed. | **Regression fix.** The return statement always composed `baseProduct?.field || enrichment?.field || ...`, but the fetch was guarded so that successful CRUD calls would never trigger enrichment, which silently dropped telemetry and enriched fields (rating, enriched_description, related, etc.) on the happy path. The test contract pinned the original "always enrich, then merge" intent. |

## Test code changes

| File | Lines | What changed |
|---|---|---|
| `apps/ui/tests/unit/pagesRender.test.tsx` | top-level imports | Removed unused `fireEvent` import (no longer needed after profile tab assertions were rewritten to not click). |
| `apps/ui/tests/unit/pagesRender.test.tsx` | `jest.mock('../../lib/hooks/useCart', ...)` | Added `useAddToCart` mock returning a no-op mutation object. |
| `apps/ui/tests/unit/pagesRender.test.tsx` | "renders profile page" assertions | Replaced four `fireEvent.click(...) + getByText(panel content)` pairs with `getByRole('tab', { name: /X/ })` regex lookups + `toBeDisabled()` assertions — the only contract the page can honor while the four tabs are disabled placeholders. |
| `apps/ui/tests/unit/pagesRender.test.tsx` | "renders deals page" assertion | Updated copy to match current page text. |

## Coverage delta (touched files only)

| File | Before (lines) | After (lines) | Before (branch) | After (branch) |
|---|---|---|---|---|
| `apps/ui/app/api/_shared/base-url-resolver.ts` | 94.52% | 94.73% | 82.22% | 80.43% |
| `apps/ui/lib/services/productService.ts` | 36.36% | **44.44%** | 46.26% | 45.45% |

Line coverage is up overall. `productService.ts` line coverage gains ~8 points because the now-passing test exercises the enrichment fetch path. Branch coverage on `productService.ts` slips ~1 point because we removed the `if (!baseProduct)` branch entirely. Branch coverage on `base-url-resolver.ts` slips ~2 points because the new `NODE_ENV === 'test'` and `!nodeEnv && JEST_WORKER_ID` checks introduce additional branch points; the existing tests cover them all in practice but contract tests for the new escape hatch are not added (out of scope — see below).

No coverage threshold breach (`branches: 44, functions: 49, lines: 58, statements: 57` from `jest.config.js`).

## Test plan

```powershell
cd apps/ui
yarn jest                  # 42 suites passed, 216 tests passed, 0 failed
yarn lint                  # clean
```

Pre-existing `yarn type-check` error in the generated `.next/dev/types/routes.d.ts:120` is unrelated to this PR (reproduces on `main` with the change stashed).

## Branch / governance

- Branch: `chore/ui-jest-stale-tests`. Per ADR-018, baseline test cleanup of this size omits an issue id; the work is bookkeeping for the ui-quality job.
- Branch was created from `main` (verified before edits).
- No `--force-push`, no `--no-verify`. Local push gate runs the full Python suite.
- All staged paths are under `apps/ui/`. No `.tmp/` or generated artifacts committed.

## Out of scope

- **ESLint flat-config migration** (tracked under ADR-033 follow-up). This PR keeps the existing `.eslintrc.json`.
- **UI as modular monolith on SWA refactor** (ADR-033). Not pre-empted here.
- **Other UI lint warnings** outside the failing-test scope. None of the lint output not directly tied to the test fixes was touched.
- **Adding contract tests for the new `NODE_ENV` escape hatch in `inferRuntimeKind`**. The existing tests exercise the new branch indirectly; a dedicated regression test could be added in a follow-up to `baseUrlResolverContract.test.ts`.
- **Pre-existing `tsc` error in `.next/dev/types/routes.d.ts`**. Generated file; unrelated.
