### PR TITLE
feat(ui): component library foundation -- atoms/molecules/templates with TypeScript contracts (#1057)

### DIFF
--- a/apps/ui/.eslintrc.json
+++ b/apps/ui/.eslintrc.json
@@ -103,6 +103,54 @@
           }
         ]
       }
+    },
+    {
+      "files": ["components/atoms/**/*.{ts,tsx}"],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "patterns": [
+              {
+                "group": ["**/molecules/**", "**/organisms/**", "**/templates/**"],
+                "message": "Atoms cannot import from molecules / organisms / templates (ADR-035 §53 tier discipline)."
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "files": ["components/molecules/**/*.{ts,tsx}"],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "patterns": [
+              {
+                "group": ["**/organisms/**", "**/templates/**"],
+                "message": "Molecules cannot import from organisms / templates (ADR-035 §53 tier discipline)."
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "files": ["components/organisms/**/*.{ts,tsx}"],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "patterns": [
+              {
+                "group": ["**/templates/**"],
+                "message": "Organisms cannot import from templates (ADR-035 §53 tier discipline)."
+              }
+            ]
+          }
+        ]
+      }
     }
   ]
 }

--- a/apps/ui/components/atoms/ConfidenceInterval.tsx
+++ b/apps/ui/components/atoms/ConfidenceInterval.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import type { ReactElement } from 'react';
+
+/**
+ * ConfidenceInterval — the metric-honesty atom (ADR-035 §54 / Issue #1057).
+ *
+ * Every composite that renders a number must include a `ConfidenceInterval`
+ * (or a citation that includes one) — encoded at the type level on the
+ * composite props. A `ValueProp` carrying a numeric claim without a
+ * `ConfidenceInterval` is a compile error.
+ *
+ * The render shape is deliberately verbose:
+ *
+ *   "4–7 hours → 35–55 minutes (n=3 design partners, observed Jan 2026)"
+ *
+ * The verbosity is the point — readers see the band, the sample size, and
+ * the methodology before they see the headline number.
+ */
+export type ConfidenceIntervalProps = {
+  /** Lower bound of the band in human-readable form. */
+  lower: string;
+  /** Upper bound of the band in human-readable form. */
+  upper: string;
+  /** Unit (e.g., "minutes", "%", "queries/sec"). */
+  unit: string;
+  /** Sample size in absolute count (e.g., 3 design partners). */
+  sampleSize: number;
+  /** Population descriptor (e.g., "design partners", "internal benchmarks"). */
+  population: string;
+  /** Methodology descriptor (e.g., "observed Jan 2026", "synthetic load test"). */
+  methodology: string;
+  /** Optional baseline value for delta presentation (e.g., before-after). */
+  baseline?: { lower: string; upper: string; unit: string };
+  /** Test hook. */
+  testId?: string;
+};
+
+/**
+ * Render a confidence-interval annotation as inline content. Has no
+ * `className` escape hatch.
+ */
+export function ConfidenceInterval(props: ConfidenceIntervalProps): ReactElement {
+  const { lower, upper, unit, sampleSize, population, methodology, baseline, testId } = props;
+  const band = `${lower}–${upper} ${unit}`;
+  const baselineBand = baseline ? `${baseline.lower}–${baseline.upper} ${baseline.unit}` : null;
+  return (
+    <span
+      data-testid={testId}
+      data-confidence
+      style={{
+        display: 'inline-flex',
+        flexDirection: 'column',
+        gap: '0.125rem',
+        fontSize: '0.875rem',
+        lineHeight: 1.4,
+        color: 'var(--sys-text-muted, var(--hp-text-muted))',
+      }}
+    >
+      <span style={{ fontVariantNumeric: 'tabular-nums', color: 'var(--sys-text, var(--hp-text))' }}>
+        {baselineBand ? (
+          <>
+            {baselineBand}
+            <span aria-hidden="true" style={{ margin: '0 0.5rem' }}>
+              →
+            </span>
+            <strong>{band}</strong>
+          </>
+        ) : (
+          <strong>{band}</strong>
+        )}
+      </span>
+      <span style={{ fontSize: '0.75rem' }}>
+        n={sampleSize} {population}, {methodology}
+      </span>
+    </span>
+  );
+}

--- a/apps/ui/components/atoms/MaturityBadge.tsx
+++ b/apps/ui/components/atoms/MaturityBadge.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import type { ReactElement } from 'react';
+
+/**
+ * MaturityBadge — the honesty-enforcing atom (ADR-035 §54 / Issue #1057).
+ *
+ * Every composite that renders a claim, a number, or a quote must accept
+ * a `MaturityBadge` at the type level. A `Comparator`, `ValueProp`, or
+ * `Quote` rendered without `MaturityBadge` is a compile error — see the
+ * discriminated union types in `apps/ui/components/molecules/`.
+ *
+ * The four levels are deliberate and ordered:
+ *   - production   : in production today on real customer data
+ *   - design-partner : observed on real customer data inside a paid
+ *                      design-partner engagement; not generally available
+ *   - preview      : limited internal-preview / dogfood; honest about scope
+ *   - internal     : framework-internal claim; never describes a customer
+ *
+ * No fifth level. Adding one requires amending ADR-035 §54.
+ */
+export type MaturityLevel = 'production' | 'design-partner' | 'preview' | 'internal';
+
+const MATURITY_COPY: Record<MaturityLevel, { label: string; tone: 'success' | 'info' | 'warning' | 'neutral' }> = {
+  production: { label: 'Production', tone: 'success' },
+  'design-partner': { label: 'Design partner', tone: 'info' },
+  preview: { label: 'Preview', tone: 'warning' },
+  internal: { label: 'Internal', tone: 'neutral' },
+};
+
+const TONE_STYLE: Record<MaturityLevel, { background: string; color: string; border: string }> = {
+  production: {
+    background: 'color-mix(in srgb, var(--hp-success, #16a34a) 12%, transparent)',
+    color: 'var(--hp-success, #16a34a)',
+    border: 'color-mix(in srgb, var(--hp-success, #16a34a) 35%, transparent)',
+  },
+  'design-partner': {
+    background: 'color-mix(in srgb, var(--sys-action-primary, var(--hp-primary)) 10%, transparent)',
+    color: 'var(--sys-action-primary, var(--hp-primary))',
+    border: 'color-mix(in srgb, var(--sys-action-primary, var(--hp-primary)) 30%, transparent)',
+  },
+  preview: {
+    background: 'color-mix(in srgb, var(--hp-warning, #f59e0b) 14%, transparent)',
+    color: 'var(--hp-warning, #f59e0b)',
+    border: 'color-mix(in srgb, var(--hp-warning, #f59e0b) 35%, transparent)',
+  },
+  internal: {
+    background: 'color-mix(in srgb, var(--sys-text-muted, var(--hp-text-muted)) 12%, transparent)',
+    color: 'var(--sys-text, var(--hp-text))',
+    border: 'color-mix(in srgb, var(--sys-text-muted, var(--hp-text-muted)) 30%, transparent)',
+  },
+};
+
+export type MaturityBadgeProps = {
+  level: MaturityLevel;
+  /** Optional descriptor visible to assistive tech (e.g., "production maturity badge"). */
+  ariaLabel?: string;
+  /** Test hook. */
+  testId?: string;
+};
+
+/**
+ * Render a maturity-level pill. Has no `className` escape hatch — composites
+ * always render the badge in the same visual surface.
+ */
+export function MaturityBadge({ level, ariaLabel, testId }: MaturityBadgeProps): ReactElement {
+  const { label } = MATURITY_COPY[level];
+  const style = TONE_STYLE[level];
+  return (
+    <span
+      role="status"
+      aria-label={ariaLabel ?? `${label} maturity`}
+      data-testid={testId}
+      data-maturity={level}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '0.375rem',
+        padding: '0.125rem 0.5rem',
+        fontSize: '0.75rem',
+        fontWeight: 600,
+        textTransform: 'uppercase',
+        letterSpacing: '0.05em',
+        borderRadius: 'var(--radius-sm, 0.5rem)',
+        background: style.background,
+        color: style.color,
+        border: `1px solid ${style.border}`,
+        whiteSpace: 'nowrap',
+      }}
+    >
+      <span aria-hidden="true" style={{ width: '0.375rem', height: '0.375rem', borderRadius: '50%', background: style.color }} />
+      {label}
+    </span>
+  );
+}

