### PR TITLE
feat(ui): per-section SEO metadata + segmented sitemap (#1013)

### DIFF
--- a/apps/ui/app/(builder)/builders/page.tsx
+++ b/apps/ui/app/(builder)/builders/page.tsx
@@ -1,11 +1,14 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 
-export const metadata: Metadata = {
-  title: 'For Builders — Holiday Peak Hub',
+import { buildMetadata } from '@/lib/seo';
+
+export const metadata: Metadata = buildMetadata({
+  section: 'builder',
   description:
     'Architecture, ADRs, patterns, telemetry, and the reference implementation for engineers building on the platform.',
-};
+  path: '/builders',
+});
 
 /**
  * Placeholder hero for `/builders`.

--- a/apps/ui/app/(deploy)/deploy/page.tsx
+++ b/apps/ui/app/(deploy)/deploy/page.tsx
@@ -1,11 +1,14 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 
-export const metadata: Metadata = {
-  title: 'Deploy — Holiday Peak Hub',
+import { buildMetadata } from '@/lib/seo';
+
+export const metadata: Metadata = buildMetadata({
+  section: 'deploy',
   description:
     'One-click deployment portal. Pick a scenario, configure, pre-flight, deploy, track, clean up — no GitHub account required.',
-};
+  path: '/deploy',
+});
 
 /**
  * Placeholder hero for `/deploy`.

--- a/apps/ui/app/(retailer)/retailers/page.tsx
+++ b/apps/ui/app/(retailer)/retailers/page.tsx
@@ -1,11 +1,14 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 
-export const metadata: Metadata = {
-  title: 'For Retailers — Holiday Peak Hub',
+import { buildMetadata } from '@/lib/seo';
+
+export const metadata: Metadata = buildMetadata({
+  section: 'retailer',
   description:
     'Business outcomes, agent catalog, ROI calculator, comparators, and case studies for retail leaders.',
-};
+  path: '/retailers',
+});
 
 /**
  * Placeholder hero for `/retailers`.

--- a/apps/ui/app/page.tsx
+++ b/apps/ui/app/page.tsx
@@ -4,11 +4,14 @@ import Link from 'next/link';
 import { HomeSplitHero } from '@/components/shared/HomeSplitHero';
 import { resolvePersonaFromRequest } from '@/lib/persona/resolve';
 
-export const metadata: Metadata = {
-  title: 'Holiday Peak Hub — Intelligent Retail Platform',
+import { buildMetadata } from '@/lib/seo';
+
+export const metadata: Metadata = buildMetadata({
+  section: 'home',
   description:
     'An audience-segmented router. Retailers see business outcomes; builders see architecture and reference implementation. Pick your lane.',
-};
+  path: '/',
+});
 
 type HomePageProps = {
   searchParams: Promise<Record<string, string | string[] | undefined>>;

--- a/apps/ui/app/robots.ts
+++ b/apps/ui/app/robots.ts
@@ -1,0 +1,19 @@
+import type { MetadataRoute } from 'next';
+
+import { SEO_CONFIG } from '@/lib/seo';
+
+/**
+ * robots.txt — points to the segmented sitemap per ADR-034 §6.
+ */
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: ['/api/'],
+      },
+    ],
+    sitemap: `${SEO_CONFIG.SITE_URL}/sitemap.xml`,
+  };
+}

