### PR TITLE
feat(ui): introduce route groups (retailer)/(builder)/(deploy) (#1010)

### DIFF
--- a/apps/ui/app/(builder)/builders/page.tsx
+++ b/apps/ui/app/(builder)/builders/page.tsx
@@ -1,0 +1,67 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: 'For Builders — Holiday Peak Hub',
+  description:
+    'Architecture, ADRs, patterns, telemetry, and the reference implementation for engineers building on the platform.',
+};
+
+/**
+ * Placeholder hero for `/builders`.
+ *
+ * Real content lands in epic #1053 (Internal Technical Reference):
+ * - #1047 /builders/architecture with auto-rendered Mermaid + downloadable artifacts
+ * - #1048 /builders/adrs UI backed by scripts/ops/build_adr_registry.py
+ * - #1049 /builders/patterns (modular monolith, MCP A2A, AGC canary, three-tier memory, OTEL)
+ * - #1050 /builders/telemetry App Insights workbook iframe
+ * - #1051 /builders/enablement role-gated subtree
+ * - #1052 owner + last_reviewed front-matter contract for enablement assets
+ */
+export default function BuildersIndexPage() {
+  return (
+    <section className="mx-auto w-full max-w-3xl px-6 py-16 text-center">
+      <p className="mb-4 text-sm font-semibold uppercase tracking-widest text-[var(--hp-builder-accent,#1d4ed8)]">
+        For Builders
+      </p>
+      <h1 className="mb-6 text-4xl font-bold leading-tight">
+        The architecture, the contracts, the receipts.
+      </h1>
+      <p className="mb-10 text-lg text-[var(--hp-muted,#6b7280)]">
+        Architecture diagrams, ADRs, patterns, telemetry, and enablement land
+        here. This is the skeleton that epic{' '}
+        <a
+          href="https://github.com/Azure-Samples/holiday-peak-hub/issues/1053"
+          className="underline hover:no-underline"
+        >
+          #1053
+        </a>{' '}
+        fills out.
+      </p>
+      <div className="grid grid-cols-1 gap-4 text-left sm:grid-cols-2">
+        <Link
+          href="/retailers"
+          className="rounded-xl border border-[var(--hp-border,#e5e7eb)] p-4 hover:shadow-sm"
+        >
+          <span className="block text-sm font-semibold uppercase tracking-wide text-[var(--hp-retailer-accent,#b45309)]">
+            Looking for the business case?
+          </span>
+          <span className="mt-1 block text-sm text-[var(--hp-muted,#6b7280)]">
+            Switch to the retailer lane →
+          </span>
+        </Link>
+        <Link
+          href="/deploy"
+          className="rounded-xl border border-[var(--hp-border,#e5e7eb)] p-4 hover:shadow-sm"
+        >
+          <span className="block text-sm font-semibold uppercase tracking-wide text-[var(--hp-text,#111827)]">
+            Spin up your own
+          </span>
+          <span className="mt-1 block text-sm text-[var(--hp-muted,#6b7280)]">
+            One-click deployment portal →
+          </span>
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/apps/ui/app/(builder)/layout.tsx
+++ b/apps/ui/app/(builder)/layout.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from 'react';
+import { SectionShell } from '@/components/shared/SectionShell';
+
+/**
+ * (builder) route group layout.
+ *
+ * Wraps every page under `/builders/...` in the shared SectionShell.
+ * Section-specific chrome (architecture diagrams, ADR registry, telemetry,
+ * enablement) lives in epic #1053.
+ */
+export default function BuilderGroupLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return <SectionShell variant="builder">{children}</SectionShell>;
+}

--- a/apps/ui/app/(deploy)/deploy/page.tsx
+++ b/apps/ui/app/(deploy)/deploy/page.tsx
@@ -1,0 +1,73 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: 'Deploy — Holiday Peak Hub',
+  description:
+    'One-click deployment portal. Pick a scenario, configure, pre-flight, deploy, track, clean up — no GitHub account required.',
+};
+
+/**
+ * Placeholder hero for `/deploy`.
+ *
+ * Real content lands in epic #1039 (One-Click Deployment Portal):
+ * - #1027 deploy-portal Bicep module (Container Apps + APIM + Key Vault + Cosmos)
+ * - #1028 catalog UI at /deploy/catalog with live cost estimator
+ * - #1029 configure UI at /deploy/configure
+ * - #1030 pre-flight backend (quota / capacity / RG) + UI
+ * - #1031 OBO OAuth + ARM deployment kickoff
+ * - #1032 SignalR-driven track UI at /deploy/track/<id>
+ * - #1033 mid-flight failure cleanup contract
+ * - #1034 rate limiting + abuse detection
+ * - #1035 deployment metadata persistence + log scrubbing
+ * - #1036 exit / portability action
+ * - #1037 SOC 2 / GDPR / PCI posture for /retailers/security
+ * - #1038 cost-transparency disclosure + Azure Retail Prices integration
+ */
+export default function DeployIndexPage() {
+  return (
+    <section className="mx-auto w-full max-w-3xl px-6 py-16 text-center">
+      <p className="mb-4 text-sm font-semibold uppercase tracking-widest text-[var(--hp-text,#111827)]">
+        Deploy
+      </p>
+      <h1 className="mb-6 text-4xl font-bold leading-tight">
+        Spin up your own. No GitHub account required.
+      </h1>
+      <p className="mb-10 text-lg text-[var(--hp-muted,#6b7280)]">
+        The one-click deployment portal lands here. This is the skeleton that
+        epic{' '}
+        <a
+          href="https://github.com/Azure-Samples/holiday-peak-hub/issues/1039"
+          className="underline hover:no-underline"
+        >
+          #1039
+        </a>{' '}
+        fills out.
+      </p>
+      <div className="grid grid-cols-1 gap-4 text-left sm:grid-cols-2">
+        <Link
+          href="/retailers"
+          className="rounded-xl border border-[var(--hp-border,#e5e7eb)] p-4 hover:shadow-sm"
+        >
+          <span className="block text-sm font-semibold uppercase tracking-wide text-[var(--hp-retailer-accent,#b45309)]">
+            Need the business case first?
+          </span>
+          <span className="mt-1 block text-sm text-[var(--hp-muted,#6b7280)]">
+            See the retailer lane →
+          </span>
+        </Link>
+        <Link
+          href="/builders"
+          className="rounded-xl border border-[var(--hp-border,#e5e7eb)] p-4 hover:shadow-sm"
+        >
+          <span className="block text-sm font-semibold uppercase tracking-wide text-[var(--hp-builder-accent,#1d4ed8)]">
+            Want to read the architecture first?
+          </span>
+          <span className="mt-1 block text-sm text-[var(--hp-muted,#6b7280)]">
+            See the builder lane →
+          </span>
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/apps/ui/app/(deploy)/layout.tsx
+++ b/apps/ui/app/(deploy)/layout.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from 'react';
+import { SectionShell } from '@/components/shared/SectionShell';
+
+/**
+ * (deploy) route group layout.
+ *
+ * Wraps every page under `/deploy/...` in the shared SectionShell.
+ * Section-specific chrome (catalog, configure, pre-flight, track) lives in
+ * epic #1039.
+ */
+export default function DeployGroupLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return <SectionShell variant="deploy">{children}</SectionShell>;
+}

--- a/apps/ui/app/(retailer)/layout.tsx
+++ b/apps/ui/app/(retailer)/layout.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from 'react';
+import { SectionShell } from '@/components/shared/SectionShell';
+
+/**
+ * (retailer) route group layout.
+ *
+ * Wraps every page under `/retailers/...` in the shared SectionShell.
+ * Section-specific chrome (heroes, calculators, comparators) lives in the
+ * page-level components and follow-up issues #1040–#1045.
+ */
+export default function RetailerGroupLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return <SectionShell variant="retailer">{children}</SectionShell>;
+}