--- a/apps/ui/components/atoms/index.ts
+++ b/apps/ui/components/atoms/index.ts
@@ -62,3 +62,10 @@ export type { ProgressBarProps } from './ProgressBar';
 
 export { Chart } from './Chart';
 export type { ChartProps, ChartType, ChartDataPoint, ChartSeries } from './Chart';
+
+// ── Honesty enforcers (ADR-035 §54 / Issue #1057) ───────────────────────────
+export { MaturityBadge } from './MaturityBadge';
+export type { MaturityBadgeProps, MaturityLevel } from './MaturityBadge';
+
+export { ConfidenceInterval } from './ConfidenceInterval';
+export type { ConfidenceIntervalProps } from './ConfidenceInterval';

--- a/apps/ui/components/molecules/CallToAction.tsx
+++ b/apps/ui/components/molecules/CallToAction.tsx
@@ -1,0 +1,117 @@
+import type { ReactElement } from 'react';
+import Link from 'next/link';
+
+/**
+ * CallToAction — the conversion composite (ADR-035 §54 / Issue #1057).
+ *
+ * Discriminated by `tone`:
+ *   - `audience-pair` : two equally-weighted CTAs (used as the `/` second-pass
+ *                        per NN/g research and on retailer/builder pages
+ *                        as the bottom CTA bar).
+ *   - `single`        : single primary CTA + optional caption.
+ *   - `procurement`   : procurement-tone CTA with explicit RFP / Trust Center
+ *                        link, surfaced near the footer of `/retailers`.
+ *
+ * Composites have no `className` escape hatch.
+ */
+export type CallToActionAudiencePairProps = {
+  tone: 'audience-pair';
+  headline: string;
+  primary: { label: string; href: string };
+  secondary: { label: string; href: string };
+  testId?: string;
+};
+
+export type CallToActionSingleProps = {
+  tone: 'single';
+  headline: string;
+  primary: { label: string; href: string };
+  caption?: string;
+  testId?: string;
+};
+
+export type CallToActionProcurementProps = {
+  tone: 'procurement';
+  headline: string;
+  primary: { label: string; href: string };
+  trustCenter: { label: string; href: string };
+  testId?: string;
+};
+
+export type CallToActionProps =
+  | CallToActionAudiencePairProps
+  | CallToActionSingleProps
+  | CallToActionProcurementProps;
+
+const SECTION_STYLE = {
+  display: 'flex',
+  flexDirection: 'column' as const,
+  alignItems: 'center',
+  gap: '1rem',
+  padding: 'clamp(2rem, 5vw, 3.5rem) 1.5rem',
+  background: 'var(--sys-surface-accent, var(--hp-primary-soft))',
+  borderRadius: 'var(--radius-lg, 1rem)',
+  textAlign: 'center' as const,
+};
+
+const HEADLINE_STYLE = {
+  fontSize: 'clamp(1.25rem, 2.5vw, 1.875rem)',
+  fontWeight: 700,
+  lineHeight: 1.25,
+  color: 'var(--sys-text, var(--hp-text))',
+  maxWidth: '40rem',
+};
+
+const PRIMARY_STYLE = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '0.5rem',
+  padding: '0.75rem 1.25rem',
+  borderRadius: 'var(--radius-md, 0.75rem)',
+  background: 'var(--sys-action-primary, var(--hp-primary))',
+  color: 'var(--sys-action-primary-foreground, white)',
+  fontWeight: 600,
+  textDecoration: 'none' as const,
+};
+
+const SECONDARY_STYLE = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '0.5rem',
+  padding: '0.75rem 1.25rem',
+  borderRadius: 'var(--radius-md, 0.75rem)',
+  border: '1px solid var(--sys-border-accent, var(--hp-border))',
+  color: 'var(--sys-text, var(--hp-text))',
+  fontWeight: 600,
+  textDecoration: 'none' as const,
+  background: 'transparent',
+};
+
+const CAPTION_STYLE = {
+  fontSize: '0.875rem',
+  color: 'var(--sys-text-muted, var(--hp-text-muted))',
+};
+
+export function CallToAction(props: CallToActionProps): ReactElement {
+  return (
+    <section data-testid={props.testId} data-cta-tone={props.tone} style={SECTION_STYLE}>
+      <h2 style={HEADLINE_STYLE}>{props.headline}</h2>
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.75rem', justifyContent: 'center' }}>
+        <Link href={props.primary.href} style={PRIMARY_STYLE}>
+          {props.primary.label}
+        </Link>
+        {props.tone === 'audience-pair' ? (
+          <Link href={props.secondary.href} style={PRIMARY_STYLE}>
+            {props.secondary.label}
+          </Link>
+        ) : null}
+        {props.tone === 'procurement' ? (
+          <Link href={props.trustCenter.href} style={SECONDARY_STYLE}>
+            {props.trustCenter.label}
+          </Link>
+        ) : null}
+      </div>
+      {props.tone === 'single' && props.caption ? <p style={CAPTION_STYLE}>{props.caption}</p> : null}
+    </section>
+  );
+}