--- a/apps/ui/app/sitemap.ts
+++ b/apps/ui/app/sitemap.ts
@@ -1,0 +1,59 @@
+import type { MetadataRoute } from 'next';
+
+import { SEO_CONFIG } from '@/lib/seo';
+
+/**
+ * Segmented sitemap per ADR-034 §6.
+ *
+ * Sections are grouped (retailer, builder, deploy, docs, home) so the lanes
+ * do not compete for the same impressions in organic search. The mkdocs
+ * subtree maintains its own `/docs/sitemap.xml`; the entry below references
+ * that subtree without duplicating its URLs (cross-reference rule).
+ *
+ * `priority` and `changeFrequency` reflect the editorial cadence:
+ *   - 1.0 / weekly for the home — always relevant.
+ *   - 0.9 / weekly for top-level audience landings.
+ *   - 0.7 / monthly for deeper section pages once they ship.
+ *   - 0.5 / monthly for the docs subtree pointer.
+ */
+export default function sitemap(): MetadataRoute.Sitemap {
+  const base = SEO_CONFIG.SITE_URL;
+  const lastModified = new Date();
+
+  const entries: MetadataRoute.Sitemap = [
+    {
+      url: `${base}/`,
+      lastModified,
+      changeFrequency: 'weekly',
+      priority: 1.0,
+    },
+    {
+      url: `${base}/retailers`,
+      lastModified,
+      changeFrequency: 'weekly',
+      priority: 0.9,
+    },
+    {
+      url: `${base}/builders`,
+      lastModified,
+      changeFrequency: 'weekly',
+      priority: 0.9,
+    },
+    {
+      url: `${base}/deploy`,
+      lastModified,
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+    {
+      // Cross-reference to the mkdocs sitemap. Search engines follow nested
+      // sitemap pointers; we don't duplicate the URLs.
+      url: `${base}/docs/sitemap.xml`,
+      lastModified,
+      changeFrequency: 'monthly',
+      priority: 0.5,
+    },
+  ];
+
+  return entries;
+}

--- a/apps/ui/lib/seo/buildMetadata.ts
+++ b/apps/ui/lib/seo/buildMetadata.ts
@@ -1,0 +1,108 @@
+import type { Metadata } from 'next';
+
+/**
+ * Audience lanes addressable by the SEO layer.
+ *
+ * Defined here (instead of imported from `@/components/shared/LaneSwitch`)
+ * so the SEO contract stays independent of LaneSwitch's render layer. Once
+ * #1012 lands, `LaneAudience` from LaneSwitch is structurally identical to
+ * the `'retailer' | 'builder' | 'deploy'` arm of `Section` below.
+ */
+export type Section = 'retailer' | 'builder' | 'deploy' | 'home' | 'docs';
+
+const SITE_NAME = 'Holiday Peak Hub';
+
+/**
+ * Canonical site URL. Set via NEXT_PUBLIC_SITE_URL at build time; falls back
+ * to the GitHub Pages preview origin so local builds don't crash. The fallback
+ * is a known string and is only used when the env var is missing — production
+ * builds set it explicitly via the Static Web Apps deploy workflow.
+ */
+const SITE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL ?? 'https://holiday-peak-hub.example';
+
+const OG_IMAGE_BY_SECTION: Record<Section, string> = {
+  home: '/og/home.svg',
+  retailer: '/og/retailer.svg',
+  builder: '/og/builder.svg',
+  deploy: '/og/deploy.svg',
+  docs: '/og/docs.svg',
+};
+
+const TITLE_SUFFIX_BY_SECTION: Record<Section, string> = {
+  home: SITE_NAME,
+  retailer: `For Retailers — ${SITE_NAME}`,
+  builder: `For Builders — ${SITE_NAME}`,
+  deploy: `Deploy — ${SITE_NAME}`,
+  docs: `Documentation — ${SITE_NAME}`,
+};
+
+export type BuildMetadataInput = {
+  /** Audience section the page belongs to. */
+  section: Section;
+  /** Page title (without site suffix — buildMetadata appends it). */
+  title?: string;
+  /** Page description; should fit in ~150 chars to avoid truncation. */
+  description: string;
+  /** Path under the site root, e.g. `/retailers/value`. */
+  path: string;
+  /** Optional override for the OG image path. */
+  ogImage?: string;
+};
+
+/**
+ * Per-section metadata helper.
+ *
+ * Per ADR-034 every section page is a valid landing page from organic search
+ * and must declare its own title, description, OG tags, and canonical URL.
+ *
+ * Section pages call this instead of hand-rolling Metadata so that:
+ *   - Title suffix stays consistent across all pages in a section.
+ *   - OG images stay matched to the audience tone.
+ *   - Canonical URLs and og:url stay in sync with the path.
+ *
+ * The helper does not add `robots` or `alternates.languages` overrides —
+ * those land in follow-up issues (i18n is out of scope for ADR-034 v1).
+ */
+export function buildMetadata({
+  section,
+  title,
+  description,
+  path,
+  ogImage,
+}: BuildMetadataInput): Metadata {
+  const fullTitle = title
+    ? `${title} — ${TITLE_SUFFIX_BY_SECTION[section]}`
+    : TITLE_SUFFIX_BY_SECTION[section];
+  const url = new URL(path, SITE_URL).toString();
+  const image = ogImage ?? OG_IMAGE_BY_SECTION[section];
+
+  return {
+    title: fullTitle,
+    description,
+    alternates: {
+      canonical: url,
+    },
+    openGraph: {
+      title: fullTitle,
+      description,
+      url,
+      siteName: SITE_NAME,
+      images: [{ url: image, width: 1200, height: 630, alt: fullTitle }],
+      type: 'website',
+      locale: 'en_US',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: fullTitle,
+      description,
+      images: [image],
+    },
+  };
+}
+
+export const SEO_CONFIG = {
+  SITE_NAME,
+  SITE_URL,
+  OG_IMAGE_BY_SECTION,
+} as const;

--- a/apps/ui/lib/seo/index.ts
+++ b/apps/ui/lib/seo/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Per-section SEO helpers (ADR-034 §6).
+ */
+export {
+  buildMetadata,
+  SEO_CONFIG,
+  type BuildMetadataInput,
+  type Section,
+} from './buildMetadata';

--- a/apps/ui/public/og/builder.svg
+++ b/apps/ui/public/og/builder.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-label="For Builders — Holiday Peak Hub">
+  <defs>
+    <linearGradient id="bgGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#eff6ff" />
+      <stop offset="100%" stop-color="#dbeafe" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bgGradient)" />
+  <rect x="0" y="0" width="6" height="630" fill="#1d4ed8" />
+  <text x="64" y="120" font-family="ui-monospace, 'JetBrains Mono', 'Fira Code', monospace" font-size="22" font-weight="600" fill="#1e3a8a" letter-spacing="6">FOR BUILDERS</text>
+  <text x="64" y="240" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="84" font-weight="700" fill="#1a1a1a">The architecture,</text>
+  <text x="64" y="340" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="84" font-weight="700" fill="#1a1a1a">the contracts, the receipts.</text>
+  <text x="64" y="430" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="32" font-weight="400" fill="#6b6b6b">ADRs, patterns, telemetry, reference implementation.</text>
+  <text x="64" y="566" font-family="ui-monospace, 'JetBrains Mono', 'Fira Code', monospace" font-size="20" font-weight="500" fill="#1d4ed8">Holiday Peak Hub · Microsoft · Azure-Samples</text>
+</svg>