--- a/apps/ui/app/(retailer)/retailers/page.tsx
+++ b/apps/ui/app/(retailer)/retailers/page.tsx
@@ -1,0 +1,67 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: 'For Retailers — Holiday Peak Hub',
+  description:
+    'Business outcomes, agent catalog, ROI calculator, comparators, and case studies for retail leaders.',
+};
+
+/**
+ * Placeholder hero for `/retailers`.
+ *
+ * Real content lands in epic #1046 (Retailer-Facing Value Pages):
+ * - #1040 hero + 3-pillar value proposition
+ * - #1041 agent catalog (27 agents, domain grouping, cost/1k)
+ * - #1042 interactive ROI calculator with confidence intervals
+ * - #1043 comparators matrix
+ * - #1044 case studies with maturity badges
+ * - #1045 cost-model methodology + Azure Retail Prices integration
+ */
+export default function RetailersIndexPage() {
+  return (
+    <section className="mx-auto w-full max-w-3xl px-6 py-16 text-center">
+      <p className="mb-4 text-sm font-semibold uppercase tracking-widest text-[var(--hp-retailer-accent,#b45309)]">
+        For Retailers
+      </p>
+      <h1 className="mb-6 text-4xl font-bold leading-tight">
+        Built for the people who run the business.
+      </h1>
+      <p className="mb-10 text-lg text-[var(--hp-muted,#6b7280)]">
+        Agents, ROI, case studies, and comparators land here. This is the
+        skeleton that epic{' '}
+        <a
+          href="https://github.com/Azure-Samples/holiday-peak-hub/issues/1046"
+          className="underline hover:no-underline"
+        >
+          #1046
+        </a>{' '}
+        fills out.
+      </p>
+      <div className="grid grid-cols-1 gap-4 text-left sm:grid-cols-2">
+        <Link
+          href="/builders"
+          className="rounded-xl border border-[var(--hp-border,#e5e7eb)] p-4 hover:shadow-sm"
+        >
+          <span className="block text-sm font-semibold uppercase tracking-wide text-[var(--hp-builder-accent,#1d4ed8)]">
+            Looking for the architecture?
+          </span>
+          <span className="mt-1 block text-sm text-[var(--hp-muted,#6b7280)]">
+            Switch to the builder lane →
+          </span>
+        </Link>
+        <Link
+          href="/deploy"
+          className="rounded-xl border border-[var(--hp-border,#e5e7eb)] p-4 hover:shadow-sm"
+        >
+          <span className="block text-sm font-semibold uppercase tracking-wide text-[var(--hp-text,#111827)]">
+            Try it yourself
+          </span>
+          <span className="mt-1 block text-sm text-[var(--hp-muted,#6b7280)]">
+            One-click deployment portal →
+          </span>
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/apps/ui/components/shared/SectionShell.tsx
+++ b/apps/ui/components/shared/SectionShell.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import Link from 'next/link';
+
+export type SectionVariant = 'home' | 'retailer' | 'builder' | 'deploy' | 'docs';
+
+type SectionShellProps = {
+  variant: SectionVariant;
+  children: ReactNode;
+  /** Optional breadcrumb slot rendered above the section content. */
+  breadcrumb?: ReactNode;
+  /** Optional lane-switch slot. Used by the audience-IA persona switcher. */
+  laneSwitch?: ReactNode;
+};
+
+const VARIANT_LABEL: Record<SectionVariant, string> = {
+  home: 'Holiday Peak Hub',
+  retailer: 'For Retailers',
+  builder: 'For Builders',
+  deploy: 'Deploy',
+  docs: 'Documentation',
+};
+
+/**
+ * SectionShell — the single shell consumed by every audience route group.
+ *
+ * Per ADR-034 the shell only handles:
+ *   - tokens (variant attribute on the wrapper for CSS scoping)
+ *   - top-level brand mark + section label
+ *   - breadcrumb slot
+ *   - lane-switch slot (filled by the audience-IA persona switcher)
+ *
+ * Section-specific chrome (heroes, dashboards, calculators, etc.) stays
+ * inside the section's own layout and pages — the shell does NOT grow into
+ * a god-component.
+ */
+export function SectionShell({
+  variant,
+  children,
+  breadcrumb,
+  laneSwitch,
+}: SectionShellProps) {
+  return (
+    <div data-section={variant} className="flex min-h-screen flex-col">
+      <header className="border-b border-[var(--hp-border,#e5e7eb)] bg-white">
+        <div className="mx-auto flex w-full max-w-7xl items-center justify-between px-6 py-4">
+          <Link
+            href="/"
+            className="flex items-baseline gap-2 text-base font-semibold text-[var(--hp-text,#111827)] hover:opacity-80"
+          >
+            <span>Holiday Peak Hub</span>
+            <span
+              aria-hidden="true"
+              className="text-xs font-medium uppercase tracking-widest text-[var(--hp-muted,#6b7280)]"
+            >
+              {VARIANT_LABEL[variant]}
+            </span>
+          </Link>
+          {laneSwitch ? <div className="ml-auto">{laneSwitch}</div> : null}
+        </div>
+        {breadcrumb ? (
+          <div className="mx-auto w-full max-w-7xl px-6 pb-3 text-sm text-[var(--hp-muted,#6b7280)]">
+            {breadcrumb}
+          </div>
+        ) : null}
+      </header>
+      <main className="flex-1">{children}</main>
+      <footer className="border-t border-[var(--hp-border,#e5e7eb)] bg-white">
+        <div className="mx-auto flex w-full max-w-7xl flex-col gap-2 px-6 py-6 text-sm text-[var(--hp-muted,#6b7280)] sm:flex-row sm:items-center sm:justify-between">
+          <span>© Holiday Peak Hub — Microsoft Azure-Samples</span>
+          <nav aria-label="Footer">
+            <ul className="flex flex-wrap gap-4">
+              <li>
+                <Link href="/retailers" className="hover:underline">
+                  For Retailers
+                </Link>
+              </li>
+              <li>
+                <Link href="/builders" className="hover:underline">
+                  For Builders
+                </Link>
+              </li>
+              <li>
+                <Link href="/deploy" className="hover:underline">
+                  Deploy
+                </Link>
+              </li>
+              <li>
+                <Link href="/docs" className="hover:underline">
+                  Docs
+                </Link>
+              </li>
+            </ul>
+          </nav>
+        </div>
+      </footer>
+    </div>
+  );
+}
+
+export default SectionShell;

--- a/apps/ui/components/shared/index.ts
+++ b/apps/ui/components/shared/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Shared route-group primitives.
+ *
+ * Per ADR-034, every audience route group consumes `SectionShell` for the
+ * cross-cutting chrome (brand mark, section label, breadcrumb slot, lane-switch
+ * slot). Section-specific chrome stays inside each group's own layout.
+ */
+export { SectionShell } from './SectionShell';
+export type { SectionVariant } from './SectionShell';


### PR DESCRIPTION
## Summary

Introduces the App Router route-group skeleton required by **ADR-034** (audience-segmented IA) and **ADR-035** (UI design system contract). Closes the structural prerequisite for every other GTM capability under epics #1046, #1053, and #1039.

## Changes

### Route groups

Three new App Router route groups under `apps/ui/app/`:

```
app/
├── (retailer)/
│   ├── layout.tsx          → SectionShell variant="retailer"
│   └── retailers/
│       └── page.tsx
├── (builder)/
│   ├── layout.tsx          → SectionShell variant="builder"
│   └── builders/
│       └── page.tsx
└── (deploy)/
    ├── layout.tsx          → SectionShell variant="deploy"
    └── deploy/
        └── page.tsx
```

Verified routes in `yarn build`:
- `Ï /retailers`
- `Ï /builders`
- `Ï /deploy`

### Shared shell

New `apps/ui/components/shared/SectionShell.tsx` — section chrome (brand mark, section label, breadcrumb slot, lane-switch slot, footer audience nav) extracted as a single reusable client component. Variants: `home | retailer | builder | deploy | docs`.

Each route-group `layout.tsx` consumes `SectionShell` with the corresponding variant. Section-specific chrome (heroes, calculators, comparators, ADR registry UI, deployment wizard) stays inside each group's `page.tsx` files.

### Placeholder content

Each `page.tsx` renders a minimal hero + audience-router cross-links. The placeholder explicitly names the follow-up epic so the next contributor knows what lands next:

| Route       | Real content lands in |
|-------------|-----------------------|
| `/retailers`| Epic #1046            |
| `/builders` | Epic #1053            |
| `/deploy`   | Epic #1039            |

## Acceptance criteria

- [x] Three route groups under `apps/ui/app/`: `(retailer)/retailers/`, `(builder)/builders/`, `(deploy)/deploy/`.
- [x] Shared shell extracted to `apps/ui/components/shared/SectionShell.tsx` with `variant` prop.
- [x] Each route group has its own `layout.tsx` consuming `<SectionShell>`.
- [x] Default `/` (home) keeps the audience-router shell from #1055 — split-hero with two equally-weighted CTAs, no carousel/autoplay.
- [x] No cross-route-group imports of section-private components — each `(group)/layout.tsx` only imports from `@/components/shared`; pages only import from `@/components/shared` or `next/link`.
- [x] `yarn build` green; existing routes unaffected.

## Verification

```
yarn install --ignore-engines  ✓
yarn lint --quiet               ✓ (0 warnings)
yarn build                       ✓ (40 routes; 3 new audience routes prerendered)
yarn test --silent               ✓ (42 suites, 216 tests)
```

## Note on import contract

Issue #1010 mentions an ESLint rule or `tsconfig` path enforcement to prevent cross-route-group section-private imports. In this PR the contract is enforced **structurally**: section-private components don't yet exist. They will be introduced under epics #1046, #1053, and #1039. When the first section-private component lands, follow-up issue #1011 (dual design tokens) is the natural place to land the lint rule, since it's the same area of the codebase. This is documented as a follow-up so the PR stays scoped to the skeleton.

## ADR alignment

- **ADR-033** — UI as a modular monolith on Static Web Apps: implementation step.
- **ADR-034** — Audience-segmented IA: locks the three top paths.
- **ADR-035** — UI design system contract: route-group structure is the prerequisite for the design-system roll-out (#1056–#1060).
- **ADR-018** — Branch naming: `feature/1010-route-groups`.

Closes #1010.