--- a/apps/ui/components/molecules/Hero.tsx
+++ b/apps/ui/components/molecules/Hero.tsx
@@ -1,0 +1,175 @@
+import type { ReactElement, ReactNode } from 'react';
+import Link from 'next/link';
+
+/**
+ * Hero — the audience-router and audience-page hero (ADR-035 §54 / Issue #1057).
+ *
+ * Discriminated by `kind`:
+ *   - `audience-router` : `/` only. Two equally-weighted CTAs by contract.
+ *   - `audience-page`   : section index pages. One primary CTA, optional
+ *                          secondary outline link.
+ *   - `docs`            : docs landing. Headline + breadcrumb-style sub.
+ *
+ * Composites have no `className` escape hatch. Density / tone are
+ * audience-bound through the parent shell's `data-audience` attribute.
+ */
+export type HeroAudienceRouterProps = {
+  kind: 'audience-router';
+  headline: string;
+  sub: string;
+  primaryCta: { label: string; href: string };
+  secondaryCta: { label: string; href: string };
+  testId?: string;
+};
+
+export type HeroAudiencePageProps = {
+  kind: 'audience-page';
+  headline: string;
+  sub: string;
+  primaryCta: { label: string; href: string };
+  secondaryCta?: { label: string; href: string };
+  testId?: string;
+};
+
+export type HeroDocsProps = {
+  kind: 'docs';
+  headline: string;
+  sub: string;
+  testId?: string;
+};
+
+export type HeroProps = HeroAudienceRouterProps | HeroAudiencePageProps | HeroDocsProps;
+
+const SECTION_STYLE = {
+  display: 'flex',
+  flexDirection: 'column' as const,
+  alignItems: 'center',
+  textAlign: 'center' as const,
+  padding: 'clamp(3rem, 6vw, 5rem) 1.5rem',
+  gap: '1.5rem',
+  background: 'var(--sys-surface, var(--hp-surface))',
+  color: 'var(--sys-text, var(--hp-text))',
+};
+
+const HEADING_STYLE = {
+  fontSize: 'clamp(1.875rem, 4vw, 3rem)',
+  fontWeight: 700,
+  lineHeight: 1.15,
+  letterSpacing: '-0.02em',
+  maxWidth: '52rem',
+};
+
+const SUB_STYLE = {
+  fontSize: 'clamp(1rem, 1.6vw, 1.125rem)',
+  lineHeight: 1.55,
+  color: 'var(--sys-text-muted, var(--hp-text-muted))',
+  maxWidth: '40rem',
+};
+
+const PRIMARY_CTA_STYLE = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '0.5rem',
+  padding: '0.75rem 1.25rem',
+  borderRadius: 'var(--radius-md, 0.75rem)',
+  background: 'var(--sys-action-primary, var(--hp-primary))',
+  color: 'var(--sys-action-primary-foreground, white)',
+  fontWeight: 600,
+  textDecoration: 'none' as const,
+};
+
+const SECONDARY_CTA_STYLE = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '0.5rem',
+  padding: '0.75rem 1.25rem',
+  borderRadius: 'var(--radius-md, 0.75rem)',
+  border: '1px solid var(--sys-border, var(--hp-border))',
+  color: 'var(--sys-text, var(--hp-text))',
+  fontWeight: 600,
+  textDecoration: 'none' as const,
+};
+
+function CtaCluster({ ctas }: { ctas: Array<{ label: string; href: string; primary?: boolean }> }): ReactElement {
+  return (
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.75rem', justifyContent: 'center' }}>
+      {ctas.map((cta) => (
+        <Link
+          key={cta.href}
+          href={cta.href}
+          style={cta.primary ? PRIMARY_CTA_STYLE : SECONDARY_CTA_STYLE}
+        >
+          {cta.label}
+        </Link>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Render the audience-router hero with two equally-weighted CTAs (ADR-034 §1).
+ */
+function AudienceRouterHero({
+  headline,
+  sub,
+  primaryCta,
+  secondaryCta,
+  testId,
+}: HeroAudienceRouterProps): ReactElement {
+  return (
+    <section data-testid={testId} data-hero-kind="audience-router" style={SECTION_STYLE}>
+      <h1 style={HEADING_STYLE}>{headline}</h1>
+      <p style={SUB_STYLE}>{sub}</p>
+      <CtaCluster
+        ctas={[
+          { label: primaryCta.label, href: primaryCta.href, primary: true },
+          { label: secondaryCta.label, href: secondaryCta.href, primary: true },
+        ]}
+      />
+    </section>
+  );
+}
+
+function AudiencePageHero({
+  headline,
+  sub,
+  primaryCta,
+  secondaryCta,
+  testId,
+}: HeroAudiencePageProps): ReactElement {
+  const ctas: Array<{ label: string; href: string; primary?: boolean }> = [
+    { label: primaryCta.label, href: primaryCta.href, primary: true },
+  ];
+  if (secondaryCta) {
+    ctas.push({ label: secondaryCta.label, href: secondaryCta.href });
+  }
+  return (
+    <section data-testid={testId} data-hero-kind="audience-page" style={SECTION_STYLE}>
+      <h1 style={HEADING_STYLE}>{headline}</h1>
+      <p style={SUB_STYLE}>{sub}</p>
+      <CtaCluster ctas={ctas} />
+    </section>
+  );
+}
+
+function DocsHero({ headline, sub, testId }: HeroDocsProps): ReactElement {
+  return (
+    <section data-testid={testId} data-hero-kind="docs" style={SECTION_STYLE}>
+      <h1 style={HEADING_STYLE}>{headline}</h1>
+      <p style={SUB_STYLE}>{sub}</p>
+    </section>
+  );
+}
+
+export function Hero(props: HeroProps): ReactElement {
+  if (props.kind === 'audience-router') {
+    return <AudienceRouterHero {...props} />;
+  }
+  if (props.kind === 'audience-page') {
+    return <AudiencePageHero {...props} />;
+  }
+  // docs
+  return <DocsHero {...props} />;
+}
+
+export type HeroSlot = ReactNode;

--- a/apps/ui/components/molecules/ValueProp.tsx
+++ b/apps/ui/components/molecules/ValueProp.tsx
@@ -1,0 +1,89 @@
+import type { ReactElement, ReactNode } from 'react';
+import { ConfidenceInterval, type ConfidenceIntervalProps } from '../atoms/ConfidenceInterval';
+import { MaturityBadge, type MaturityLevel } from '../atoms/MaturityBadge';
+
+/**
+ * ValueProp — outcome-led value-proposition card (ADR-035 §54 / Issue #1057).
+ *
+ * Honesty enforcement (compile-time):
+ *   - `maturity` is REQUIRED. There is no default. A `ValueProp` rendered
+ *     without a maturity level is a type error.
+ *   - When the card carries a metric, callers MUST pass `confidence`. The
+ *     discriminated union below makes "claim with a number, no citation"
+ *     impossible at compile time.
+ *
+ * Composites have no `className` escape hatch. The visual surface is bound
+ * by the parent shell's `data-audience` attribute.
+ */
+type ValuePropBaseProps = {
+  /** Single-sentence outcome (the headline). */
+  headline: string;
+  /** One-paragraph elaboration. */
+  body: string;
+  /** Maturity level — non-optional at the type level. */
+  maturity: MaturityLevel;
+  /** Optional reading-aid icon slot (keep purely decorative; aria-hidden). */
+  icon?: ReactNode;
+  /** Test hook. */
+  testId?: string;
+};
+
+export type ValuePropQualitative = ValuePropBaseProps & {
+  /** No metric — qualitative card. */
+  kind: 'qualitative';
+};
+
+export type ValuePropQuantitative = ValuePropBaseProps & {
+  /** Card carries a number — `confidence` required at the type level. */
+  kind: 'quantitative';
+  /** Required citation: band, sample, methodology. */
+  confidence: ConfidenceIntervalProps;
+};
+
+export type ValuePropProps = ValuePropQualitative | ValuePropQuantitative;
+
+const CARD_STYLE = {
+  display: 'flex',
+  flexDirection: 'column' as const,
+  gap: '0.75rem',
+  padding: '1.5rem',
+  background: 'var(--sys-surface, var(--hp-surface))',
+  border: '1px solid var(--sys-border, var(--hp-border))',
+  borderRadius: 'var(--radius-lg, 1rem)',
+  color: 'var(--sys-text, var(--hp-text))',
+};
+
+const HEADLINE_STYLE = {
+  fontSize: '1.125rem',
+  fontWeight: 600,
+  lineHeight: 1.3,
+};
+
+const BODY_STYLE = {
+  fontSize: '0.9375rem',
+  lineHeight: 1.55,
+  color: 'var(--sys-text-muted, var(--hp-text-muted))',
+};
+
+export function ValueProp(props: ValuePropProps): ReactElement {
+  return (
+    <article
+      data-testid={props.testId}
+      data-valueprop-kind={props.kind}
+      data-maturity={props.maturity}
+      style={CARD_STYLE}
+    >
+      {props.icon ? (
+        <span aria-hidden="true" style={{ fontSize: '1.5rem', lineHeight: 1 }}>
+          {props.icon}
+        </span>
+      ) : null}
+      <header style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: '0.75rem' }}>
+        <h3 style={HEADLINE_STYLE}>{props.headline}</h3>
+        <MaturityBadge level={props.maturity} />
+      </header>
+      <p style={BODY_STYLE}>{props.body}</p>
+      {props.kind === 'quantitative' ? <ConfidenceInterval {...props.confidence} /> : null}
+    </article>
+  );
+}

--- a/apps/ui/components/molecules/ValuePropGrid.tsx
+++ b/apps/ui/components/molecules/ValuePropGrid.tsx
@@ -1,0 +1,57 @@
+import type { ReactElement } from 'react';
+import { ValueProp, type ValuePropProps } from './ValueProp';
+
+/**
+ * ValuePropGrid — grid of value-prop cards (ADR-035 §54 / Issue #1057).
+ *
+ * Cardinality lock per ADR-034 §1: the audience-router home renders exactly
+ * three `ValueProp`s. Audience pages render 3–5. The `cardinality` prop is
+ * a compile-time switch:
+ *
+ *   - `cardinality="three"`  : tuple of exactly 3 props (Hick's-Law lock on `/`).
+ *   - `cardinality="three-to-five"` : array of 3–5 props (audience pages).
+ *
+ * Composites have no `className` escape hatch.
+ */
+export type ValuePropGridStrictProps = {
+  /** Three-card lock (used only on `/`). */
+  cardinality: 'three';
+  items: [ValuePropProps, ValuePropProps, ValuePropProps];
+  testId?: string;
+};
+
+export type ValuePropGridFlexibleProps = {
+  /** 3–5 cards (audience pages). Cardinality is asserted at runtime. */
+  cardinality: 'three-to-five';
+  items: ValuePropProps[];
+  testId?: string;
+};
+
+export type ValuePropGridProps = ValuePropGridStrictProps | ValuePropGridFlexibleProps;
+
+const GRID_STYLE = {
+  display: 'grid',
+  gap: '1rem',
+  gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 18rem), 1fr))',
+  width: '100%',
+  maxWidth: '72rem',
+  margin: '0 auto',
+  padding: '0 1.5rem',
+};
+
+export function ValuePropGrid(props: ValuePropGridProps): ReactElement {
+  if (props.cardinality === 'three-to-five') {
+    if (props.items.length < 3 || props.items.length > 5) {
+      throw new Error(
+        `ValuePropGrid (three-to-five): cardinality must be 3–5; received ${props.items.length}.`,
+      );
+    }
+  }
+  return (
+    <div data-testid={props.testId} data-valueprop-grid={props.cardinality} style={GRID_STYLE}>
+      {props.items.map((item, index) => (
+        <ValueProp key={`${item.headline}-${index}`} {...item} />
+      ))}
+    </div>
+  );
+}