--- a/apps/ui/public/og/deploy.svg
+++ b/apps/ui/public/og/deploy.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-label="Deploy — Holiday Peak Hub">
+  <defs>
+    <linearGradient id="bgGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#f8fafc" />
+      <stop offset="100%" stop-color="#e2e8f0" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bgGradient)" />
+  <rect x="0" y="0" width="6" height="630" fill="#334155" />
+  <text x="64" y="120" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="22" font-weight="600" fill="#1e293b" letter-spacing="6">DEPLOY</text>
+  <text x="64" y="240" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="84" font-weight="700" fill="#1a1a1a">Spin up your own.</text>
+  <text x="64" y="340" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="84" font-weight="700" fill="#1a1a1a">No GitHub account required.</text>
+  <text x="64" y="430" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="32" font-weight="400" fill="#6b6b6b">One-click deployment portal. Catalog, configure, track, clean up.</text>
+  <text x="64" y="566" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="20" font-weight="500" fill="#334155">Holiday Peak Hub · Microsoft · Azure-Samples</text>
+</svg>

--- a/apps/ui/public/og/docs.svg
+++ b/apps/ui/public/og/docs.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-label="Documentation — Holiday Peak Hub">
+  <defs>
+    <linearGradient id="bgGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#fafaf9" />
+      <stop offset="100%" stop-color="#f5f3ef" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bgGradient)" />
+  <rect x="0" y="0" width="6" height="630" fill="#0d7a70" />
+  <text x="64" y="120" font-family="ui-monospace, 'JetBrains Mono', 'Fira Code', monospace" font-size="22" font-weight="600" fill="#0d7a70" letter-spacing="6">DOCUMENTATION</text>
+  <text x="64" y="240" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="84" font-weight="700" fill="#1a1a1a">Read the docs.</text>
+  <text x="64" y="430" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="32" font-weight="400" fill="#6b6b6b">ADRs, runbooks, architecture, governance.</text>
+  <text x="64" y="566" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="20" font-weight="500" fill="#0d7a70">Holiday Peak Hub · Microsoft · Azure-Samples</text>
+</svg>