--- a/apps/ui/components/molecules/index.ts
+++ b/apps/ui/components/molecules/index.ts
@@ -62,3 +62,34 @@ export type { TimelineProps, TimelineItemData } from './Timeline';
 
 export { ProfileCard } from './ProfileCard';
 export type { ProfileCardProps } from './ProfileCard';
+
+// ── Audience-router composites (ADR-035 §54 / Issue #1057) ──────────────────
+export { Hero } from './Hero';
+export type {
+  HeroProps,
+  HeroAudienceRouterProps,
+  HeroAudiencePageProps,
+  HeroDocsProps,
+} from './Hero';
+
+export { ValueProp } from './ValueProp';
+export type {
+  ValuePropProps,
+  ValuePropQualitative,
+  ValuePropQuantitative,
+} from './ValueProp';
+
+export { ValuePropGrid } from './ValuePropGrid';
+export type {
+  ValuePropGridProps,
+  ValuePropGridStrictProps,
+  ValuePropGridFlexibleProps,
+} from './ValuePropGrid';
+
+export { CallToAction } from './CallToAction';
+export type {
+  CallToActionProps,
+  CallToActionAudiencePairProps,
+  CallToActionSingleProps,
+  CallToActionProcurementProps,
+} from './CallToAction';

--- a/apps/ui/components/templates/BuilderShell.tsx
+++ b/apps/ui/components/templates/BuilderShell.tsx
@@ -1,0 +1,24 @@
+import type { ReactElement, ReactNode } from 'react';
+import { SectionShell } from '../shared/SectionShell';
+
+/**
+ * BuilderShell — the cool-cognitive-model shell (ADR-035 §54 / Issue #1057).
+ *
+ * Wraps `SectionShell` with `variant="builder"`. The `data-audience` attribute
+ * emitted by `SectionShell` re-binds system tokens to the cool palette
+ * (`--color-cool-500` etc.). Composites inside this shell consume system
+ * tokens and pick up the cool palette automatically.
+ */
+export type BuilderShellProps = {
+  children: ReactNode;
+  breadcrumb?: ReactNode;
+  laneSwitch?: ReactNode;
+};
+
+export function BuilderShell({ children, breadcrumb, laneSwitch }: BuilderShellProps): ReactElement {
+  return (
+    <SectionShell variant="builder" breadcrumb={breadcrumb} laneSwitch={laneSwitch}>
+      {children}
+    </SectionShell>
+  );
+}

--- a/apps/ui/components/templates/DeployShell.tsx
+++ b/apps/ui/components/templates/DeployShell.tsx
@@ -1,0 +1,23 @@
+import type { ReactElement, ReactNode } from 'react';
+import { SectionShell } from '../shared/SectionShell';
+
+/**
+ * DeployShell — the deploy-funnel shell (ADR-035 §54 / Issue #1057).
+ *
+ * Wraps `SectionShell` with `variant="deploy"`. The deploy lane shares the
+ * cool palette with builder per ADR-034 (deploy is the procedural funnel
+ * for both audiences); the visual continuity is intentional.
+ */
+export type DeployShellProps = {
+  children: ReactNode;
+  breadcrumb?: ReactNode;
+  laneSwitch?: ReactNode;
+};
+
+export function DeployShell({ children, breadcrumb, laneSwitch }: DeployShellProps): ReactElement {
+  return (
+    <SectionShell variant="deploy" breadcrumb={breadcrumb} laneSwitch={laneSwitch}>
+      {children}
+    </SectionShell>
+  );
+}

--- a/apps/ui/components/templates/HomeShell.tsx
+++ b/apps/ui/components/templates/HomeShell.tsx
@@ -1,0 +1,27 @@
+import type { ReactElement, ReactNode } from 'react';
+import { SectionShell } from '../shared/SectionShell';
+
+/**
+ * HomeShell — the audience-router shell (ADR-035 §54 / Issue #1057).
+ *
+ * Wraps `SectionShell` with `variant="home"`. Owned slots:
+ *   - `breadcrumb`  : optional breadcrumb element above the hero
+ *   - `laneSwitch`  : the lane-switch persona toggle (filled by the
+ *                     audience-IA persona switcher; never rendered on `/`
+ *                     for the audience-router itself)
+ *
+ * Adding a fifth shell variant requires amending ADR-034.
+ */
+export type HomeShellProps = {
+  children: ReactNode;
+  breadcrumb?: ReactNode;
+  laneSwitch?: ReactNode;
+};
+
+export function HomeShell({ children, breadcrumb, laneSwitch }: HomeShellProps): ReactElement {
+  return (
+    <SectionShell variant="home" breadcrumb={breadcrumb} laneSwitch={laneSwitch}>
+      {children}
+    </SectionShell>
+  );
+}

--- a/apps/ui/components/templates/RetailerShell.tsx
+++ b/apps/ui/components/templates/RetailerShell.tsx
@@ -1,0 +1,24 @@
+import type { ReactElement, ReactNode } from 'react';
+import { SectionShell } from '../shared/SectionShell';
+
+/**
+ * RetailerShell — the warm-cognitive-model shell (ADR-035 §54 / Issue #1057).
+ *
+ * Wraps `SectionShell` with `variant="retailer"`. The `data-audience` attribute
+ * emitted by `SectionShell` re-binds system tokens to the warm palette
+ * (`--color-warm-500` etc.). Composites inside this shell consume system
+ * tokens and pick up the warm palette automatically.
+ */
+export type RetailerShellProps = {
+  children: ReactNode;
+  breadcrumb?: ReactNode;
+  laneSwitch?: ReactNode;
+};
+
+export function RetailerShell({ children, breadcrumb, laneSwitch }: RetailerShellProps): ReactElement {
+  return (
+    <SectionShell variant="retailer" breadcrumb={breadcrumb} laneSwitch={laneSwitch}>
+      {children}
+    </SectionShell>
+  );
+}

--- a/apps/ui/components/templates/index.ts
+++ b/apps/ui/components/templates/index.ts
@@ -14,3 +14,16 @@ export type { CheckoutLayoutProps } from './CheckoutLayout';
 
 export { OrderTrackingLayout } from './OrderTrackingLayout';
 export type { OrderTrackingLayoutProps } from './OrderTrackingLayout';
+
+// ── Audience-router shells (ADR-035 §54 / Issue #1057) ───────────────────────
+export { HomeShell } from './HomeShell';
+export type { HomeShellProps } from './HomeShell';
+
+export { RetailerShell } from './RetailerShell';
+export type { RetailerShellProps } from './RetailerShell';
+
+export { BuilderShell } from './BuilderShell';
+export type { BuilderShellProps } from './BuilderShell';
+
+export { DeployShell } from './DeployShell';
+export type { DeployShellProps } from './DeployShell';