--- a/apps/ui/public/og/home.svg
+++ b/apps/ui/public/og/home.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-label="Holiday Peak Hub — Intelligent Retail Platform">
+  <defs>
+    <linearGradient id="bgGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#fafaf9" />
+      <stop offset="100%" stop-color="#f5f3ef" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bgGradient)" />
+  <rect x="0" y="0" width="6" height="630" fill="#c73a2a" />
+  <text x="64" y="120" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="22" font-weight="600" fill="#6b6b6b" letter-spacing="6">HOLIDAY PEAK HUB</text>
+  <text x="64" y="240" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="84" font-weight="700" fill="#1a1a1a">Intelligent retail,</text>
+  <text x="64" y="340" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="84" font-weight="700" fill="#1a1a1a">on Azure's agentic platform.</text>
+  <text x="64" y="430" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="32" font-weight="400" fill="#6b6b6b">Pick your lane: retailer, builder, or deploy.</text>
+  <text x="64" y="566" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="20" font-weight="500" fill="#0d7a70">Microsoft · Azure-Samples</text>
+</svg>

--- a/apps/ui/public/og/retailer.svg
+++ b/apps/ui/public/og/retailer.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-label="For Retailers — Holiday Peak Hub">
+  <defs>
+    <linearGradient id="bgGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#fffbeb" />
+      <stop offset="100%" stop-color="#fef3c7" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bgGradient)" />
+  <rect x="0" y="0" width="6" height="630" fill="#b45309" />
+  <text x="64" y="120" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="22" font-weight="600" fill="#92400e" letter-spacing="6">FOR RETAILERS</text>
+  <text x="64" y="240" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="84" font-weight="700" fill="#1a1a1a">Built for the people</text>
+  <text x="64" y="340" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="84" font-weight="700" fill="#1a1a1a">who run the business.</text>
+  <text x="64" y="430" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="32" font-weight="400" fill="#6b6b6b">Agents, ROI, case studies, comparators.</text>
+  <text x="64" y="566" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="20" font-weight="500" fill="#b45309">Holiday Peak Hub · Microsoft · Azure-Samples</text>
+</svg>

--- a/apps/ui/tests/unit/seoBuildMetadata.test.ts
+++ b/apps/ui/tests/unit/seoBuildMetadata.test.ts
@@ -1,0 +1,80 @@
+import { buildMetadata, SEO_CONFIG } from '@/lib/seo/buildMetadata';
+
+describe('lib/seo/buildMetadata', () => {
+  it('appends section title suffix when title is provided', () => {
+    const meta = buildMetadata({
+      section: 'retailer',
+      title: 'ROI Calculator',
+      description: 'Estimate the value.',
+      path: '/retailers/roi',
+    });
+    expect(meta.title).toBe(
+      'ROI Calculator — For Retailers — Holiday Peak Hub',
+    );
+    expect(meta.description).toBe('Estimate the value.');
+  });
+
+  it('uses the section title suffix as the full title when no title is provided', () => {
+    const meta = buildMetadata({
+      section: 'home',
+      description: 'Pick your lane.',
+      path: '/',
+    });
+    expect(meta.title).toBe('Holiday Peak Hub');
+  });
+
+  it('produces canonical and og:url that match the path', () => {
+    const meta = buildMetadata({
+      section: 'builder',
+      title: 'Architecture',
+      description: 'See the architecture.',
+      path: '/builders/architecture',
+    });
+    const expected = `${SEO_CONFIG.SITE_URL}/builders/architecture`;
+    expect(meta.alternates?.canonical).toBe(expected);
+    expect(meta.openGraph?.url).toBe(expected);
+  });
+
+  it('selects the per-section OG image by default', () => {
+    const meta = buildMetadata({
+      section: 'deploy',
+      description: 'Spin up your own.',
+      path: '/deploy',
+    });
+    const images = meta.openGraph?.images as Array<{ url: string }> | undefined;
+    expect(images?.[0]?.url).toBe('/og/deploy.svg');
+  });
+
+  it('honours an explicit ogImage override', () => {
+    const meta = buildMetadata({
+      section: 'retailer',
+      title: 'Case study',
+      description: 'A retailer story.',
+      path: '/retailers/case-studies/contoso',
+      ogImage: '/og/cases/contoso.svg',
+    });
+    const images = meta.openGraph?.images as Array<{ url: string }> | undefined;
+    expect(images?.[0]?.url).toBe('/og/cases/contoso.svg');
+    const twitterImages = meta.twitter?.images as string[] | undefined;
+    expect(twitterImages?.[0]).toBe('/og/cases/contoso.svg');
+  });
+
+  it('emits Twitter summary_large_image card', () => {
+    const meta = buildMetadata({
+      section: 'home',
+      description: 'Pick your lane.',
+      path: '/',
+    });
+    expect(meta.twitter?.card).toBe('summary_large_image');
+  });
+
+  it('uses en_US locale and website type for OG', () => {
+    const meta = buildMetadata({
+      section: 'builder',
+      description: 'Architecture.',
+      path: '/builders',
+    });
+    expect(meta.openGraph?.locale).toBe('en_US');
+    expect(meta.openGraph?.type).toBe('website');
+  });
+});