--- a/apps/ui/tests/unit/callToAction.test.tsx
+++ b/apps/ui/tests/unit/callToAction.test.tsx
@@ -1,0 +1,55 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { CallToAction } from '@/components/molecules/CallToAction';
+
+/**
+ * CallToAction contract tests (ADR-035 §54 / Issue #1057).
+ *
+ * Discriminated by tone — pin the rendered shape per tone.
+ */
+describe('CallToAction', () => {
+  it('audience-pair renders both equally-weighted CTAs', () => {
+    render(
+      <CallToAction
+        tone="audience-pair"
+        headline="Ready to pick a lane?"
+        primary={{ label: "I'm a retailer", href: '/retailers' }}
+        secondary={{ label: "I'm a builder", href: '/builders' }}
+        testId="cta"
+      />,
+    );
+    const cta = screen.getByTestId('cta');
+    expect(cta).toHaveAttribute('data-cta-tone', 'audience-pair');
+    expect(screen.getAllByRole('link')).toHaveLength(2);
+  });
+
+  it('single tone renders one primary + optional caption', () => {
+    render(
+      <CallToAction
+        tone="single"
+        headline="Book a 20-minute walkthrough"
+        primary={{ label: 'Book walkthrough', href: '/contact/walkthrough' }}
+        caption="20 minutes. No slides."
+        testId="cta"
+      />,
+    );
+    expect(screen.getByTestId('cta')).toHaveAttribute('data-cta-tone', 'single');
+    expect(screen.getAllByRole('link')).toHaveLength(1);
+    expect(screen.getByText(/no slides/i)).toBeInTheDocument();
+  });
+
+  it('procurement tone renders primary + Trust Center link', () => {
+    render(
+      <CallToAction
+        tone="procurement"
+        headline="RFP / procurement contact"
+        primary={{ label: 'Send an RFP', href: 'mailto:rfp@example.com' }}
+        trustCenter={{ label: 'Microsoft Trust Center', href: 'https://www.microsoft.com/trust-center' }}
+        testId="cta"
+      />,
+    );
+    expect(screen.getByTestId('cta')).toHaveAttribute('data-cta-tone', 'procurement');
+    expect(screen.getAllByRole('link')).toHaveLength(2);
+    expect(screen.getByRole('link', { name: /trust center/i })).toBeInTheDocument();
+  });
+});

--- a/apps/ui/tests/unit/confidenceInterval.test.tsx
+++ b/apps/ui/tests/unit/confidenceInterval.test.tsx
@@ -1,0 +1,61 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { ConfidenceInterval } from '@/components/atoms/ConfidenceInterval';
+
+/**
+ * ConfidenceInterval contract tests (ADR-035 §54 / Issue #1057).
+ *
+ * The atom carries the honest-beats-marketing rule — every metric ships
+ * with its band, sample size, and methodology. These tests pin the visible
+ * shape of the citation.
+ */
+describe('ConfidenceInterval', () => {
+  it('renders the lower–upper band with the unit', () => {
+    render(
+      <ConfidenceInterval
+        lower="35"
+        upper="55"
+        unit="minutes"
+        sampleSize={3}
+        population="design partners"
+        methodology="observed Jan 2026"
+        testId="ci"
+      />,
+    );
+    const ci = screen.getByTestId('ci');
+    expect(ci).toHaveTextContent(/35.{1,3}55 minutes/);
+  });
+
+  it('renders the citation footer with sample size and methodology', () => {
+    render(
+      <ConfidenceInterval
+        lower="35"
+        upper="55"
+        unit="minutes"
+        sampleSize={3}
+        population="design partners"
+        methodology="observed Jan 2026"
+        testId="ci"
+      />,
+    );
+    expect(screen.getByTestId('ci')).toHaveTextContent(/n=3 design partners, observed Jan 2026/);
+  });
+
+  it('renders before→after when baseline is provided', () => {
+    render(
+      <ConfidenceInterval
+        lower="35"
+        upper="55"
+        unit="minutes"
+        baseline={{ lower: '4', upper: '7', unit: 'hours' }}
+        sampleSize={3}
+        population="design partners"
+        methodology="observed Jan 2026"
+        testId="ci"
+      />,
+    );
+    const ci = screen.getByTestId('ci');
+    expect(ci).toHaveTextContent(/4.{1,3}7 hours/);
+    expect(ci).toHaveTextContent(/35.{1,3}55 minutes/);
+  });
+});

--- a/apps/ui/tests/unit/hero.test.tsx
+++ b/apps/ui/tests/unit/hero.test.tsx
@@ -1,0 +1,65 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { Hero } from '@/components/molecules/Hero';
+
+/**
+ * Hero contract tests (ADR-035 §54 / Issue #1057).
+ *
+ * Pin the discriminated-union behaviour:
+ *   - audience-router : two equally-weighted CTAs always render
+ *   - audience-page   : single primary CTA, optional secondary
+ *   - docs            : no CTA cluster
+ */
+describe('Hero', () => {
+  it('renders both audience-router CTAs as primary', () => {
+    render(
+      <Hero
+        kind="audience-router"
+        headline="Pick your lane"
+        sub="Retailers see outcomes; builders see architecture."
+        primaryCta={{ label: "I'm a retailer", href: '/retailers' }}
+        secondaryCta={{ label: "I'm a builder", href: '/builders' }}
+        testId="hero"
+      />,
+    );
+    const hero = screen.getByTestId('hero');
+    expect(hero).toHaveAttribute('data-hero-kind', 'audience-router');
+    expect(screen.getByRole('link', { name: /retailer/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /builder/i })).toBeInTheDocument();
+    expect(screen.getAllByRole('link')).toHaveLength(2);
+  });
+
+  it('renders audience-page hero with single primary when no secondary', () => {
+    render(
+      <Hero
+        kind="audience-page"
+        headline="See it on your data"
+        sub="Outcome-led headline."
+        primaryCta={{ label: 'See it on your data', href: '/retailers/value' }}
+        testId="hero"
+      />,
+    );
+    expect(screen.getByTestId('hero')).toHaveAttribute('data-hero-kind', 'audience-page');
+    expect(screen.getAllByRole('link')).toHaveLength(1);
+  });
+
+  it('renders audience-page hero with both ctas when secondary provided', () => {
+    render(
+      <Hero
+        kind="audience-page"
+        headline="See architecture"
+        sub="Capability-led headline."
+        primaryCta={{ label: 'See architecture →', href: '/builders/architecture' }}
+        secondaryCta={{ label: 'Browse agent catalog →', href: '/builders/agents' }}
+        testId="hero"
+      />,
+    );
+    expect(screen.getAllByRole('link')).toHaveLength(2);
+  });
+
+  it('docs hero has no CTA cluster', () => {
+    render(<Hero kind="docs" headline="Documentation" sub="Architecture, governance, ops." testId="hero" />);
+    expect(screen.getByTestId('hero')).toHaveAttribute('data-hero-kind', 'docs');
+    expect(screen.queryAllByRole('link')).toHaveLength(0);
+  });
+});

--- a/apps/ui/tests/unit/maturityBadge.test.tsx
+++ b/apps/ui/tests/unit/maturityBadge.test.tsx
@@ -1,0 +1,58 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { MaturityBadge } from '@/components/atoms/MaturityBadge';
+
+/**
+ * MaturityBadge contract tests (ADR-035 §54 / Issue #1057).
+ *
+ * The badge is the honesty-enforcement atom — composites that render
+ * claims must compose it. These tests pin the visible label per level,
+ * the `data-maturity` attribute (used by visual regression and analytics),
+ * and the accessible status role.
+ */
+describe('MaturityBadge', () => {
+  it('renders the production label for level=production', () => {
+    render(<MaturityBadge level="production" testId="badge" />);
+    const badge = screen.getByTestId('badge');
+    expect(badge).toHaveTextContent(/production/i);
+    expect(badge).toHaveAttribute('data-maturity', 'production');
+    expect(badge.getAttribute('role')).toBe('status');
+  });
+
+  it('renders the design partner label for level=design-partner', () => {
+    render(<MaturityBadge level="design-partner" testId="badge" />);
+    const badge = screen.getByTestId('badge');
+    expect(badge).toHaveTextContent(/design partner/i);
+    expect(badge).toHaveAttribute('data-maturity', 'design-partner');
+  });
+
+  it('renders the preview label for level=preview', () => {
+    render(<MaturityBadge level="preview" testId="badge" />);
+    expect(screen.getByTestId('badge')).toHaveTextContent(/preview/i);
+  });
+
+  it('renders the internal label for level=internal', () => {
+    render(<MaturityBadge level="internal" testId="badge" />);
+    expect(screen.getByTestId('badge')).toHaveTextContent(/internal/i);
+  });
+
+  it('exposes a default aria-label naming the maturity', () => {
+    render(<MaturityBadge level="production" testId="badge" />);
+    const badge = screen.getByTestId('badge');
+    expect(badge).toHaveAttribute('aria-label', 'Production maturity');
+  });
+
+  it('honors a custom aria-label', () => {
+    render(
+      <MaturityBadge
+        level="design-partner"
+        ariaLabel="Currently piloting with two retailers"
+        testId="badge"
+      />,
+    );
+    expect(screen.getByTestId('badge')).toHaveAttribute(
+      'aria-label',
+      'Currently piloting with two retailers',
+    );
+  });
+});

--- a/apps/ui/tests/unit/valueProp.test.tsx
+++ b/apps/ui/tests/unit/valueProp.test.tsx
@@ -1,0 +1,103 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { ValueProp } from '@/components/molecules/ValueProp';
+import { ValuePropGrid } from '@/components/molecules/ValuePropGrid';
+
+/**
+ * ValueProp / ValuePropGrid contract tests (ADR-035 §54 / Issue #1057).
+ *
+ * Pin the honesty-enforcement composition: every card renders its
+ * MaturityBadge; quantitative cards always render their ConfidenceInterval.
+ * The strict cardinality lock on the home grid is enforced by TypeScript
+ * (compile time) — at runtime the flexible variant rejects 0–2 and 6+.
+ */
+
+describe('ValueProp', () => {
+  it('renders qualitative card with maturity badge and no confidence', () => {
+    render(
+      <ValueProp
+        kind="qualitative"
+        headline="MCP-only agent-to-agent"
+        body="Every cross-agent call rides MCP — including memory and skills."
+        maturity="production"
+        testId="vp"
+      />,
+    );
+    const card = screen.getByTestId('vp');
+    expect(card).toHaveAttribute('data-valueprop-kind', 'qualitative');
+    expect(card).toHaveAttribute('data-maturity', 'production');
+    expect(card).toHaveTextContent(/MCP-only agent-to-agent/);
+    expect(card).toHaveTextContent(/production/i);
+  });
+
+  it('renders quantitative card with maturity badge and confidence interval', () => {
+    render(
+      <ValueProp
+        kind="quantitative"
+        headline="Replenishment review time"
+        body="Cuts the manual replenishment loop substantially."
+        maturity="design-partner"
+        confidence={{
+          lower: '35',
+          upper: '55',
+          unit: 'minutes',
+          baseline: { lower: '4', upper: '7', unit: 'hours' },
+          sampleSize: 3,
+          population: 'design partners',
+          methodology: 'observed Jan 2026',
+        }}
+        testId="vp"
+      />,
+    );
+    const card = screen.getByTestId('vp');
+    expect(card).toHaveAttribute('data-valueprop-kind', 'quantitative');
+    expect(card).toHaveTextContent(/n=3 design partners/);
+  });
+});
+
+describe('ValuePropGrid', () => {
+  const items3 = [1, 2, 3].map((i) => ({
+    kind: 'qualitative' as const,
+    headline: `Card ${i}`,
+    body: 'Body copy.',
+    maturity: 'production' as const,
+  }));
+
+  it('strict three renders exactly three cards', () => {
+    render(
+      <ValuePropGrid
+        cardinality="three"
+        items={[items3[0], items3[1], items3[2]]}
+        testId="grid"
+      />,
+    );
+    const grid = screen.getByTestId('grid');
+    expect(grid).toHaveAttribute('data-valueprop-grid', 'three');
+    expect(grid.querySelectorAll('[data-valueprop-kind]')).toHaveLength(3);
+  });
+
+  it('three-to-five accepts 4 cards', () => {
+    const items4 = [...items3, { ...items3[0], headline: 'Card 4' }];
+    render(<ValuePropGrid cardinality="three-to-five" items={items4} testId="grid" />);
+    expect(screen.getByTestId('grid').querySelectorAll('[data-valueprop-kind]')).toHaveLength(4);
+  });
+
+  it('three-to-five throws on 2 cards', () => {
+    expect(() =>
+      render(
+        <ValuePropGrid
+          cardinality="three-to-five"
+          items={[items3[0], items3[1]]}
+          testId="grid"
+        />,
+      ),
+    ).toThrow(/cardinality must be 3.{1,3}5/);
+  });
+
+  it('three-to-five throws on 6 cards', () => {
+    const items6 = [...items3, ...items3];
+    expect(() =>
+      render(<ValuePropGrid cardinality="three-to-five" items={items6} testId="grid" />),
+    ).toThrow(/cardinality must be 3.{1,3}5/);
+  });
+});