--- a/apps/ui/tests/unit/seoBuildMetadata.test.ts
+++ b/apps/ui/tests/unit/seoBuildMetadata.test.ts
@@ -65,7 +65,8 @@ describe('lib/seo/buildMetadata', () => {
       description: 'Pick your lane.',
       path: '/',
     });
-    expect(meta.twitter?.card).toBe('summary_large_image');
+    const twitter = meta.twitter as { card?: string } | undefined;
+    expect(twitter?.card).toBe('summary_large_image');
   });
 
   it('uses en_US locale and website type for OG', () => {
@@ -74,7 +75,8 @@ describe('lib/seo/buildMetadata', () => {
       description: 'Architecture.',
       path: '/builders',
     });
-    expect(meta.openGraph?.locale).toBe('en_US');
-    expect(meta.openGraph?.type).toBe('website');
+    const og = meta.openGraph as { locale?: string; type?: string } | undefined;
+    expect(og?.locale).toBe('en_US');
+    expect(og?.type).toBe('website');
   });
 });

--- a/apps/ui/tests/unit/sitemap.test.ts
+++ b/apps/ui/tests/unit/sitemap.test.ts
@@ -1,0 +1,67 @@
+import sitemap from '@/app/sitemap';
+import robots from '@/app/robots';
+import { SEO_CONFIG } from '@/lib/seo/buildMetadata';
+
+describe('app/sitemap.ts', () => {
+  const entries = sitemap();
+
+  it('emits the home, three audience landings, plus the docs cross-reference', () => {
+    const urls = entries.map((entry) => entry.url);
+    expect(urls).toEqual(
+      expect.arrayContaining([
+        `${SEO_CONFIG.SITE_URL}/`,
+        `${SEO_CONFIG.SITE_URL}/retailers`,
+        `${SEO_CONFIG.SITE_URL}/builders`,
+        `${SEO_CONFIG.SITE_URL}/deploy`,
+        `${SEO_CONFIG.SITE_URL}/docs/sitemap.xml`,
+      ]),
+    );
+    expect(urls.length).toBe(5);
+  });
+
+  it('home has the highest priority', () => {
+    const home = entries.find(
+      (entry) => entry.url === `${SEO_CONFIG.SITE_URL}/`,
+    );
+    expect(home?.priority).toBe(1.0);
+  });
+
+  it('audience landings sit between home and docs in priority', () => {
+    const retailer = entries.find(
+      (entry) => entry.url === `${SEO_CONFIG.SITE_URL}/retailers`,
+    );
+    const builder = entries.find(
+      (entry) => entry.url === `${SEO_CONFIG.SITE_URL}/builders`,
+    );
+    const docs = entries.find((entry) =>
+      entry.url.endsWith('/docs/sitemap.xml'),
+    );
+    expect(retailer?.priority).toBe(0.9);
+    expect(builder?.priority).toBe(0.9);
+    expect(docs?.priority).toBe(0.5);
+  });
+
+  it('every entry has a lastModified timestamp', () => {
+    entries.forEach((entry) => {
+      expect(entry.lastModified).toBeInstanceOf(Date);
+    });
+  });
+});
+
+describe('app/robots.ts', () => {
+  it('points to the segmented sitemap', () => {
+    const result = robots();
+    expect(result.sitemap).toBe(`${SEO_CONFIG.SITE_URL}/sitemap.xml`);
+  });
+
+  it('disallows /api/ and allows everything else', () => {
+    const result = robots();
+    const rules = Array.isArray(result.rules) ? result.rules : [result.rules];
+    const wildcard = rules.find(
+      (rule) => rule && (rule.userAgent === '*' || (Array.isArray(rule.userAgent) && rule.userAgent.includes('*'))),
+    );
+    expect(wildcard).toBeDefined();
+    expect(wildcard?.allow).toBe('/');
+    expect(wildcard?.disallow).toEqual(['/api/']);
+  });
+});


### PR DESCRIPTION
## Summary

Implements ADR-034 §6 — per-section SEO metadata + segmented sitemap. Every audience landing declares its own title, description, Open Graph / Twitter tags, and canonical URL via a shared helper. Sitemap groups retailer / builder / deploy with priority tiers; mkdocs sitemap is cross-referenced.

## New surface

### `apps/ui/lib/seo/`
- `buildMetadata.ts` — `buildMetadata({ section, title, description, path, ogImage? })` returns a `Metadata` object with title suffix, canonical URL, og:url, per-section OG image, en_US locale, Twitter `summary_large_image` card.
- `index.ts` — barrel.

### `apps/ui/app/sitemap.ts`
Next.js `MetadataRoute.Sitemap`. Five entries:

| URL | Priority | changeFrequency |
|---|---|---|
| `/` | 1.0 | weekly |
| `/retailers` | 0.9 | weekly |
| `/builders` | 0.9 | weekly |
| `/deploy` | 0.8 | monthly |
| `/docs/sitemap.xml` (cross-ref) | 0.5 | monthly |

### `apps/ui/app/robots.ts`
Allows `/`, disallows `/api/`, points to `/sitemap.xml`.

### `apps/ui/public/og/{home,retailer,builder,deploy,docs}.svg`
1200×630 SVG social cards. Per-audience tone:
- **Home** — terracotta accent
- **Retailer** — amber gradient (warm)
- **Builder** — blue gradient + monospace eyebrow (cool / docs feel)
- **Deploy** — slate gradient (neutral / procedural)
- **Docs** — teal accent

## Updated pages

`app/page.tsx`, `app/(retailer)/retailers/page.tsx`, `app/(builder)/builders/page.tsx`, `app/(deploy)/deploy/page.tsx` all consume `buildMetadata`, replacing hand-rolled `Metadata` objects.

## Acceptance criteria

- [x] Every page under `/retailers/*`, `/builders/*`, `/deploy/*` (and `/`) declares its own title and description via Next.js Metadata.
- [x] OG tags tuned per audience (`og:title`, `og:description`, `og:image`, `og:url`):
  - [x] Retailer pages → `/og/retailer.svg` (warm tone).
  - [x] Builder pages → `/og/builder.svg` (cool tone).
  - [x] Deploy pages → `/og/deploy.svg` (neutral / task-focused tone).
- [x] `apps/ui/app/sitemap.ts` emits a segmented sitemap.
- [x] `robots.txt` references the sitemap.
- [x] mkdocs `/docs/sitemap.xml` is linked from the root sitemap (cross-reference, no duplication).
- [ ] Lighthouse SEO ≥ 90 — **deferred to PR #1014 / lighthouse-ci infrastructure**. Static metadata correctness is covered by 13 unit tests in this PR; runtime quality gates are owned by the `ui-axe-core` / `ui-lighthouse` job from #1014.

## Verification

```
yarn lint --quiet  ✓ (0 warnings)
yarn build          ✓  (/sitemap.xml + /robots.txt + 4 audience routes prerender)
yarn test --silent  ✓ (44 suites, 229 tests; +13 from #1013)
```

## ADR alignment

- **ADR-034 §6** — Per-section SEO metadata + segmented sitemap: this is the implementation.
- **ADR-018** — Branch naming: `feature/1013-per-section-seo`.

Closes #1013.