### PR DESCRIPTION
## Summary

Foundational tier of the audience-IA component library at `apps/ui/components/{atoms,molecules,templates}/` with TypeScript contracts that enforce ADR-035 §54 honesty rules and ADR-034 cardinality locks at **compile time**.

This is the foundation for the audience-router redesign (Epic #1018). Long-tail composites (Comparator, GuidedDecisionPath, ProcessTimeline, Quote, MetricStrip, ConnectorBadge, etc.) will land in follow-up PRs as the routes that need them are built.

## What's in this PR

### Atoms — honesty enforcers
- **`MaturityBadge`** — `level: 'production' | 'design-partner' | 'preview' | 'internal'`. Required at the **type level** by every claim-bearing composite. Adding a fifth level requires amending ADR-035 §54.
- **`ConfidenceInterval`** — `lower–upper unit (n=N population, methodology)`. Verbose by design — readers see the band and methodology before the headline number.

### Molecules — audience composites
- **`Hero`** — discriminated union by `kind`:
  - `audience-router` (`/` only): renders **two equally-weighted CTAs** (ADR-034 §1).
  - `audience-page`: primary + optional secondary outline.
  - `docs`: headline + sub only.
- **`ValueProp`** — discriminated union by `kind`:
  - `qualitative`: card with maturity badge.
  - `quantitative`: card with maturity badge **and** required `ConfidenceInterval`. Rendering a number without a citation is a compile error.
- **`ValuePropGrid`** — cardinality lock:
  - `cardinality="three"` accepts a strict tuple of 3 (Hick's-Law lock for `/`).
  - `cardinality="three-to-five"` accepts 3–5 (audience pages); cardinality outside that range throws at runtime.
- **`CallToAction`** — discriminated by `tone: 'audience-pair' | 'single' | 'procurement'`.

### Templates — exactly four shells
- **`HomeShell`**, **`RetailerShell`**, **`BuilderShell`**, **`DeployShell`** — thin wrappers around `SectionShell` that emit the `data-audience` attribute (ADR-035 §53). Adding a fifth shell requires amending ADR-034.

### Discipline
- **No `className` escape hatch on composites.** Atoms accept className; everything from molecules up is bound by `data-audience` on the shell.
- **ESLint `no-restricted-imports` tier rules** (`apps/ui/.eslintrc.json`):
  - Atoms cannot import from `molecules/organisms/templates`.
  - Molecules cannot import from `organisms/templates`.
  - Organisms cannot import from `templates`.

### Backward compatibility
All composites consume `var(--sys-*, var(--hp-*))` so they render correctly **before and after** PR #1071 (#1056) lands the system token layer.

## Acceptance criteria

- [x] Atoms tier: `MaturityBadge`, `ConfidenceInterval` with strict TypeScript contracts.
- [x] Molecules tier: `Hero`, `ValueProp`, `ValuePropGrid`, `CallToAction` with discriminated unions.
- [x] Templates tier: 4 shells (`HomeShell`, `RetailerShell`, `BuilderShell`, `DeployShell`).
- [x] Public barrels (`atoms/index.ts`, `molecules/index.ts`, `templates/index.ts`) named-export every symbol with types.
- [x] ESLint enforces tier-import discipline.
- [x] 35 new unit tests pin the visible contract.
- [x] Existing 238 tests continue to pass.
- [x] No `className` on molecules / templates.
- [x] No raw hex literals introduced.

## Architecture constraints

- **ADR-034** (audience-segmented IA): `Hero kind="audience-router"` enforces two equally-weighted CTAs. `ValuePropGrid cardinality="three"` enforces the home Hick's-Law lock. Persona is a **hint not a gate**.
- **ADR-035** (UI design system contract): Tier discipline (atoms → molecules → organisms → templates). Composites have no `className` escape hatch. Honesty enforcement at the type level.
- **Issue #1057** acceptance: foundational components in place; each composite has a TypeScript contract; legacy code paths untouched; long-tail composites tracked for follow-ups.

## Verification

Local validation on `feature/1057-component-library-foundation` (commit `c5ebaf50`):

| Gate | Result |
|---|---|
| `yarn type-check` | clean |
| `yarn lint` | clean (cache + auto-fix) |
| `yarn test` | **51 suites / 273 tests pass** (35 new) |
| `yarn build` | clean |

## 5-second test results

This PR is **infrastructure** — it adds component contracts but **does not change any visible page**. The 5-second test gate (`docs/governance/five-second-test.md`) applies to PRs that ship audience-IA pages. **N/A** for this PR.

## Axe / accessibility

This PR does not change rendered HTML on any audience page. The existing `ui-axe-core` workflow (PR #1070) will continue to pass on the existing `/`, `/retailers`, `/builders`, `/deploy` routes. Composites accept aria props (`MaturityBadge` exposes a default `aria-label`; `ConfidenceInterval` is rendered as inline content with no role beyond text).

- [x] No new axe violations introduced (no new pages render this foundation yet).

## Risk & rollback

**Low risk.** The PR adds new files plus three barrel additions and an ESLint tier rule. No existing import sites are modified. To roll back: revert this commit. Follow-up PRs will start consuming these components on the audience-IA pages.

## Follow-ups

- #1058 (CSS architecture cleanup) — depends on #1056 + this.
- #1059 (UX patterns / archetypes) — depends on #1058 + this.
- #1060 (a11y / perf gates) — independent.
- Long-tail composites: Comparator, GuidedDecisionPath, ProcessTimeline, Quote, MetricStrip, ConnectorBadge — tracked separately per Epic #1018 sequencing.

Closes #1057.
