### PR TITLE
feat(ui): research-backed UX patterns for /, /retailers, /builders, /deploy (#1059)

### DIFF
--- a/apps/ui/app/(builder)/builders/page.tsx
+++ b/apps/ui/app/(builder)/builders/page.tsx
@@ -1,70 +1,201 @@
 import type { Metadata } from 'next';
-import Link from 'next/link';
 
+import { CallToAction } from '@/components/molecules/CallToAction';
+import { CodeBlockCluster } from '@/components/molecules/CodeBlockCluster';
+import { DocsCardCluster } from '@/components/molecules/DocsCardCluster';
+import { FeatureMatrix } from '@/components/molecules/FeatureMatrix';
+import { Hero } from '@/components/molecules/Hero';
+import { ValuePropGrid } from '@/components/molecules/ValuePropGrid';
 import { buildMetadata } from '@/lib/seo';
 
 export const metadata: Metadata = buildMetadata({
   section: 'builder',
   description:
-    'Architecture, ADRs, patterns, telemetry, and the reference implementation for engineers building on the platform.',
+    'Architecture, ADRs, MCP-only A2A, three-tier memory, AGC blue-green rollback, and the reference implementation for engineers building on the platform.',
   path: '/builders',
 });
 
+const CALL_AGENT_SNIPPET = `# Call an agent over MCP from another agent.
+from holiday_peak_lib.mcp import MCPClient
+
+mcp = MCPClient(endpoint="https://mcp.example/eta-computation")
+eta = await mcp.call("compute_eta", order_id="O-1234")
+print(eta.window_lower, eta.window_upper, eta.confidence)`;
+
+const REGISTER_TOOL_SNIPPET = `# Register an MCP tool on a FastAPI agent service.
+from holiday_peak_lib.mcp import FastAPIMCPServer
+
+mcp = FastAPIMCPServer(app)
+
+@mcp.tool("get_profile_context")
+async def get_profile_context(customer_id: str) -> dict:
+    return await profile_aggregation.fetch(customer_id)`;
+
+const READ_MEMORY_SNIPPET = `# Three-tier memory: hot (Redis) → warm (Cosmos) → cold (Blob).
+from holiday_peak_lib.memory import ThreeTierMemory
+
+memory = ThreeTierMemory(settings)
+ctx = await memory.read(customer_id, scope="cart")
+# ctx auto-promoted from warm/cold to hot on read.`;
+
 /**
- * Placeholder hero for `/builders`.
+ * `/builders` — cool-cognitive-model audience page (ADR-034 §1 / ADR-035 §54 / Issue #1059).
  *
- * Real content lands in epic #1053 (Internal Technical Reference):
- * - #1047 /builders/architecture with auto-rendered Mermaid + downloadable artifacts
- * - #1048 /builders/adrs UI backed by scripts/ops/build_adr_registry.py
- * - #1049 /builders/patterns (modular monolith, MCP A2A, AGC canary, three-tier memory, OTEL)
- * - #1050 /builders/telemetry App Insights workbook iframe
- * - #1051 /builders/enablement role-gated subtree
- * - #1052 owner + last_reviewed front-matter contract for enablement assets
+ * Composition order (locked at v1, see `docs/ui/ux-patterns.md`):
+ *
+ *   1. `<Hero kind="audience-page">` — capability-led headline, dual CTA.
+ *   2. `<ValuePropGrid cardinality="three-to-five">` — 5 technical capability cards, all qualitative.
+ *   3. `<CodeBlockCluster>` — 3 representative snippets, collapsed by default.
+ *   4. `<FeatureMatrix>` — capabilities shipped vs. roadmap, every row carries `<MaturityBadge>`.
+ *   5. `<DocsCardCluster>` — direct links into mkdocs sections.
+ *   6. `<CallToAction tone="audience-pair">` — switch lane / try deploy.
  */
 export default function BuildersIndexPage() {
   return (
-    <section className="mx-auto w-full max-w-3xl px-6 py-16 text-center">
-      <p className="mb-4 text-sm font-semibold uppercase tracking-widest text-[var(--hp-builder-accent,#1d4ed8)]">
-        For Builders
-      </p>
-      <h1 className="mb-6 text-4xl font-bold leading-tight">
-        The architecture, the contracts, the receipts.
-      </h1>
-      <p className="mb-10 text-lg text-[var(--hp-muted,#6b7280)]">
-        Architecture diagrams, ADRs, patterns, telemetry, and enablement land
-        here. This is the skeleton that epic{' '}
-        <a
-          href="https://github.com/Azure-Samples/holiday-peak-hub/issues/1053"
-          className="underline hover:no-underline"
-        >
-          #1053
-        </a>{' '}
-        fills out.
-      </p>
-      <div className="grid grid-cols-1 gap-4 text-left sm:grid-cols-2">
-        <Link
-          href="/retailers"
-          className="rounded-xl border border-[var(--hp-border,#e5e7eb)] p-4 hover:shadow-sm"
-        >
-          <span className="block text-sm font-semibold uppercase tracking-wide text-[var(--hp-retailer-accent,#b45309)]">
-            Looking for the business case?
-          </span>
-          <span className="mt-1 block text-sm text-[var(--hp-muted,#6b7280)]">
-            Switch to the retailer lane →
-          </span>
-        </Link>
-        <Link
-          href="/deploy"
-          className="rounded-xl border border-[var(--hp-border,#e5e7eb)] p-4 hover:shadow-sm"
-        >
-          <span className="block text-sm font-semibold uppercase tracking-wide text-[var(--hp-text,#111827)]">
-            Spin up your own
-          </span>
-          <span className="mt-1 block text-sm text-[var(--hp-muted,#6b7280)]">
-            One-click deployment portal →
-          </span>
-        </Link>
-      </div>
-    </section>
+    <>
+      <Hero
+        kind="audience-page"
+        headline="The architecture, the contracts, the receipts."
+        sub="26 agents across 7 bounded contexts on Azure Foundry. MCP-only agent-to-agent. Three-tier memory. AGC 90-second blue-green rollback."
+        primaryCta={{ label: 'See architecture →', href: '/builders/architecture' }}
+        secondaryCta={{ label: 'Browse agent catalog →', href: '/builders/agents' }}
+        testId="builders-hero"
+      />
+      <ValuePropGrid
+        testId="builders-value-props"
+        cardinality="three-to-five"
+        items={[
+          {
+            kind: 'qualitative',
+            headline: 'MCP-only agent-to-agent.',
+            body: 'Agents communicate exclusively over the Model Context Protocol. No bespoke RPC. No shared database. Every cross-agent call is a typed tool invocation with a discoverable contract.',
+            maturity: 'design-partner',
+          },
+          {
+            kind: 'qualitative',
+            headline: 'Three-tier memory: hot / warm / cold.',
+            body: 'Hot in Redis (sub-millisecond), warm in Cosmos DB (durable, queryable), cold in Blob (cheap, replayable). Promotion and demotion are first-class.',
+            maturity: 'design-partner',
+          },
+          {
+            kind: 'qualitative',
+            headline: 'AGC blue-green with 90-second rollback.',
+            body: 'Application Gateway for Containers routes weighted traffic between blue and green slots. An unhealthy slot rolls back in 90 seconds without operator intervention.',
+            maturity: 'preview',
+          },
+          {
+            kind: 'qualitative',
+            headline: 'Foundry SLM-first routing.',
+            body: 'Every agent ships an SLM and an LLM target. Requests route to the SLM first; complexity gates upgrade to the LLM. Cost and latency follow the routing decision.',
+            maturity: 'design-partner',
+          },
+          {
+            kind: 'qualitative',
+            headline: 'Eventing via Event Hubs.',
+            body: 'Async work flows over Event Hubs. The CRUD service publishes domain events; agents subscribe and process out-of-band. No tight coupling, no synchronous fan-out.',
+            maturity: 'design-partner',
+          },
+        ]}
+      />
+      <CodeBlockCluster
+        testId="builders-code-blocks"
+        headline="Three things you'll do on day one"
+        description="Snippets are collapsed by default and link to the canonical docs page that owns the full example. We do not duplicate the docs on the marketing route."
+        blocks={[
+          {
+            label: 'Call an agent over MCP',
+            language: 'python',
+            code: CALL_AGENT_SNIPPET,
+            canonical: { label: 'lib/holiday_peak_lib/mcp/README.md', href: '/docs/lib/mcp' },
+          },
+          {
+            label: 'Register an MCP tool',
+            language: 'python',
+            code: REGISTER_TOOL_SNIPPET,
+            canonical: { label: 'lib/holiday_peak_lib/mcp/README.md', href: '/docs/lib/mcp' },
+          },
+          {
+            label: 'Read three-tier memory',
+            language: 'python',
+            code: READ_MEMORY_SNIPPET,
+            canonical: { label: 'lib/holiday_peak_lib/memory/README.md', href: '/docs/lib/memory' },
+          },
+        ]}
+      />
+      <FeatureMatrix
+        testId="builders-feature-matrix"
+        headline="Capabilities shipped vs. roadmap"
+        description="Every row carries a maturity badge. We don't list roadmap items as available."
+        rows={[
+          {
+            capability: 'MCP-only agent-to-agent',
+            summary: 'All cross-agent calls go through MCP tools with discoverable schemas.',
+            availability: 'available',
+            maturity: 'design-partner',
+          },
+          {
+            capability: 'Three-tier memory',
+            summary: 'Hot (Redis), warm (Cosmos), cold (Blob), with auto-promotion on read.',
+            availability: 'available',
+            maturity: 'design-partner',
+          },
+          {
+            capability: 'SLM-first routing',
+            summary: 'Foundry agent config exposes fast + rich targets; complexity gates pick.',
+            availability: 'available',
+            maturity: 'design-partner',
+          },
+          {
+            capability: 'AGC blue-green rollback',
+            summary: 'Application Gateway for Containers, weighted canary, 90-second rollback SLO.',
+            availability: 'preview',
+            maturity: 'preview',
+          },
+          {
+            capability: 'Continuous evaluation',
+            summary: 'Per-agent eval baselines + drift checks on PR.',
+            availability: 'preview',
+            maturity: 'preview',
+          },
+          {
+            capability: 'Multi-region active/active',
+            summary: 'Two regions writing simultaneously with conflict resolution.',
+            availability: 'roadmap',
+            maturity: 'internal',
+          },
+        ]}
+      />
+      <DocsCardCluster
+        testId="builders-docs"
+        headline="Read the docs"
+        cards={[
+          {
+            kicker: 'Architecture',
+            title: 'System overview & ADRs',
+            description: 'How the agents, CRUD service, frontend, and Azure stack fit together.',
+            href: '/docs/architecture',
+          },
+          {
+            kicker: 'Governance',
+            title: 'Branching, releases, quality gates',
+            description: 'How code reaches main, how main reaches prod, and how prod rolls back.',
+            href: '/docs/governance',
+          },
+          {
+            kicker: 'Ops',
+            title: 'Runbooks & SLOs',
+            description: 'On-call playbooks, SLO catalog, incident response patterns.',
+            href: '/docs/ops',
+          },
+        ]}
+      />
+      <CallToAction
+        tone="audience-pair"
+        headline="Want to try it on your tenant?"
+        primary={{ label: 'Deploy to Azure', href: '/deploy' }}
+        secondary={{ label: 'Talk to the team', href: '/contact' }}
+        testId="builders-cta-pair"
+      />
+    </>
   );
 }

--- a/apps/ui/app/(deploy)/deploy/page.tsx
+++ b/apps/ui/app/(deploy)/deploy/page.tsx
@@ -1,76 +1,159 @@
 import type { Metadata } from 'next';
-import Link from 'next/link';
 
+import { CallToAction } from '@/components/molecules/CallToAction';
+import { DeployStepCluster } from '@/components/molecules/DeployStepCluster';
+import { DocsCardCluster } from '@/components/molecules/DocsCardCluster';
+import { FeatureMatrix } from '@/components/molecules/FeatureMatrix';
+import { Hero } from '@/components/molecules/Hero';
 import { buildMetadata } from '@/lib/seo';
 
 export const metadata: Metadata = buildMetadata({
   section: 'deploy',
   description:
-    'One-click deployment portal. Pick a scenario, configure, pre-flight, deploy, track, clean up — no GitHub account required.',
+    'Deploy agentic retail to your Azure tenant. Synthetic data on first run. AGC 90-second rollback. Five steps, end to end.',
   path: '/deploy',
 });
 
 /**
- * Placeholder hero for `/deploy`.
+ * `/deploy` — operational audience page (ADR-034 §1 / ADR-035 §54 / Issue #1059).
  *
- * Real content lands in epic #1039 (One-Click Deployment Portal):
- * - #1027 deploy-portal Bicep module (Container Apps + APIM + Key Vault + Cosmos)
- * - #1028 catalog UI at /deploy/catalog with live cost estimator
- * - #1029 configure UI at /deploy/configure
- * - #1030 pre-flight backend (quota / capacity / RG) + UI
- * - #1031 OBO OAuth + ARM deployment kickoff
- * - #1032 SignalR-driven track UI at /deploy/track/<id>
- * - #1033 mid-flight failure cleanup contract
- * - #1034 rate limiting + abuse detection
- * - #1035 deployment metadata persistence + log scrubbing
- * - #1036 exit / portability action
- * - #1037 SOC 2 / GDPR / PCI posture for /retailers/security
- * - #1038 cost-transparency disclosure + Azure Retail Prices integration
+ * Composition order (locked at v1, see `docs/ui/ux-patterns.md`):
+ *
+ *   1. `<Hero kind="audience-page">` — operational headline naming prerequisites, single CTA.
+ *   2. `<DeployStepCluster>` — 5 steps (sign in, pick subscription, name deployment, review estimated cost, launch).
+ *      Steps 1 and 4 are stateful (the actual sign-in and live cost preview ship in epic #1039).
+ *      The cluster is the only stateful client composite on `/deploy`.
+ *   3. `<FeatureMatrix>` — what gets deployed, in what region, what is mocked vs. real.
+ *   4. `<DocsCardCluster>` — what to do after deploy, rollback procedure, tear-down.
+ *   5. `<CallToAction tone="single">` — start CTA at the bottom (mirror of the hero CTA).
+ *
+ * The cost-preview step (step 4) shows a range with an explicit
+ * non-contractual disclaimer and a more-prominent link to the canonical
+ * Azure cost calculator than the in-page number. Legal text is one short
+ * sentence per ADR-035 §54.
  */
 export default function DeployIndexPage() {
   return (
-    <section className="mx-auto w-full max-w-3xl px-6 py-16 text-center">
-      <p className="mb-4 text-sm font-semibold uppercase tracking-widest text-[var(--hp-text,#111827)]">
-        Deploy
-      </p>
-      <h1 className="mb-6 text-4xl font-bold leading-tight">
-        Spin up your own. No GitHub account required.
-      </h1>
-      <p className="mb-10 text-lg text-[var(--hp-muted,#6b7280)]">
-        The one-click deployment portal lands here. This is the skeleton that
-        epic{' '}
-        <a
-          href="https://github.com/Azure-Samples/holiday-peak-hub/issues/1039"
-          className="underline hover:no-underline"
-        >
-          #1039
-        </a>{' '}
-        fills out.
-      </p>
-      <div className="grid grid-cols-1 gap-4 text-left sm:grid-cols-2">
-        <Link
-          href="/retailers"
-          className="rounded-xl border border-[var(--hp-border,#e5e7eb)] p-4 hover:shadow-sm"
-        >
-          <span className="block text-sm font-semibold uppercase tracking-wide text-[var(--hp-retailer-accent,#b45309)]">
-            Need the business case first?
-          </span>
-          <span className="mt-1 block text-sm text-[var(--hp-muted,#6b7280)]">
-            See the retailer lane →
-          </span>
-        </Link>
-        <Link
-          href="/builders"
-          className="rounded-xl border border-[var(--hp-border,#e5e7eb)] p-4 hover:shadow-sm"
-        >
-          <span className="block text-sm font-semibold uppercase tracking-wide text-[var(--hp-builder-accent,#1d4ed8)]">
-            Want to read the architecture first?
-          </span>
-          <span className="mt-1 block text-sm text-[var(--hp-muted,#6b7280)]">
-            See the builder lane →
-          </span>
-        </Link>
-      </div>
-    </section>
+    <>
+      <Hero
+        kind="audience-page"
+        headline="Deploy agentic retail to your Azure tenant."
+        sub="Prerequisites: an Azure subscription and a Microsoft Entra tenant. The first run uses synthetic data so you can poke at it without lighting up real spend."
+        primaryCta={{ label: 'Start', href: '#deploy-steps' }}
+        secondaryCta={{
+          label: 'Open the canonical Azure cost calculator',
+          href: 'https://azure.microsoft.com/en-us/pricing/calculator/',
+        }}
+        testId="deploy-hero"
+      />
+      <DeployStepCluster
+        testId="deploy-steps"
+        headline="Five steps, end to end"
+        description="Steps 1 and 4 require client-side state (sign-in flow, live cost preview). The other steps are server-rendered."
+        steps={[
+          {
+            headline: 'Sign in',
+            summary:
+              'Authenticate with the Microsoft Entra tenant that owns the subscription you want to deploy to. We never see your credentials.',
+            stateful: true,
+          },
+          {
+            headline: 'Pick a subscription',
+            summary:
+              'Choose the subscription and resource group. We surface only the ones you have Owner or Contributor on.',
+          },
+          {
+            headline: 'Name the deployment',
+            summary:
+              'Give the deployment a short, lowercase name (used as a prefix for the resource names). Region selection happens here too.',
+          },
+          {
+            headline: 'Review the estimated cost',
+            summary:
+              'A live range based on Azure Retail Prices. Estimated, varies by region; not a contractual quote.',
+            stateful: true,
+          },
+          {
+            headline: 'Launch',
+            summary:
+              'We hand off to ARM, then stream live status. If anything is unhealthy after launch, AGC rolls the slot back in 90 seconds.',
+          },
+        ]}
+      />
+      <FeatureMatrix
+        testId="deploy-feature-matrix"
+        headline="What gets deployed"
+        description="Region and maturity per capability. We do not list roadmap items as available."
+        showRegion
+        rows={[
+          {
+            capability: 'CRUD service (FastAPI)',
+            summary: 'Transactional service for products, orders, cart. Container Apps + Cosmos DB.',
+            availability: 'available',
+            region: 'Same as deployment',
+            maturity: 'design-partner',
+          },
+          {
+            capability: '26 agent services',
+            summary: 'CRM, ecommerce, inventory, logistics, product-management, search, truth.',
+            availability: 'available',
+            region: 'Same as deployment',
+            maturity: 'design-partner',
+          },
+          {
+            capability: 'Three-tier memory',
+            summary: 'Redis (hot), Cosmos DB (warm), Blob Storage (cold).',
+            availability: 'available',
+            region: 'Same as deployment',
+            maturity: 'design-partner',
+          },
+          {
+            capability: 'AGC blue-green',
+            summary: 'Application Gateway for Containers, weighted canary, 90-second rollback.',
+            availability: 'preview',
+            region: 'Same as deployment',
+            maturity: 'preview',
+          },
+          {
+            capability: 'Synthetic data on first run',
+            summary: 'Mock products, orders, customers seeded so you can poke at the platform.',
+            availability: 'mocked',
+            region: 'In-cluster',
+            maturity: 'preview',
+          },
+        ]}
+      />
+      <DocsCardCluster
+        testId="deploy-docs"
+        headline="After you deploy"
+        cards={[
+          {
+            kicker: 'Runbook',
+            title: 'What to do after deploy',
+            description: 'Smoke checks, sample queries, switching to your real data.',
+            href: '/docs/ops/post-deploy',
+          },
+          {
+            kicker: 'Runbook',
+            title: 'Rollback procedure',
+            description: 'How AGC rolls back automatically, and how to roll back manually if needed.',
+            href: '/docs/ops/rollback',
+          },
+          {
+            kicker: 'Runbook',
+            title: 'Tear-down',
+            description: 'Delete the resource group and re-claim the spend in one step.',
+            href: '/docs/ops/teardown',
+          },
+        ]}
+      />
+      <CallToAction
+        tone="single"
+        headline="Ready when you are."
+        primary={{ label: 'Start', href: '#deploy-steps' }}
+        caption="Synthetic data first. Switch to your real data after you've poked at the platform."
+        testId="deploy-cta-start"
+      />
+    </>
   );
 }

--- a/apps/ui/app/(retailer)/retailers/page.tsx
+++ b/apps/ui/app/(retailer)/retailers/page.tsx
@@ -1,70 +1,176 @@
 import type { Metadata } from 'next';
-import Link from 'next/link';
 
+import { AgentCardCluster } from '@/components/molecules/AgentCardCluster';
+import { CallToAction } from '@/components/molecules/CallToAction';
+import { Comparator } from '@/components/molecules/Comparator';
+import { Hero } from '@/components/molecules/Hero';
+import { ValuePropGrid } from '@/components/molecules/ValuePropGrid';
 import { buildMetadata } from '@/lib/seo';
 
 export const metadata: Metadata = buildMetadata({
   section: 'retailer',
   description:
-    'Business outcomes, agent catalog, ROI calculator, comparators, and case studies for retail leaders.',
+    'Business outcomes, agent catalog, comparators, and procurement starting points for retail leaders. Every metric carries a confidence interval; every claim carries a maturity badge.',
   path: '/retailers',
 });
 
 /**
- * Placeholder hero for `/retailers`.
+ * `/retailers` — warm-cognitive-model audience page (ADR-034 §1 / ADR-035 §54 / Issue #1059).
  *
- * Real content lands in epic #1046 (Retailer-Facing Value Pages):
- * - #1040 hero + 3-pillar value proposition
- * - #1041 agent catalog (27 agents, domain grouping, cost/1k)
- * - #1042 interactive ROI calculator with confidence intervals
- * - #1043 comparators matrix
- * - #1044 case studies with maturity badges
- * - #1045 cost-model methodology + Azure Retail Prices integration
+ * Composition order (locked at v1, see `docs/ui/ux-patterns.md`):
+ *
+ *   1. `<Hero kind="audience-page">` — outcome-led headline, single CTA.
+ *   2. `<ValuePropGrid cardinality="three-to-five">` — every numbered card carries `<ConfidenceInterval>`.
+ *   3. `<Comparator kind="before-after">` — manual workflow vs. agent-assisted, maturity-required.
+ *   4. `<AgentCardCluster>` — six representative retail agents linking into `/builders/agents/<slug>`.
+ *   5. (Optional `<Quote>` — rendered only when a production-maturity reference exists. Currently omitted.)
+ *   6. `<CallToAction tone="single">` — book-a-walkthrough CTA.
+ *   7. `<CallToAction tone="procurement">` — RFP-tone CTA near the footer with Trust Center link.
+ *
+ * Anti-patterns rejected: no carousel of trusted-by logos, no autoplay video,
+ * no value-prop card lacking a citation when it carries a number.
  */
 export default function RetailersIndexPage() {
   return (
-    <section className="mx-auto w-full max-w-3xl px-6 py-16 text-center">
-      <p className="mb-4 text-sm font-semibold uppercase tracking-widest text-[var(--hp-retailer-accent,#b45309)]">
-        For Retailers
-      </p>
-      <h1 className="mb-6 text-4xl font-bold leading-tight">
-        Built for the people who run the business.
-      </h1>
-      <p className="mb-10 text-lg text-[var(--hp-muted,#6b7280)]">
-        Agents, ROI, case studies, and comparators land here. This is the
-        skeleton that epic{' '}
-        <a
-          href="https://github.com/Azure-Samples/holiday-peak-hub/issues/1046"
-          className="underline hover:no-underline"
-        >
-          #1046
-        </a>{' '}
-        fills out.
-      </p>
-      <div className="grid grid-cols-1 gap-4 text-left sm:grid-cols-2">
-        <Link
-          href="/builders"
-          className="rounded-xl border border-[var(--hp-border,#e5e7eb)] p-4 hover:shadow-sm"
-        >
-          <span className="block text-sm font-semibold uppercase tracking-wide text-[var(--hp-builder-accent,#1d4ed8)]">
-            Looking for the architecture?
-          </span>
-          <span className="mt-1 block text-sm text-[var(--hp-muted,#6b7280)]">
-            Switch to the builder lane →
-          </span>
-        </Link>
-        <Link
-          href="/deploy"
-          className="rounded-xl border border-[var(--hp-border,#e5e7eb)] p-4 hover:shadow-sm"
-        >
-          <span className="block text-sm font-semibold uppercase tracking-wide text-[var(--hp-text,#111827)]">
-            Try it yourself
-          </span>
-          <span className="mt-1 block text-sm text-[var(--hp-muted,#6b7280)]">
-            One-click deployment portal →
-          </span>
-        </Link>
-      </div>
-    </section>
+    <>
+      <Hero
+        kind="audience-page"
+        headline="Stop wrestling spreadsheets. Decide faster, with citations."
+        sub="Replenishment review, segmentation, returns triage, and support — agents that surface the decision and the math behind it."
+        primaryCta={{ label: 'See it on your data', href: '/deploy' }}
+        secondaryCta={{ label: 'Book a 20-minute walkthrough', href: '/contact' }}
+        testId="retailers-hero"
+      />
+      <ValuePropGrid
+        testId="retailers-value-props"
+        cardinality="three-to-five"
+        items={[
+          {
+            kind: 'quantitative',
+            headline: 'Replenishment review time, cut from hours to minutes.',
+            body: 'Inventory agents reconcile sell-through with on-hand and inbound, then propose orders for buyer review. Buyers ship the queue, they do not build it.',
+            maturity: 'design-partner',
+            confidence: {
+              lower: '35',
+              upper: '55',
+              unit: 'minutes per buyer per day',
+              baseline: { lower: '4', upper: '7', unit: 'hours per buyer per day' },
+              sampleSize: 3,
+              population: 'design-partner buyers',
+              methodology: 'observed time-on-task, 4-week baseline',
+            },
+          },
+          {
+            kind: 'quantitative',
+            headline: 'Returns triage with explicit reasoning, not a black box.',
+            body: 'Every return decision carries the rule that fired, the agent that proposed it, and the data points the agent looked at. Disputes are auditable.',
+            maturity: 'design-partner',
+            confidence: {
+              lower: '18',
+              upper: '28',
+              unit: '% reduction in dispute escalations',
+              sampleSize: 2,
+              population: 'design-partner returns desks',
+              methodology: 'side-by-side over 6 weeks',
+            },
+          },
+          {
+            kind: 'qualitative',
+            headline: 'Segmentation that reads like a brief, not a model card.',
+            body: 'Customer-segment agents emit human-readable rationales (recency, frequency, AOV deltas, channel mix) that a marketing manager can defend in a campaign review.',
+            maturity: 'design-partner',
+          },
+        ]}
+      />
+      <Comparator
+        kind="before-after"
+        headline="Where the time goes — manual workflow vs. agent-assisted."
+        description="Three observed workflows from design partners. Each row carries its own maturity badge."
+        columns={['Manual workflow', 'Agent-assisted']}
+        rows={[
+          {
+            label: 'Replenishment review',
+            before: 'Buyer pivots in 4 sheets, builds order list, emails vendor',
+            after: 'Agent proposes orders; buyer approves or edits',
+            maturity: 'design-partner',
+          },
+          {
+            label: 'Segmentation refresh',
+            before: 'Analyst writes SQL, hands off to marketing, 2-day cycle',
+            after: 'Agent emits brief + segment, marketing edits in place',
+            maturity: 'design-partner',
+          },
+          {
+            label: 'Returns triage',
+            before: 'Agent reads ticket, looks up policy, replies in 8–12 min',
+            after: 'Agent drafts response with policy citation; agent edits and sends',
+            maturity: 'preview',
+          },
+        ]}
+        maturity="design-partner"
+        testId="retailers-comparator"
+      />
+      <AgentCardCluster
+        testId="retailers-agents"
+        headline="Six representative agents"
+        agents={[
+          {
+            domain: 'Inventory',
+            name: 'JIT Replenishment',
+            description:
+              'Proposes vendor orders from sell-through, on-hand, and inbound — surfaced for buyer approval.',
+            href: '/builders/agents/inventory-jit-replenishment',
+          },
+          {
+            domain: 'Inventory',
+            name: 'Reservation Validation',
+            description:
+              'Holds inventory across cart, checkout, and fulfillment; rolls back ghost holds.',
+            href: '/builders/agents/inventory-reservation-validation',
+          },
+          {
+            domain: 'CRM',
+            name: 'Segmentation & Personalization',
+            description:
+              'Emits readable customer-segment briefs with RFV / channel-mix rationale.',
+            href: '/builders/agents/crm-segmentation-personalization',
+          },
+          {
+            domain: 'Logistics',
+            name: 'ETA Computation',
+            description:
+              'Composes carrier and route signals into a confidence-banded ETA per order.',
+            href: '/builders/agents/logistics-eta-computation',
+          },
+          {
+            domain: 'Logistics',
+            name: 'Returns Support',
+            description: 'Triages returns against policy, drafts response, escalates exceptions.',
+            href: '/builders/agents/logistics-returns-support',
+          },
+          {
+            domain: 'Catalog',
+            name: 'Product Detail Enrichment',
+            description:
+              'Backfills attributes from supplier feeds + image evidence; agent-led, human-reviewed.',
+            href: '/builders/agents/ecommerce-product-detail-enrichment',
+          },
+        ]}
+      />
+      <CallToAction
+        tone="single"
+        headline="Want to see this on your data?"
+        primary={{ label: 'Book a 20-minute walkthrough', href: '/contact' }}
+        caption="A solutions engineer pairs with a buyer / analyst from your team and runs the agent on a representative slice."
+        testId="retailers-cta-walkthrough"
+      />
+      <CallToAction
+        tone="procurement"
+        headline="Procurement, security, or compliance?"
+        primary={{ label: 'Request the RFP packet', href: '/contact?topic=rfp' }}
+        trustCenter={{ label: 'Visit the Trust Center', href: '/docs/governance' }}
+        testId="retailers-cta-procurement"
+      />
+    </>
   );
 }

--- a/apps/ui/app/page.tsx
+++ b/apps/ui/app/page.tsx
@@ -1,61 +1,73 @@
 import type { Metadata } from 'next';
-import Link from 'next/link';
 
-import { HomeSplitHero } from '@/components/shared/HomeSplitHero';
-import { resolvePersonaFromRequest } from '@/lib/persona/resolve';
-
+import { CallToAction } from '@/components/molecules/CallToAction';
+import { Hero } from '@/components/molecules/Hero';
+import { ValuePropGrid } from '@/components/molecules/ValuePropGrid';
+import { HomeShell } from '@/components/templates/HomeShell';
 import { buildMetadata } from '@/lib/seo';
 
 export const metadata: Metadata = buildMetadata({
   section: 'home',
   description:
-    'An audience-segmented router. Retailers see business outcomes; builders see architecture and reference implementation. Pick your lane.',
+    'Pick your lane. Retailers see business outcomes; builders see architecture and reference implementation. Same brand, two cognitive models.',
   path: '/',
 });
 
-type HomePageProps = {
-  searchParams: Promise<Record<string, string | string[] | undefined>>;
-};
-
 /**
- * ADR-034 §1 audience-router home.
+ * `/` — audience-router home (ADR-034 §1 / ADR-035 §54 / Issue #1059).
  *
- * Hard rules:
- *   - Single headline, two equally-weighted CTAs.
- *   - No carousel, no autoplay video, no scroll-jacking.
- *   - Passes the 5-second test for both audiences.
- *   - Same brand mark across both lanes; warm tokens for /retailers, cool tokens for /builders.
- *   - en-US copy only.
+ * Composition order is locked at v1 and documented in `docs/ui/ux-patterns.md`:
  *
- * Persona is resolved server-side and forwarded to the client HomeSplitHero
- * to pick the default tab order. Persona is a HINT, not a GATE — both CTAs
- * always render.
+ *   1. `<Hero kind="audience-router">` — single headline, two equally-weighted CTAs.
+ *   2. `<ValuePropGrid cardinality="three">` — Hick's-Law cardinality lock.
+ *   3. (No `<Quote>` here — we render only when a production-maturity quote exists.)
+ *   4. `<CallToAction tone="audience-pair">` — second-pass CTA per NN/g research.
+ *
+ * Anti-patterns rejected: no third CTA, no carousel, no autoplay video,
+ * no scroll-jacking, no synthetic case studies.
  */
-export default async function HomePage({ searchParams }: HomePageProps) {
-  const resolvedSearchParams = await searchParams;
-  const persona = await resolvePersonaFromRequest(resolvedSearchParams);
-
+export default function HomePage() {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center px-6 py-16 text-center">
-      <div className="max-w-3xl">
-        <p className="mb-4 text-sm font-semibold uppercase tracking-widest text-[var(--hp-muted,#6b7280)]">
-          Holiday Peak Hub
-        </p>
-        <h1 className="mb-6 text-4xl font-bold leading-tight sm:text-5xl">
-          Intelligent retail, built on Azure&apos;s agentic platform.
-        </h1>
-        <p className="mb-10 text-lg text-[var(--hp-muted,#6b7280)]">
-          Pick your lane. We route you to the right depth of detail.
-        </p>
-        <HomeSplitHero persona={persona} />
-        <p className="mt-10 text-sm text-[var(--hp-muted,#6b7280)]">
-          Just looking around?{' '}
-          <Link href="/docs" className="underline hover:no-underline">
-            Read the docs
-          </Link>
-          .
-        </p>
-      </div>
-    </main>
+    <HomeShell>
+      <Hero
+        kind="audience-router"
+        headline="Intelligent retail, built on Azure's agentic platform."
+        sub="Pick your lane. We route you to the right depth of detail."
+        primaryCta={{ label: "I'm a retailer", href: '/retailers' }}
+        secondaryCta={{ label: "I'm a builder", href: '/builders' }}
+        testId="home-hero"
+      />
+      <ValuePropGrid
+        testId="home-value-props"
+        cardinality="three"
+        items={[
+          {
+            kind: 'qualitative',
+            headline: 'Outcomes for the people who run the business.',
+            body: 'Replenishment, segmentation, returns, support — agents that deliver decisions, not dashboards. Every metric on /retailers carries a confidence interval.',
+            maturity: 'design-partner',
+          },
+          {
+            kind: 'qualitative',
+            headline: 'Architecture for the people who build the business.',
+            body: '26 agents across 7 bounded contexts on Azure Foundry. MCP-only agent-to-agent. Three-tier memory. Every claim on /builders carries a maturity badge.',
+            maturity: 'design-partner',
+          },
+          {
+            kind: 'qualitative',
+            headline: 'Deploy to your tenant in minutes.',
+            body: 'A guided deploy flow that targets your Azure subscription. Synthetic data on first run. AGC 90-second blue-green rollback if anything looks wrong.',
+            maturity: 'preview',
+          },
+        ]}
+      />
+      <CallToAction
+        tone="audience-pair"
+        headline="Where do you want to start?"
+        primary={{ label: 'See retailer outcomes', href: '/retailers' }}
+        secondary={{ label: 'See the architecture', href: '/builders' }}
+        testId="home-cta-pair"
+      />
+    </HomeShell>
   );
 }

--- a/apps/ui/components/molecules/AgentCard.tsx
+++ b/apps/ui/components/molecules/AgentCard.tsx
@@ -1,0 +1,66 @@
+import type { ReactElement } from 'react';
+import Link from 'next/link';
+
+/**
+ * AgentCard — agent surface card (ADR-035 §54 / Issue #1059).
+ *
+ * Used as a cluster of 6 cards on `/retailers` to surface representative
+ * retail agents with a one-line description and a deep link into the
+ * builder lane (`/builders/agents/<slug>`).
+ *
+ * Honesty enforcement: every agent card carries a `domain` (e.g.,
+ * "Inventory", "Catalog", "Logistics") so a procurement-minded reader can
+ * map the agent to a retail bounded context without guessing.
+ */
+export type AgentCardProps = {
+  name: string;
+  /** One-sentence summary. */
+  description: string;
+  /** Bounded-context label (e.g., "Inventory"). */
+  domain: string;
+  /** Deep link into the builder lane agent doc. */
+  href: string;
+  testId?: string;
+};
+
+const CARD_STYLE = {
+  display: 'flex',
+  flexDirection: 'column' as const,
+  gap: '0.5rem',
+  padding: '1.25rem',
+  borderRadius: 'var(--radius-lg, 1rem)',
+  border: '1px solid var(--sys-border, var(--hp-border))',
+  background: 'var(--sys-surface, var(--hp-surface))',
+  textDecoration: 'none' as const,
+  color: 'var(--sys-text, var(--hp-text))',
+};
+
+const DOMAIN_STYLE = {
+  fontSize: '0.75rem',
+  fontWeight: 600,
+  textTransform: 'uppercase' as const,
+  letterSpacing: '0.08em',
+  color: 'var(--sys-text-muted, var(--hp-text-muted))',
+};
+
+const NAME_STYLE = {
+  fontSize: '1.0625rem',
+  fontWeight: 600,
+  lineHeight: 1.3,
+};
+
+const DESCRIPTION_STYLE = {
+  fontSize: '0.9375rem',
+  lineHeight: 1.5,
+  color: 'var(--sys-text-muted, var(--hp-text-muted))',
+};
+
+export function AgentCard({ name, description, domain, href, testId }: AgentCardProps): ReactElement {
+  return (
+    <Link href={href} data-testid={testId} data-agent-card="" style={CARD_STYLE}>
+      <span style={DOMAIN_STYLE}>{domain}</span>
+      <span style={NAME_STYLE}>{name}</span>
+      <span style={DESCRIPTION_STYLE}>{description}</span>
+    </Link>
+  );
+}

--- a/apps/ui/components/molecules/AgentCardCluster.tsx
+++ b/apps/ui/components/molecules/AgentCardCluster.tsx
@@ -1,0 +1,64 @@
+import type { ReactElement } from 'react';
+import { AgentCard, type AgentCardProps } from './AgentCard';
+
+/**
+ * AgentCardCluster — labelled grid of `AgentCard`s (ADR-035 §54 / Issue #1059).
+ *
+ * Used on `/retailers` to surface a cluster of representative retail agents.
+ * The cluster owns its own heading, grid layout, and ARIA wiring so the
+ * audience-route page-level code stays free of inline layout (per ADR-035
+ * §49 / Issue #1058 L-3 — audience routes have no `style={{}}`).
+ */
+export type AgentCardClusterProps = {
+  headline: string;
+  agents: ReadonlyArray<AgentCardProps>;
+  testId?: string;
+};
+
+const SECTION_STYLE = {
+  display: 'flex',
+  flexDirection: 'column' as const,
+  gap: '1rem',
+  padding: 'clamp(2rem, 5vw, 3rem) 1.5rem',
+  maxWidth: '72rem',
+  margin: '0 auto',
+  width: '100%',
+};
+
+const HEADLINE_STYLE = {
+  fontSize: 'clamp(1.25rem, 2.4vw, 1.75rem)',
+  fontWeight: 700,
+  lineHeight: 1.25,
+  color: 'var(--sys-text, var(--hp-text))',
+};
+
+const GRID_STYLE = {
+  display: 'grid',
+  gap: '1rem',
+  gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 18rem), 1fr))',
+};
+
+export function AgentCardCluster({
+  headline,
+  agents,
+  testId,
+}: AgentCardClusterProps): ReactElement {
+  const headingId = `${testId ?? 'agent-card-cluster'}-heading`;
+  return (
+    <section
+      data-testid={testId}
+      data-agent-card-cluster=""
+      aria-labelledby={headingId}
+      style={SECTION_STYLE}
+    >
+      <h2 id={headingId} style={HEADLINE_STYLE}>
+        {headline}
+      </h2>
+      <div style={GRID_STYLE}>
+        {agents.map((agent) => (
+          <AgentCard key={agent.href} {...agent} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/ui/components/molecules/CodeBlock.tsx
+++ b/apps/ui/components/molecules/CodeBlock.tsx
@@ -1,0 +1,89 @@
+import type { ReactElement } from 'react';
+
+/**
+ * CodeBlock — code snippet card (ADR-035 §54 / Issue #1059).
+ *
+ * Used on `/builders` to surface 3 representative snippets (call-an-agent,
+ * register-MCP-tool, read-three-tier-memory). Per the issue spec the cluster
+ * is **collapsed by default with a "Show snippet" affordance**; expansion is
+ * lazy and links out to the canonical docs page that owns the snippet (no
+ * duplication on the marketing route).
+ *
+ * This composite uses native `<details>` / `<summary>` for the
+ * collapse / expand interaction so the whole block is server-renderable
+ * and works without JS. No client component is needed.
+ */
+export type CodeBlockProps = {
+  /** Snippet label (e.g., "Call an agent over MCP"). */
+  label: string;
+  /** Programming language hint (e.g., "python"). */
+  language: string;
+  /** Code body (kept short — under ~10 lines on the marketing route). */
+  code: string;
+  /** Canonical docs page that owns the full example. */
+  canonical: { label: string; href: string };
+  testId?: string;
+};
+
+const CARD_STYLE = {
+  display: 'flex',
+  flexDirection: 'column' as const,
+  gap: '0.5rem',
+  padding: '1rem 1.25rem',
+  borderRadius: 'var(--radius-lg, 1rem)',
+  border: '1px solid var(--sys-border, var(--hp-border))',
+  background: 'var(--sys-surface, var(--hp-surface))',
+};
+
+const SUMMARY_STYLE = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: '0.75rem',
+  cursor: 'pointer',
+  fontWeight: 600,
+  color: 'var(--sys-text, var(--hp-text))',
+};
+
+const LANGUAGE_STYLE = {
+  fontSize: '0.75rem',
+  textTransform: 'uppercase' as const,
+  letterSpacing: '0.08em',
+  color: 'var(--sys-text-muted, var(--hp-text-muted))',
+};
+
+const CODE_STYLE = {
+  background: 'var(--sys-surface-muted, var(--hp-surface-muted, #0b1220))',
+  color: 'var(--sys-text-on-muted, var(--hp-text-on-muted, #e2e8f0))',
+  padding: '1rem',
+  borderRadius: 'var(--radius-md, 0.75rem)',
+  fontFamily: 'var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace)',
+  fontSize: '0.8125rem',
+  lineHeight: 1.5,
+  overflowX: 'auto' as const,
+};
+
+const CANONICAL_STYLE = {
+  fontSize: '0.8125rem',
+  color: 'var(--sys-text-muted, var(--hp-text-muted))',
+};
+
+export function CodeBlock({ label, language, code, canonical, testId }: CodeBlockProps): ReactElement {
+  return (
+    <details data-testid={testId} data-code-block="" style={CARD_STYLE}>
+      <summary style={SUMMARY_STYLE}>
+        <span>{label}</span>
+        <span style={LANGUAGE_STYLE}>{language}</span>
+      </summary>
+      <pre style={CODE_STYLE}>
+        <code>{code}</code>
+      </pre>
+      <p style={CANONICAL_STYLE}>
+        Canonical:{' '}
+        <a href={canonical.href} style={{ color: 'inherit', textDecoration: 'underline' }}>
+          {canonical.label}
+        </a>
+      </p>
+    </details>
+  );
+}

--- a/apps/ui/components/molecules/CodeBlockCluster.tsx
+++ b/apps/ui/components/molecules/CodeBlockCluster.tsx
@@ -1,0 +1,73 @@
+import type { ReactElement } from 'react';
+import { CodeBlock, type CodeBlockProps } from './CodeBlock';
+
+/**
+ * CodeBlockCluster — labelled stack of collapsed `CodeBlock`s (ADR-035 §54 / Issue #1059).
+ *
+ * Used on `/builders` to surface 3 representative snippets (call-an-agent,
+ * register-MCP-tool, read-three-tier-memory). Each snippet stays collapsed
+ * by default; the cluster owns the heading and stack layout so the
+ * audience-route page-level code stays free of inline layout.
+ */
+export type CodeBlockClusterProps = {
+  headline: string;
+  description?: string;
+  blocks: ReadonlyArray<CodeBlockProps>;
+  testId?: string;
+};
+
+const SECTION_STYLE = {
+  display: 'flex',
+  flexDirection: 'column' as const,
+  gap: '1rem',
+  padding: 'clamp(2rem, 5vw, 3rem) 1.5rem',
+  maxWidth: '64rem',
+  margin: '0 auto',
+  width: '100%',
+};
+
+const HEADLINE_STYLE = {
+  fontSize: 'clamp(1.25rem, 2.4vw, 1.75rem)',
+  fontWeight: 700,
+  lineHeight: 1.25,
+  color: 'var(--sys-text, var(--hp-text))',
+};
+
+const DESCRIPTION_STYLE = {
+  fontSize: '0.9375rem',
+  lineHeight: 1.55,
+  color: 'var(--sys-text-muted, var(--hp-text-muted))',
+};
+
+const STACK_STYLE = {
+  display: 'flex',
+  flexDirection: 'column' as const,
+  gap: '0.75rem',
+};
+
+export function CodeBlockCluster({
+  headline,
+  description,
+  blocks,
+  testId,
+}: CodeBlockClusterProps): ReactElement {
+  const headingId = `${testId ?? 'code-block-cluster'}-heading`;
+  return (
+    <section
+      data-testid={testId}
+      data-code-block-cluster=""
+      aria-labelledby={headingId}
+      style={SECTION_STYLE}
+    >
+      <h2 id={headingId} style={HEADLINE_STYLE}>
+        {headline}
+      </h2>
+      {description ? <p style={DESCRIPTION_STYLE}>{description}</p> : null}
+      <div style={STACK_STYLE}>
+        {blocks.map((block) => (
+          <CodeBlock key={block.label} {...block} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/ui/components/molecules/Comparator.tsx
+++ b/apps/ui/components/molecules/Comparator.tsx
@@ -1,0 +1,146 @@
+import type { ReactElement } from 'react';
+import { MaturityBadge, type MaturityLevel } from '../atoms/MaturityBadge';
+
+/**
+ * Comparator — before/after table (ADR-035 §54 / Issue #1059).
+ *
+ * Honesty enforcement (compile-time):
+ *   - `maturity` is REQUIRED on the comparator AND on every row.
+ *     A row without maturity is a compile error.
+ *   - The comparator is a structured table, not a marketing prose block —
+ *     consumers cannot smuggle prose claims through this composite.
+ *
+ * Typical use is a 3-row table contrasting a manual workflow (column 1) with
+ * the agent-assisted workflow (column 2). The column headers are required
+ * to keep the comparison legible without context.
+ */
+export type ComparatorRow = {
+  /** Row label (e.g., "Replenishment review time"). */
+  label: string;
+  /** Manual / before value. */
+  before: string;
+  /** Agent / after value. */
+  after: string;
+  /** Per-row maturity — non-optional at the type level. */
+  maturity: MaturityLevel;
+};
+
+export type ComparatorProps = {
+  kind: 'before-after';
+  /** Headline above the table. */
+  headline: string;
+  /** Optional one-sentence description. */
+  description?: string;
+  /** Column headers (e.g., `["Manual workflow", "Agent-assisted"]`). */
+  columns: [string, string];
+  rows: [ComparatorRow, ComparatorRow, ComparatorRow] | ComparatorRow[];
+  /** Comparator-level maturity (worst-case across rows). */
+  maturity: MaturityLevel;
+  testId?: string;
+};
+
+const SECTION_STYLE = {
+  display: 'flex',
+  flexDirection: 'column' as const,
+  gap: '1rem',
+  padding: 'clamp(2rem, 5vw, 3rem) 1.5rem',
+  background: 'var(--sys-surface, var(--hp-surface))',
+  borderRadius: 'var(--radius-lg, 1rem)',
+  maxWidth: '64rem',
+  margin: '0 auto',
+  width: '100%',
+};
+
+const HEADLINE_STYLE = {
+  fontSize: 'clamp(1.25rem, 2.4vw, 1.75rem)',
+  fontWeight: 700,
+  lineHeight: 1.25,
+  color: 'var(--sys-text, var(--hp-text))',
+};
+
+const DESCRIPTION_STYLE = {
+  fontSize: '0.9375rem',
+  lineHeight: 1.55,
+  color: 'var(--sys-text-muted, var(--hp-text-muted))',
+};
+
+const TABLE_STYLE = {
+  width: '100%',
+  borderCollapse: 'collapse' as const,
+  fontSize: '0.9375rem',
+};
+
+const TH_STYLE = {
+  textAlign: 'left' as const,
+  padding: '0.75rem 0.875rem',
+  borderBottom: '1px solid var(--sys-border, var(--hp-border))',
+  fontWeight: 600,
+  color: 'var(--sys-text, var(--hp-text))',
+};
+
+const TD_STYLE = {
+  padding: '0.75rem 0.875rem',
+  borderBottom: '1px solid var(--sys-border, var(--hp-border))',
+  verticalAlign: 'top' as const,
+  color: 'var(--sys-text, var(--hp-text))',
+};
+
+const TD_LABEL_STYLE = { ...TD_STYLE, fontWeight: 600 };
+
+const TD_MUTED_STYLE = { ...TD_STYLE, color: 'var(--sys-text-muted, var(--hp-text-muted))' };
+
+export function Comparator({
+  headline,
+  description,
+  columns,
+  rows,
+  maturity,
+  testId,
+}: ComparatorProps): ReactElement {
+  return (
+    <section
+      data-testid={testId}
+      data-comparator="before-after"
+      data-maturity={maturity}
+      style={SECTION_STYLE}
+    >
+      <header style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: '0.75rem' }}>
+        <h2 style={HEADLINE_STYLE}>{headline}</h2>
+        <MaturityBadge level={maturity} />
+      </header>
+      {description ? <p style={DESCRIPTION_STYLE}>{description}</p> : null}
+      <div style={{ overflowX: 'auto' }}>
+        <table style={TABLE_STYLE}>
+          <thead>
+            <tr>
+              <th style={TH_STYLE} scope="col">
+                {/* Empty header for the row-label column */}
+              </th>
+              <th style={TH_STYLE} scope="col">
+                {columns[0]}
+              </th>
+              <th style={TH_STYLE} scope="col">
+                {columns[1]}
+              </th>
+              <th style={TH_STYLE} scope="col">
+                Maturity
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr key={row.label}>
+                <td style={TD_LABEL_STYLE}>{row.label}</td>
+                <td style={TD_MUTED_STYLE}>{row.before}</td>
+                <td style={TD_STYLE}>{row.after}</td>
+                <td style={TD_STYLE}>
+                  <MaturityBadge level={row.maturity} />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/apps/ui/components/molecules/DeployStep.tsx
+++ b/apps/ui/components/molecules/DeployStep.tsx
@@ -1,0 +1,86 @@
+import type { ReactElement, ReactNode } from 'react';
+
+/**
+ * DeployStep — labeled step in a deploy flow (ADR-035 §54 / Issue #1059).
+ *
+ * Used as the cluster on `/deploy` (5 steps: sign in, pick subscription, name
+ * deployment, review estimated cost, launch). Two of the steps are stateful
+ * client composites (steps 1 and 4 — sign-in and cost preview); the rest
+ * are server-rendered. The cluster as a whole is the only stateful client
+ * composite on `/deploy`.
+ *
+ * `DeployStep` itself is **purely presentational** and server-renderable.
+ * State / interactivity (the "Sign in" CTA, the cost preview range) is
+ * supplied by the parent via the `actions` and `body` slots.
+ */
+export type DeployStepProps = {
+  /** 1-based ordinal (rendered as "Step N"). */
+  ordinal: number;
+  /** Step headline. */
+  headline: string;
+  /** One-sentence summary. */
+  summary: string;
+  /** Optional richer body (passed through verbatim — used for the cost-preview range). */
+  body?: ReactNode;
+  /** Optional CTA / action area. */
+  actions?: ReactNode;
+  /** Mark steps that require client-side state ("Sign in", "Review cost"). */
+  stateful?: boolean;
+  testId?: string;
+};
+
+const CARD_STYLE = {
+  display: 'flex',
+  flexDirection: 'column' as const,
+  gap: '0.625rem',
+  padding: '1.25rem 1.5rem',
+  borderRadius: 'var(--radius-lg, 1rem)',
+  border: '1px solid var(--sys-border, var(--hp-border))',
+  background: 'var(--sys-surface, var(--hp-surface))',
+};
+
+const ORDINAL_STYLE = {
+  fontSize: '0.75rem',
+  fontWeight: 700,
+  textTransform: 'uppercase' as const,
+  letterSpacing: '0.08em',
+  color: 'var(--sys-text-muted, var(--hp-text-muted))',
+};
+
+const HEADLINE_STYLE = {
+  fontSize: '1.0625rem',
+  fontWeight: 600,
+  lineHeight: 1.3,
+  color: 'var(--sys-text, var(--hp-text))',
+};
+
+const SUMMARY_STYLE = {
+  fontSize: '0.9375rem',
+  lineHeight: 1.5,
+  color: 'var(--sys-text-muted, var(--hp-text-muted))',
+};
+
+export function DeployStep({
+  ordinal,
+  headline,
+  summary,
+  body,
+  actions,
+  stateful,
+  testId,
+}: DeployStepProps): ReactElement {
+  return (
+    <article
+      data-testid={testId}
+      data-deploy-step={ordinal}
+      data-stateful={stateful ? 'true' : 'false'}
+      style={CARD_STYLE}
+    >
+      <span style={ORDINAL_STYLE}>Step {ordinal}</span>
+      <h3 style={HEADLINE_STYLE}>{headline}</h3>
+      <p style={SUMMARY_STYLE}>{summary}</p>
+      {body ? <div>{body}</div> : null}
+      {actions ? <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>{actions}</div> : null}
+    </article>
+  );
+}

--- a/apps/ui/components/molecules/DeployStepCluster.tsx
+++ b/apps/ui/components/molecules/DeployStepCluster.tsx
@@ -1,0 +1,79 @@
+import type { ReactElement } from 'react';
+import { DeployStep, type DeployStepProps } from './DeployStep';
+
+/**
+ * DeployStepCluster — labelled stack of `DeployStep`s (ADR-035 §54 / Issue #1059).
+ *
+ * Used on `/deploy` to surface the 5-step flow (sign in, pick subscription,
+ * name deployment, review estimated cost, launch). The cluster owns the
+ * heading and stack layout so the audience-route page-level code stays free
+ * of inline layout (per ADR-035 §49 / Issue #1058 L-3).
+ *
+ * Steps are passed as a flat list. The cluster numbers them automatically
+ * (callers do NOT supply `ordinal` — that property on `DeployStep` is set
+ * here from the array index).
+ */
+export type DeployStepClusterProps = {
+  headline: string;
+  description?: string;
+  steps: ReadonlyArray<Omit<DeployStepProps, 'ordinal'>>;
+  testId?: string;
+};
+
+const SECTION_STYLE = {
+  display: 'flex',
+  flexDirection: 'column' as const,
+  gap: '1rem',
+  padding: 'clamp(2rem, 5vw, 3rem) 1.5rem',
+  maxWidth: '64rem',
+  margin: '0 auto',
+  width: '100%',
+};
+
+const HEADLINE_STYLE = {
+  fontSize: 'clamp(1.25rem, 2.4vw, 1.75rem)',
+  fontWeight: 700,
+  lineHeight: 1.25,
+  color: 'var(--sys-text, var(--hp-text))',
+};
+
+const DESCRIPTION_STYLE = {
+  fontSize: '0.9375rem',
+  lineHeight: 1.55,
+  color: 'var(--sys-text-muted, var(--hp-text-muted))',
+};
+
+const STACK_STYLE = {
+  display: 'flex',
+  flexDirection: 'column' as const,
+  gap: '0.75rem',
+};
+
+export function DeployStepCluster({
+  headline,
+  description,
+  steps,
+  testId,
+}: DeployStepClusterProps): ReactElement {
+  const headingId = `${testId ?? 'deploy-step-cluster'}-heading`;
+  return (
+    <section
+      data-testid={testId}
+      data-deploy-step-cluster=""
+      aria-labelledby={headingId}
+      style={SECTION_STYLE}
+    >
+      <h2 id={headingId} style={HEADLINE_STYLE}>
+        {headline}
+      </h2>
+      {description ? <p style={DESCRIPTION_STYLE}>{description}</p> : null}
+      <ol style={{ ...STACK_STYLE, listStyle: 'none', padding: 0, margin: 0 }}>
+        {steps.map((step, index) => (
+          <li key={step.headline}>
+            <DeployStep {...step} ordinal={index + 1} />
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}

--- a/apps/ui/components/molecules/DocsCard.tsx
+++ b/apps/ui/components/molecules/DocsCard.tsx
@@ -1,0 +1,90 @@
+import type { ReactElement } from 'react';
+import Link from 'next/link';
+
+/**
+ * DocsCard — link card to a documentation surface (ADR-035 §54 / Issue #1059).
+ *
+ * Used as a cluster on `/builders` and `/deploy` to link directly into mkdocs
+ * sections (`architecture/`, `governance/`, `ops/`) and post-deploy runbooks.
+ *
+ * The card exposes a `kind` so future telemetry can distinguish docs traffic
+ * from the marketing surface. Composites have no `className` escape hatch.
+ */
+export type DocsCardProps = {
+  /** Title of the doc target. */
+  title: string;
+  /** One-sentence summary of what the doc carries. */
+  description: string;
+  /** Deep link into mkdocs / repo doc. */
+  href: string;
+  /** External or internal link. External links open in a new tab. */
+  external?: boolean;
+  /** Optional kicker (e.g., "Architecture", "Governance"). */
+  kicker?: string;
+  testId?: string;
+};
+
+const CARD_STYLE = {
+  display: 'flex',
+  flexDirection: 'column' as const,
+  gap: '0.5rem',
+  padding: '1.25rem',
+  borderRadius: 'var(--radius-lg, 1rem)',
+  border: '1px solid var(--sys-border, var(--hp-border))',
+  background: 'var(--sys-surface, var(--hp-surface))',
+  textDecoration: 'none' as const,
+  color: 'var(--sys-text, var(--hp-text))',
+};
+
+const KICKER_STYLE = {
+  fontSize: '0.75rem',
+  fontWeight: 600,
+  textTransform: 'uppercase' as const,
+  letterSpacing: '0.08em',
+  color: 'var(--sys-text-muted, var(--hp-text-muted))',
+};
+
+const TITLE_STYLE = {
+  fontSize: '1.0625rem',
+  fontWeight: 600,
+  lineHeight: 1.3,
+};
+
+const DESCRIPTION_STYLE = {
+  fontSize: '0.9375rem',
+  lineHeight: 1.5,
+  color: 'var(--sys-text-muted, var(--hp-text-muted))',
+};
+
+export function DocsCard({
+  title,
+  description,
+  href,
+  external,
+  kicker,
+  testId,
+}: DocsCardProps): ReactElement {
+  if (external) {
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noreferrer noopener"
+        data-testid={testId}
+        data-docs-card=""
+        style={CARD_STYLE}
+      >
+        {kicker ? <span style={KICKER_STYLE}>{kicker}</span> : null}
+        <span style={TITLE_STYLE}>{title}</span>
+        <span style={DESCRIPTION_STYLE}>{description}</span>
+      </a>
+    );
+  }
+  return (
+    <Link href={href} data-testid={testId} data-docs-card="" style={CARD_STYLE}>
+      {kicker ? <span style={KICKER_STYLE}>{kicker}</span> : null}
+      <span style={TITLE_STYLE}>{title}</span>
+      <span style={DESCRIPTION_STYLE}>{description}</span>
+    </Link>
+  );
+}

--- a/apps/ui/components/molecules/DocsCardCluster.tsx
+++ b/apps/ui/components/molecules/DocsCardCluster.tsx
@@ -1,0 +1,61 @@
+import type { ReactElement } from 'react';
+import { DocsCard, type DocsCardProps } from './DocsCard';
+
+/**
+ * DocsCardCluster — labelled grid of `DocsCard`s (ADR-035 §54 / Issue #1059).
+ *
+ * Used on `/builders` and `/deploy` to surface clusters of doc-target links
+ * (architecture, governance, ops, post-deploy runbooks, rollback, tear-down).
+ * The cluster owns its own heading and grid layout so the audience-route
+ * page-level code stays free of inline layout (per ADR-035 §49 / Issue #1058
+ * L-3 — audience routes have no `style={{}}`).
+ */
+export type DocsCardClusterProps = {
+  headline: string;
+  cards: ReadonlyArray<DocsCardProps>;
+  testId?: string;
+};
+
+const SECTION_STYLE = {
+  display: 'flex',
+  flexDirection: 'column' as const,
+  gap: '1rem',
+  padding: 'clamp(2rem, 5vw, 3rem) 1.5rem',
+  maxWidth: '72rem',
+  margin: '0 auto',
+  width: '100%',
+};
+
+const HEADLINE_STYLE = {
+  fontSize: 'clamp(1.25rem, 2.4vw, 1.75rem)',
+  fontWeight: 700,
+  lineHeight: 1.25,
+  color: 'var(--sys-text, var(--hp-text))',
+};
+
+const GRID_STYLE = {
+  display: 'grid',
+  gap: '1rem',
+  gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 18rem), 1fr))',
+};
+
+export function DocsCardCluster({ headline, cards, testId }: DocsCardClusterProps): ReactElement {
+  const headingId = `${testId ?? 'docs-card-cluster'}-heading`;
+  return (
+    <section
+      data-testid={testId}
+      data-docs-card-cluster=""
+      aria-labelledby={headingId}
+      style={SECTION_STYLE}
+    >
+      <h2 id={headingId} style={HEADLINE_STYLE}>
+        {headline}
+      </h2>
+      <div style={GRID_STYLE}>
+        {cards.map((card) => (
+          <DocsCard key={card.href} {...card} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/ui/components/molecules/FeatureMatrix.tsx
+++ b/apps/ui/components/molecules/FeatureMatrix.tsx
@@ -1,0 +1,191 @@
+import type { ReactElement } from 'react';
+import { MaturityBadge, type MaturityLevel } from '../atoms/MaturityBadge';
+
+/**
+ * FeatureMatrix — capability matrix (ADR-035 §54 / Issue #1059).
+ *
+ * Used on `/builders` (capabilities shipped vs. roadmap) and `/deploy` (what
+ * gets deployed, in what region, what is mocked vs. real). Every row carries
+ * a `MaturityBadge` so a vaporware claim cannot ship as "available."
+ *
+ * `availability` is a deliberate enum:
+ *   - `available`    : production-grade, ready to use today
+ *   - `preview`      : limited preview / dogfood
+ *   - `roadmap`      : planned; honest about absence
+ *   - `mocked`       : synthetic on first run (deploy-flow only)
+ *
+ * The component renders a structured table; consumers cannot smuggle prose.
+ */
+export type FeatureMatrixAvailability = 'available' | 'preview' | 'roadmap' | 'mocked';
+
+export type FeatureMatrixRow = {
+  capability: string;
+  /** Short summary cell. */
+  summary: string;
+  availability: FeatureMatrixAvailability;
+  maturity: MaturityLevel;
+  /** Optional region scope (used on /deploy). */
+  region?: string;
+};
+
+export type FeatureMatrixProps = {
+  /** Matrix headline. */
+  headline: string;
+  /** Optional one-sentence description. */
+  description?: string;
+  /** Show a "Region" column (default: false; turn on for `/deploy`). */
+  showRegion?: boolean;
+  rows: FeatureMatrixRow[];
+  testId?: string;
+};
+
+const SECTION_STYLE = {
+  display: 'flex',
+  flexDirection: 'column' as const,
+  gap: '1rem',
+  padding: 'clamp(2rem, 5vw, 3rem) 1.5rem',
+  background: 'var(--sys-surface, var(--hp-surface))',
+  borderRadius: 'var(--radius-lg, 1rem)',
+  maxWidth: '64rem',
+  margin: '0 auto',
+  width: '100%',
+};
+
+const HEADLINE_STYLE = {
+  fontSize: 'clamp(1.25rem, 2.4vw, 1.75rem)',
+  fontWeight: 700,
+  lineHeight: 1.25,
+  color: 'var(--sys-text, var(--hp-text))',
+};
+
+const DESCRIPTION_STYLE = {
+  fontSize: '0.9375rem',
+  lineHeight: 1.55,
+  color: 'var(--sys-text-muted, var(--hp-text-muted))',
+};
+
+const TABLE_STYLE = {
+  width: '100%',
+  borderCollapse: 'collapse' as const,
+  fontSize: '0.9375rem',
+};
+
+const TH_STYLE = {
+  textAlign: 'left' as const,
+  padding: '0.75rem 0.875rem',
+  borderBottom: '1px solid var(--sys-border, var(--hp-border))',
+  fontWeight: 600,
+  color: 'var(--sys-text, var(--hp-text))',
+};
+
+const TD_STYLE = {
+  padding: '0.75rem 0.875rem',
+  borderBottom: '1px solid var(--sys-border, var(--hp-border))',
+  verticalAlign: 'top' as const,
+  color: 'var(--sys-text, var(--hp-text))',
+};
+
+const TD_LABEL_STYLE = { ...TD_STYLE, fontWeight: 600 };
+
+const TD_MUTED_STYLE = { ...TD_STYLE, color: 'var(--sys-text-muted, var(--hp-text-muted))' };
+
+const AVAILABILITY_PILL_STYLE: Record<FeatureMatrixAvailability, { background: string; color: string }> = {
+  available: {
+    background: 'color-mix(in srgb, var(--hp-success, #16a34a) 12%, transparent)',
+    color: 'var(--hp-success, #16a34a)',
+  },
+  preview: {
+    background: 'color-mix(in srgb, var(--hp-warning, #f59e0b) 14%, transparent)',
+    color: 'var(--hp-warning, #f59e0b)',
+  },
+  roadmap: {
+    background: 'color-mix(in srgb, var(--sys-text-muted, var(--hp-text-muted)) 12%, transparent)',
+    color: 'var(--sys-text-muted, var(--hp-text-muted))',
+  },
+  mocked: {
+    background: 'color-mix(in srgb, var(--sys-action-primary, var(--hp-primary)) 10%, transparent)',
+    color: 'var(--sys-action-primary, var(--hp-primary))',
+  },
+};
+
+const AVAILABILITY_LABEL: Record<FeatureMatrixAvailability, string> = {
+  available: 'Available',
+  preview: 'Preview',
+  roadmap: 'Roadmap',
+  mocked: 'Mocked',
+};
+
+function AvailabilityPill({
+  availability,
+}: {
+  availability: FeatureMatrixAvailability;
+}): ReactElement {
+  const style = AVAILABILITY_PILL_STYLE[availability];
+  return (
+    <span
+      data-feature-matrix-availability={availability}
+      style={{
+        display: 'inline-flex',
+        padding: '0.125rem 0.5rem',
+        fontSize: '0.75rem',
+        fontWeight: 600,
+        borderRadius: '999px',
+        background: style.background,
+        color: style.color,
+      }}
+    >
+      {AVAILABILITY_LABEL[availability]}
+    </span>
+  );
+}
+
+export function FeatureMatrix({
+  headline,
+  description,
+  showRegion = false,
+  rows,
+  testId,
+}: FeatureMatrixProps): ReactElement {
+  return (
+    <section
+      data-testid={testId}
+      data-feature-matrix=""
+      style={SECTION_STYLE}
+    >
+      <header>
+        <h2 style={HEADLINE_STYLE}>{headline}</h2>
+        {description ? <p style={DESCRIPTION_STYLE}>{description}</p> : null}
+      </header>
+      <div style={{ overflowX: 'auto' }}>
+        <table style={TABLE_STYLE}>
+          <thead>
+            <tr>
+              <th style={TH_STYLE} scope="col">Capability</th>
+              <th style={TH_STYLE} scope="col">Summary</th>
+              <th style={TH_STYLE} scope="col">Availability</th>
+              {showRegion ? (
+                <th style={TH_STYLE} scope="col">Region</th>
+              ) : null}
+              <th style={TH_STYLE} scope="col">Maturity</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr key={row.capability}>
+                <td style={TD_LABEL_STYLE}>{row.capability}</td>
+                <td style={TD_MUTED_STYLE}>{row.summary}</td>
+                <td style={TD_STYLE}>
+                  <AvailabilityPill availability={row.availability} />
+                </td>
+                {showRegion ? <td style={TD_MUTED_STYLE}>{row.region ?? '—'}</td> : null}
+                <td style={TD_STYLE}>
+                  <MaturityBadge level={row.maturity} />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/apps/ui/components/molecules/Quote.tsx
+++ b/apps/ui/components/molecules/Quote.tsx
@@ -1,0 +1,69 @@
+import type { ReactElement } from 'react';
+import { MaturityBadge, type MaturityLevel } from '../atoms/MaturityBadge';
+
+/**
+ * Quote — social-proof composite (ADR-035 §54 / Issue #1059).
+ *
+ * Honesty enforcement (compile-time):
+ *   - `maturity` is REQUIRED. Quotes carry a maturity badge so a "design
+ *     partner" voice cannot be presented as a production reference and
+ *     vice versa.
+ *   - On `/` (audience-router) we render this composite ONLY when the
+ *     consumer can supply a `production` quote. The page does not render a
+ *     `<Quote>` slot at all if no production quote exists. (See
+ *     `app/page.tsx`.)
+ *
+ * Tone is implicit — the audience tokens emitted by the parent shell drive
+ * the surface treatment via `[data-audience="…"]`. There is no className
+ * escape hatch.
+ */
+export type QuoteProps = {
+  body: string;
+  attribution: { name: string; role: string; org?: string };
+  maturity: MaturityLevel;
+  testId?: string;
+};
+
+const SECTION_STYLE = {
+  display: 'flex',
+  flexDirection: 'column' as const,
+  alignItems: 'center',
+  gap: '1rem',
+  padding: 'clamp(2rem, 4vw, 3rem) 1.5rem',
+  background: 'var(--sys-surface, var(--hp-surface))',
+  borderRadius: 'var(--radius-lg, 1rem)',
+  textAlign: 'center' as const,
+  maxWidth: '52rem',
+  margin: '0 auto',
+};
+
+const BODY_STYLE = {
+  fontSize: 'clamp(1.125rem, 2vw, 1.375rem)',
+  lineHeight: 1.5,
+  fontStyle: 'italic' as const,
+  color: 'var(--sys-text, var(--hp-text))',
+};
+
+const ATTRIBUTION_STYLE = {
+  fontSize: '0.875rem',
+  color: 'var(--sys-text-muted, var(--hp-text-muted))',
+};
+
+export function Quote({ body, attribution, maturity, testId }: QuoteProps): ReactElement {
+  return (
+    <figure
+      data-testid={testId}
+      data-quote=""
+      data-maturity={maturity}
+      style={SECTION_STYLE}
+    >
+      <blockquote style={BODY_STYLE}>“{body}”</blockquote>
+      <figcaption style={ATTRIBUTION_STYLE}>
+        <strong>{attribution.name}</strong>
+        {attribution.role ? <>, {attribution.role}</> : null}
+        {attribution.org ? <> · {attribution.org}</> : null}
+      </figcaption>
+      <MaturityBadge level={maturity} />
+    </figure>
+  );
+}

--- a/apps/ui/tests/a11y/audienceRouter.test.tsx
+++ b/apps/ui/tests/a11y/audienceRouter.test.tsx
@@ -18,13 +18,13 @@ import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import { toHaveNoViolations } from 'jest-axe';
 
+import HomePage from '@/app/page';
 import RetailerLayout from '@/app/(retailer)/layout';
 import RetailersIndexPage from '@/app/(retailer)/retailers/page';
 import BuilderLayout from '@/app/(builder)/layout';
 import BuildersIndexPage from '@/app/(builder)/builders/page';
 import DeployLayout from '@/app/(deploy)/layout';
 import DeployIndexPage from '@/app/(deploy)/deploy/page';
-import { HomeSplitHero } from '@/components/shared/HomeSplitHero';
 
 import { axeAA } from './axeConfig';
 
@@ -32,10 +32,10 @@ expect.extend(toHaveNoViolations);
 
 describe('ui-axe-core — WCAG 2.2 AA gate (ADR-034 §7)', () => {
   it('home audience-router has zero AA violations', async () => {
-    // HomePage is async (resolves persona from cookies/searchParams). Axe
-    // exercises the actually-interactive payload, which is HomeSplitHero
-    // — the rest of the home is static wrapper copy.
-    const { container } = render(<HomeSplitHero persona={null} />);
+    // HomePage is now a sync server component (Issue #1059). The full
+    // HomeShell + Hero + ValuePropGrid + CallToAction stack is rendered
+    // through the same path the route uses at runtime.
+    const { container } = render(<HomePage />);
     const results = await axeAA(container);
     expect(results).toHaveNoViolations();
   });

--- a/apps/ui/tests/unit/AgentCard.test.tsx
+++ b/apps/ui/tests/unit/AgentCard.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+
+import { AgentCard } from '@/components/molecules/AgentCard';
+import { AgentCardCluster } from '@/components/molecules/AgentCardCluster';
+
+describe('AgentCard (Issue #1059)', () => {
+  it('renders domain, name, description, and links to /builders/agents/<slug>', () => {
+    render(
+      <AgentCard
+        domain="Inventory"
+        name="JIT Replenishment"
+        description="Proposes vendor orders."
+        href="/builders/agents/inventory-jit-replenishment"
+        testId="card"
+      />,
+    );
+    const card = screen.getByTestId('card');
+    expect(card).toBeInTheDocument();
+    expect(card).toHaveAttribute('href', '/builders/agents/inventory-jit-replenishment');
+    expect(screen.getByText('Inventory')).toBeInTheDocument();
+    expect(screen.getByText('JIT Replenishment')).toBeInTheDocument();
+    expect(screen.getByText('Proposes vendor orders.')).toBeInTheDocument();
+  });
+});
+
+describe('AgentCardCluster (Issue #1059)', () => {
+  it('renders heading and one card per agent', () => {
+    render(
+      <AgentCardCluster
+        testId="cluster"
+        headline="Six representative agents"
+        agents={[
+          {
+            domain: 'Inventory',
+            name: 'JIT Replenishment',
+            description: 'A',
+            href: '/builders/agents/a',
+          },
+          {
+            domain: 'Inventory',
+            name: 'Reservation Validation',
+            description: 'B',
+            href: '/builders/agents/b',
+          },
+        ]}
+      />,
+    );
+    expect(screen.getByText(/Six representative agents/)).toBeInTheDocument();
+    expect(screen.getByText('JIT Replenishment')).toBeInTheDocument();
+    expect(screen.getByText('Reservation Validation')).toBeInTheDocument();
+  });
+});

--- a/apps/ui/tests/unit/CodeBlock.test.tsx
+++ b/apps/ui/tests/unit/CodeBlock.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+
+import { CodeBlock } from '@/components/molecules/CodeBlock';
+import { CodeBlockCluster } from '@/components/molecules/CodeBlockCluster';
+
+describe('CodeBlock (Issue #1059)', () => {
+  it('renders the snippet collapsed by default with a canonical-doc link', () => {
+    render(
+      <CodeBlock
+        label="Call an agent over MCP"
+        language="python"
+        code="print('hi')"
+        canonical={{ label: 'lib/holiday_peak_lib/mcp', href: '/docs/lib/mcp' }}
+        testId="cb"
+      />,
+    );
+    const block = screen.getByTestId('cb') as HTMLDetailsElement;
+    expect(block.tagName).toBe('DETAILS');
+    expect(block.open).toBe(false);
+    expect(screen.getByText('Call an agent over MCP')).toBeInTheDocument();
+    expect(screen.getByText('python')).toBeInTheDocument();
+    expect(screen.getByText("print('hi')")).toBeInTheDocument();
+    expect(screen.getByText(/lib\/holiday_peak_lib\/mcp/)).toBeInTheDocument();
+  });
+});
+
+describe('CodeBlockCluster (Issue #1059)', () => {
+  it('renders 3 collapsed snippets', () => {
+    render(
+      <CodeBlockCluster
+        testId="cluster"
+        headline="Three things you'll do on day one"
+        blocks={[
+          {
+            label: 'Call',
+            language: 'python',
+            code: 'a',
+            canonical: { label: 'A', href: '/a' },
+          },
+          {
+            label: 'Register',
+            language: 'python',
+            code: 'b',
+            canonical: { label: 'B', href: '/b' },
+          },
+          {
+            label: 'Read',
+            language: 'python',
+            code: 'c',
+            canonical: { label: 'C', href: '/c' },
+          },
+        ]}
+      />,
+    );
+    expect(screen.getByText(/Three things you'll do on day one/)).toBeInTheDocument();
+    expect(screen.getByText('Call')).toBeInTheDocument();
+    expect(screen.getByText('Register')).toBeInTheDocument();
+    expect(screen.getByText('Read')).toBeInTheDocument();
+  });
+});

--- a/apps/ui/tests/unit/Comparator.test.tsx
+++ b/apps/ui/tests/unit/Comparator.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+
+import { Comparator } from '@/components/molecules/Comparator';
+
+describe('Comparator (Issue #1059)', () => {
+  it('renders headline, columns, rows, and per-row maturity', () => {
+    render(
+      <Comparator
+        kind="before-after"
+        headline="Where the time goes"
+        columns={['Manual workflow', 'Agent-assisted']}
+        rows={[
+          { label: 'Replenishment', before: 'Hours', after: 'Minutes', maturity: 'design-partner' },
+          { label: 'Returns', before: 'Manual', after: 'Drafted', maturity: 'preview' },
+          { label: 'Segmentation', before: 'SQL', after: 'Brief', maturity: 'design-partner' },
+        ]}
+        maturity="design-partner"
+        testId="cmp"
+      />,
+    );
+    expect(screen.getByTestId('cmp')).toBeInTheDocument();
+    expect(screen.getByText(/Where the time goes/)).toBeInTheDocument();
+    expect(screen.getByText(/Manual workflow/)).toBeInTheDocument();
+    expect(screen.getByText(/Agent-assisted/)).toBeInTheDocument();
+    expect(screen.getByText('Replenishment')).toBeInTheDocument();
+    expect(screen.getByText('Returns')).toBeInTheDocument();
+    expect(screen.getByText('Segmentation')).toBeInTheDocument();
+    // Per-row maturity badges render.
+    expect(screen.getAllByText(/Design partner|Preview/).length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('honors the comparator-level maturity attribute', () => {
+    render(
+      <Comparator
+        kind="before-after"
+        headline="X"
+        columns={['A', 'B']}
+        rows={[{ label: 'r', before: 'b', after: 'a', maturity: 'preview' }]}
+        maturity="preview"
+        testId="cmp"
+      />,
+    );
+    expect(screen.getByTestId('cmp')).toHaveAttribute('data-maturity', 'preview');
+  });
+});

--- a/apps/ui/tests/unit/DeployStep.test.tsx
+++ b/apps/ui/tests/unit/DeployStep.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react';
+
+import { DeployStep } from '@/components/molecules/DeployStep';
+import { DeployStepCluster } from '@/components/molecules/DeployStepCluster';
+
+describe('DeployStep (Issue #1059)', () => {
+  it('renders the ordinal, headline, and summary', () => {
+    render(
+      <DeployStep
+        ordinal={1}
+        headline="Sign in"
+        summary="Authenticate with the Microsoft Entra tenant."
+        stateful
+        testId="step"
+      />,
+    );
+    expect(screen.getByText(/Step 1/)).toBeInTheDocument();
+    expect(screen.getByText('Sign in')).toBeInTheDocument();
+    expect(screen.getByText(/Microsoft Entra tenant/)).toBeInTheDocument();
+    expect(screen.getByTestId('step')).toHaveAttribute('data-stateful', 'true');
+  });
+});
+
+describe('DeployStepCluster (Issue #1059)', () => {
+  it('renders 5 numbered steps in order', () => {
+    render(
+      <DeployStepCluster
+        testId="cluster"
+        headline="Five steps, end to end"
+        steps={[
+          { headline: 'Sign in', summary: '1', stateful: true },
+          { headline: 'Pick subscription', summary: '2' },
+          { headline: 'Name deployment', summary: '3' },
+          { headline: 'Review estimated cost', summary: '4', stateful: true },
+          { headline: 'Launch', summary: '5' },
+        ]}
+      />,
+    );
+    expect(screen.getByText(/Five steps, end to end/)).toBeInTheDocument();
+    expect(screen.getByText('Step 1')).toBeInTheDocument();
+    expect(screen.getByText('Step 2')).toBeInTheDocument();
+    expect(screen.getByText('Step 3')).toBeInTheDocument();
+    expect(screen.getByText('Step 4')).toBeInTheDocument();
+    expect(screen.getByText('Step 5')).toBeInTheDocument();
+    expect(screen.getByText('Sign in')).toBeInTheDocument();
+    expect(screen.getByText('Launch')).toBeInTheDocument();
+  });
+});

--- a/apps/ui/tests/unit/DocsCard.test.tsx
+++ b/apps/ui/tests/unit/DocsCard.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react';
+
+import { DocsCard } from '@/components/molecules/DocsCard';
+import { DocsCardCluster } from '@/components/molecules/DocsCardCluster';
+
+describe('DocsCard (Issue #1059)', () => {
+  it('renders kicker, title, description, and an internal link', () => {
+    render(
+      <DocsCard
+        kicker="Architecture"
+        title="System overview"
+        description="How the agents fit together."
+        href="/docs/architecture"
+        testId="dc"
+      />,
+    );
+    const card = screen.getByTestId('dc');
+    expect(card).toHaveAttribute('href', '/docs/architecture');
+    expect(screen.getByText('Architecture')).toBeInTheDocument();
+    expect(screen.getByText('System overview')).toBeInTheDocument();
+    expect(screen.getByText('How the agents fit together.')).toBeInTheDocument();
+  });
+
+  it('opens external links in a new tab with rel="noreferrer noopener"', () => {
+    render(
+      <DocsCard
+        title="Cost calculator"
+        description="Canonical Azure cost calculator."
+        href="https://azure.microsoft.com/pricing/calculator"
+        external
+        testId="dc"
+      />,
+    );
+    const card = screen.getByTestId('dc');
+    expect(card).toHaveAttribute('target', '_blank');
+    expect(card).toHaveAttribute('rel', 'noreferrer noopener');
+  });
+});
+
+describe('DocsCardCluster (Issue #1059)', () => {
+  it('renders the heading and one card per entry', () => {
+    render(
+      <DocsCardCluster
+        testId="dcc"
+        headline="Read the docs"
+        cards={[
+          { title: 'Architecture', description: 'A', href: '/docs/a' },
+          { title: 'Governance', description: 'G', href: '/docs/g' },
+        ]}
+      />,
+    );
+    expect(screen.getByText('Read the docs')).toBeInTheDocument();
+    expect(screen.getByText('Architecture')).toBeInTheDocument();
+    expect(screen.getByText('Governance')).toBeInTheDocument();
+  });
+});

--- a/apps/ui/tests/unit/FeatureMatrix.test.tsx
+++ b/apps/ui/tests/unit/FeatureMatrix.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from '@testing-library/react';
+
+import { FeatureMatrix } from '@/components/molecules/FeatureMatrix';
+
+describe('FeatureMatrix (Issue #1059)', () => {
+  it('renders capabilities, summaries, availability pills, and per-row maturity badges', () => {
+    render(
+      <FeatureMatrix
+        headline="Capabilities"
+        rows={[
+          {
+            capability: 'MCP-only A2A',
+            summary: 'All cross-agent calls go through MCP.',
+            availability: 'available',
+            maturity: 'design-partner',
+          },
+          {
+            capability: 'AGC blue-green',
+            summary: 'AppGW for Containers, weighted canary.',
+            availability: 'preview',
+            maturity: 'preview',
+          },
+          {
+            capability: 'Multi-region active/active',
+            summary: 'Two regions writing simultaneously.',
+            availability: 'roadmap',
+            maturity: 'internal',
+          },
+        ]}
+        testId="fm"
+      />,
+    );
+    expect(screen.getByText('Capabilities')).toBeInTheDocument();
+    expect(screen.getByText('MCP-only A2A')).toBeInTheDocument();
+    expect(screen.getByText('AGC blue-green')).toBeInTheDocument();
+    expect(screen.getByText('Multi-region active/active')).toBeInTheDocument();
+    expect(screen.getByText('Available')).toBeInTheDocument();
+    // 'Preview' appears as both the availability pill and the maturity badge label.
+    expect(screen.getAllByText('Preview').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('Roadmap')).toBeInTheDocument();
+  });
+
+  it('shows a Region column when showRegion=true', () => {
+    render(
+      <FeatureMatrix
+        headline="What gets deployed"
+        showRegion
+        rows={[
+          {
+            capability: 'CRUD service',
+            summary: 'X',
+            availability: 'available',
+            maturity: 'design-partner',
+            region: 'East US 2',
+          },
+        ]}
+        testId="fm"
+      />,
+    );
+    expect(screen.getByText('Region')).toBeInTheDocument();
+    expect(screen.getByText('East US 2')).toBeInTheDocument();
+  });
+
+  it('hides the Region column when showRegion is omitted', () => {
+    render(
+      <FeatureMatrix
+        headline="X"
+        rows={[
+          {
+            capability: 'a',
+            summary: 'x',
+            availability: 'available',
+            maturity: 'production',
+          },
+        ]}
+        testId="fm"
+      />,
+    );
+    expect(screen.queryByText('Region')).not.toBeInTheDocument();
+  });
+});

--- a/apps/ui/tests/unit/Quote.test.tsx
+++ b/apps/ui/tests/unit/Quote.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+
+import { Quote } from '@/components/molecules/Quote';
+
+describe('Quote (Issue #1059)', () => {
+  it('renders body and attribution', () => {
+    render(
+      <Quote
+        body="Replenishment review went from hours to minutes."
+        attribution={{ name: 'A. Buyer', role: 'Senior buyer', org: 'Design partner' }}
+        maturity="design-partner"
+        testId="q"
+      />,
+    );
+    expect(screen.getByTestId('q')).toBeInTheDocument();
+    expect(screen.getByText(/Replenishment review went from hours to minutes/)).toBeInTheDocument();
+    expect(screen.getByText(/A. Buyer/)).toBeInTheDocument();
+    expect(screen.getByText(/Senior buyer/)).toBeInTheDocument();
+    // "Design partner" appears twice (org attribution + maturity badge).
+    expect(screen.getAllByText(/Design partner/).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders a maturity badge (honesty contract)', () => {
+    render(
+      <Quote
+        body="Useful."
+        attribution={{ name: 'A. B.', role: 'Role' }}
+        maturity="production"
+        testId="q"
+      />,
+    );
+    expect(screen.getByTestId('q')).toHaveAttribute('data-maturity', 'production');
+  });
+});

--- a/apps/ui/tests/unit/archetypes.test.tsx
+++ b/apps/ui/tests/unit/archetypes.test.tsx
@@ -1,0 +1,174 @@
+import { render, screen } from '@testing-library/react';
+
+import HomePage from '@/app/page';
+import RetailerLayout from '@/app/(retailer)/layout';
+import RetailersIndexPage from '@/app/(retailer)/retailers/page';
+import BuilderLayout from '@/app/(builder)/layout';
+import BuildersIndexPage from '@/app/(builder)/builders/page';
+import DeployLayout from '@/app/(deploy)/layout';
+import DeployIndexPage from '@/app/(deploy)/deploy/page';
+
+/**
+ * UX-pattern archetype contract tests (Issue #1059).
+ *
+ * Pin the locked composition order at v1 per `docs/ui/ux-patterns.md`.
+ * A future PR re-ordering an archetype trips these tests.
+ */
+
+describe('Archetype A: `/` (audience router, neutral)', () => {
+  it('renders the audience-router hero with two equally-weighted CTAs', () => {
+    render(<HomePage />);
+    const hero = screen.getByTestId('home-hero');
+    expect(hero).toHaveAttribute('data-hero-kind', 'audience-router');
+    expect(screen.getByText("I'm a retailer")).toBeInTheDocument();
+    expect(screen.getByText("I'm a builder")).toBeInTheDocument();
+  });
+
+  it('renders the cardinality-locked three-card value-prop grid', () => {
+    render(<HomePage />);
+    const grid = screen.getByTestId('home-value-props');
+    expect(grid).toHaveAttribute('data-valueprop-grid', 'three');
+    expect(grid.querySelectorAll('[data-valueprop-kind]').length).toBe(3);
+  });
+
+  it('renders the audience-pair second-pass CTA', () => {
+    render(<HomePage />);
+    expect(screen.getByTestId('home-cta-pair')).toBeInTheDocument();
+  });
+
+  it('does NOT render a third hero CTA (Hick\'s-Law lock)', () => {
+    render(<HomePage />);
+    const hero = screen.getByTestId('home-hero');
+    // Two anchor children inside the hero CTA cluster.
+    expect(hero.querySelectorAll('a').length).toBe(2);
+  });
+});
+
+describe('Archetype B: `/retailers` (warm)', () => {
+  function renderRetailers() {
+    return render(
+      <RetailerLayout>
+        <RetailersIndexPage />
+      </RetailerLayout>,
+    );
+  }
+
+  it('renders the audience-page hero', () => {
+    renderRetailers();
+    expect(screen.getByTestId('retailers-hero')).toHaveAttribute(
+      'data-hero-kind',
+      'audience-page',
+    );
+  });
+
+  it('renders the value-prop grid in the 3-to-5 cardinality', () => {
+    renderRetailers();
+    const grid = screen.getByTestId('retailers-value-props');
+    expect(grid).toHaveAttribute('data-valueprop-grid', 'three-to-five');
+  });
+
+  it('renders the before/after comparator with maturity', () => {
+    renderRetailers();
+    const cmp = screen.getByTestId('retailers-comparator');
+    expect(cmp).toHaveAttribute('data-comparator', 'before-after');
+    expect(cmp).toHaveAttribute('data-maturity');
+  });
+
+  it('renders the agent cluster', () => {
+    renderRetailers();
+    expect(screen.getByTestId('retailers-agents')).toBeInTheDocument();
+  });
+
+  it('renders both the walkthrough CTA and the procurement CTA', () => {
+    renderRetailers();
+    expect(screen.getByTestId('retailers-cta-walkthrough')).toBeInTheDocument();
+    expect(screen.getByTestId('retailers-cta-procurement')).toBeInTheDocument();
+  });
+});
+
+describe('Archetype C: `/builders` (cool)', () => {
+  function renderBuilders() {
+    return render(
+      <BuilderLayout>
+        <BuildersIndexPage />
+      </BuilderLayout>,
+    );
+  }
+
+  it('renders the audience-page hero with dual CTAs', () => {
+    renderBuilders();
+    expect(screen.getByTestId('builders-hero')).toHaveAttribute(
+      'data-hero-kind',
+      'audience-page',
+    );
+  });
+
+  it('renders the technical value-prop grid (3-to-5)', () => {
+    renderBuilders();
+    const grid = screen.getByTestId('builders-value-props');
+    expect(grid).toHaveAttribute('data-valueprop-grid', 'three-to-five');
+  });
+
+  it('renders the code-block cluster', () => {
+    renderBuilders();
+    expect(screen.getByTestId('builders-code-blocks')).toBeInTheDocument();
+  });
+
+  it('renders the feature matrix', () => {
+    renderBuilders();
+    expect(screen.getByTestId('builders-feature-matrix')).toBeInTheDocument();
+  });
+
+  it('renders the docs cluster', () => {
+    renderBuilders();
+    expect(screen.getByTestId('builders-docs')).toBeInTheDocument();
+  });
+
+  it('renders the audience-pair CTA at the bottom', () => {
+    renderBuilders();
+    expect(screen.getByTestId('builders-cta-pair')).toBeInTheDocument();
+  });
+});
+
+describe('Archetype D: `/deploy` (cool, slate)', () => {
+  function renderDeploy() {
+    return render(
+      <DeployLayout>
+        <DeployIndexPage />
+      </DeployLayout>,
+    );
+  }
+
+  it('renders the audience-page hero', () => {
+    renderDeploy();
+    expect(screen.getByTestId('deploy-hero')).toHaveAttribute(
+      'data-hero-kind',
+      'audience-page',
+    );
+  });
+
+  it('renders the 5-step deploy cluster', () => {
+    renderDeploy();
+    const cluster = screen.getByTestId('deploy-steps');
+    expect(cluster).toBeInTheDocument();
+    expect(cluster.querySelectorAll('[data-deploy-step]').length).toBe(5);
+  });
+
+  it('renders the feature matrix with a Region column', () => {
+    renderDeploy();
+    const fm = screen.getByTestId('deploy-feature-matrix');
+    expect(fm).toBeInTheDocument();
+    // Region header is present because showRegion=true.
+    expect(fm.textContent).toContain('Region');
+  });
+
+  it('renders the post-deploy docs cluster', () => {
+    renderDeploy();
+    expect(screen.getByTestId('deploy-docs')).toBeInTheDocument();
+  });
+
+  it('renders the start CTA at the bottom', () => {
+    renderDeploy();
+    expect(screen.getByTestId('deploy-cta-start')).toBeInTheDocument();
+  });
+});

--- a/docs/ui/ux-patterns.md
+++ b/docs/ui/ux-patterns.md
@@ -1,0 +1,157 @@
+# UX patterns / archetypes (ADR-035 §54 / Issue #1059)
+
+> **Status**: Active — landed via Issue #1059. Composition order for each archetype is **locked at v1**. A/B variations are permitted only after ≥ 4 weeks of baseline traffic. Any structural reorder requires an ADR-035 amendment.
+
+The marketing surface of the product is encoded as **four page archetypes**, each composed of components from the F3 component library (Issue #1057, PR #1072) and the F4 token system (Issue #1056, PR #1071). The archetypes are:
+
+| Route | Audience | Cognitive model | Shell |
+|---|---|---|---|
+| `/` | both / unknown | neutral (Hick's-Law-restricted) | `HomeShell` |
+| `/retailers` | retail leadership / operators | warm | `RetailerShell` (route-group layout) |
+| `/builders` | platform engineers | cool | `BuilderShell` (route-group layout) |
+| `/deploy` | DevOps / pre-sales | cool (slate accent) | `DeployShell` (route-group layout) |
+
+The **persona is a hint, not a gate** (ADR-034 §3) — every archetype renders the full content for both audiences; the persona only nudges the lane-switch CTA.
+
+## Common contract
+
+Every archetype:
+
+1. **No `className` escape hatch on composites**. Density and tone are bound by the parent shell's `data-audience` attribute and the system-token layer.
+2. **No raw hex literals in the audience routes**. ESLint rejects them. Colors come from the token system.
+3. **No inline `style={{}}` in the audience-route page-level code** (ADR-035 §49 / Issue #1058 L-3). Layout lives inside composites under `components/molecules/` (which are exempt from the `style` rule).
+4. **Honesty is enforced at compile time**. `MaturityBadge` is non-optional on every claim-bearing composite. `ConfidenceInterval` is required by the type system on every quantitative `ValueProp`.
+5. **One brand, two cognitive models** (ADR-034 §1). Same brand mark across all four archetypes; the audience tokens drive the surface treatment.
+6. **en-US only** across all copy and metadata (current repo language policy).
+
+## Archetype A — `/` (audience router, neutral)
+
+**Composition order (locked at v1)**:
+
+1. `<Hero kind="audience-router">` — single headline, one-sentence sub, **two equally-weighted CTAs** ("I'm a retailer" → `/retailers`, "I'm a builder" → `/builders`). No third CTA. No carousel. No autoplay video.
+2. `<ValuePropGrid cardinality="three">` — exactly three `<ValueProp>` cards (Hick's-Law cardinality lock).
+3. `<Quote>` rendered ONLY when a production-maturity quote exists. Currently omitted.
+4. `<CallToAction tone="audience-pair">` — second-pass CTA per NN/g research.
+
+**5-second-test rubric** (target visitor: a person who clicked an Azure-Samples link):
+
+| Question | Visual cue that answers it |
+|---|---|
+| "What is this?" | The hero headline names "intelligent retail on Azure's agentic platform." |
+| "Is this for me?" | Two equally-weighted CTAs labelled "I'm a retailer" / "I'm a builder." |
+| "What will the next click do?" | Each CTA names where it goes (the destination route is in the label). |
+| "Should I trust this?" | Three value-prop cards each carrying a maturity badge — no synthetic case-study claim above the fold. |
+
+## Archetype B — `/retailers` (warm)
+
+**Composition order (locked at v1)**:
+
+1. `<Hero kind="audience-page">` — outcome-led headline, one-sentence sub naming the problem, single primary CTA + secondary "Book a 20-minute walkthrough."
+2. `<ValuePropGrid cardinality="three-to-five">` — every numbered card carries `<ConfidenceInterval>`. No number ships without a citation.
+3. `<Comparator kind="before-after">` — three rows comparing manual workflow vs. agent-assisted workflow. `MaturityBadge` is mandatory at the type level on the comparator AND every row.
+4. `<AgentCardCluster>` — six representative retail agents linking into `/builders/agents/<slug>`.
+5. `<Quote>` rendered only with production-maturity badge. Currently omitted (no production reference).
+6. `<CallToAction tone="single">` — book-a-walkthrough CTA.
+7. `<CallToAction tone="procurement">` — RFP-tone CTA near the footer with Trust Center link.
+
+**5-second-test rubric**:
+
+| Question | Visual cue that answers it |
+|---|---|
+| "Will this save me time?" | Hero names a concrete pain ("stop wrestling spreadsheets"); first ValueProp carries an observed time-on-task delta. |
+| "Is the number real?" | Every quantitative card renders a `<ConfidenceInterval>` with sample size and methodology. |
+| "Have other retailers used this?" | Comparator rows carry maturity badges (design-partner / preview); no card is labelled "production" without evidence. |
+| "Where do I start?" | One outcome-CTA in the hero; one walkthrough-CTA mid-page; one procurement-CTA above the footer. Three doors, no decision paralysis. |
+
+## Archetype C — `/builders` (cool)
+
+**Composition order (locked at v1)**:
+
+1. `<Hero kind="audience-page">` — capability-led headline, one-sentence sub, dual CTA ("See architecture →" + "Browse agent catalog →").
+2. `<ValuePropGrid cardinality="three-to-five">` — 5 technical capability cards, all qualitative (architecture is described, not numerically claimed).
+3. `<CodeBlockCluster>` — three short snippets (call-an-agent, register-MCP-tool, read-three-tier-memory). **Collapsed by default.** Expansion lazy-loads and the canonical-link points at the docs page that owns the snippet (no duplication).
+4. `<FeatureMatrix>` — capabilities shipped vs. roadmap. Every row carries `<MaturityBadge>`. No vaporware listed as "available."
+5. `<DocsCardCluster>` — direct links into mkdocs sections (`architecture/`, `governance/`, `ops/`).
+6. `<CallToAction tone="audience-pair">` — switch lane / try deploy.
+
+**5-second-test rubric**:
+
+| Question | Visual cue that answers it |
+|---|---|
+| "What's the architecture?" | Hero names the architectural primitives (MCP-only A2A, three-tier memory, AGC blue-green). |
+| "How do I call an agent?" | The collapsed `CodeBlockCluster` makes the "call an agent over MCP" snippet a one-click reveal. |
+| "What's available today?" | The FeatureMatrix renders an Availability column (available / preview / roadmap / mocked). |
+| "Where do I read more?" | Three DocsCards link directly into mkdocs (`architecture/`, `governance/`, `ops/`). |
+
+## Archetype D — `/deploy` (cool, slate accent)
+
+**Composition order (locked at v1)**:
+
+1. `<Hero kind="audience-page">` — operational headline ("Deploy agentic retail to your Azure tenant"), sub names prerequisites (Azure subscription, Entra tenant), primary CTA "Start" + secondary "Open the canonical Azure cost calculator."
+2. `<DeployStepCluster>` — 5 steps (sign in, pick subscription, name deployment, **review estimated cost**, launch). Steps 1 and 4 are stateful (`stateful: true`); the rest are server-rendered.
+3. `<FeatureMatrix showRegion>` — what gets deployed, in what region, what is mocked vs. real (synthetic data on first run).
+4. `<DocsCardCluster>` — what to do after deploy, rollback procedure, tear-down.
+5. `<CallToAction tone="single">` — start CTA at the bottom (mirror of the hero CTA).
+
+**Cost-preview legal handling (step 4)**: the cost is rendered as a range with the explicit non-contractual disclaimer ("estimated, varies by region; not a contractual quote"). The hero secondary CTA is a more-prominent link to the canonical Azure cost calculator than the in-page number.
+
+**5-second-test rubric**:
+
+| Question | Visual cue that answers it |
+|---|---|
+| "What do I need before I start?" | Hero sub names prerequisites (Azure subscription, Entra tenant). |
+| "How many steps?" | The cluster renders 5 numbered steps; each carries a one-sentence summary. |
+| "How much will it cost?" | Step 4 carries the disclaimer; the hero secondary CTA points to the canonical Azure cost calculator. |
+| "What if it breaks?" | DocsCardCluster surfaces the rollback runbook directly, alongside the post-deploy and tear-down runbooks. |
+
+## Anti-patterns rejected
+
+- **No carousel of "trusted by" logos.** No archetype renders a logo wall.
+- **No autoplay video hero.** Heroes are text + CTAs.
+- **No scroll-jacking.** Section transitions follow the document flow.
+- **No third CTA on `/`.** Hick's-Law cardinality lock.
+- **No value-prop card lacking a citation when it carries a number.** Compile-time enforced.
+- **No `className` escape hatch on composites.** Tone is bound by audience tokens.
+- **No `style={{}}` prop in audience-route page-level code.** Layout lives in composites.
+- **No raw hex literals in audience routes.** Colors come from the token system.
+
+## Cardinality and rhythm rules
+
+| Slot | Cardinality | Rule |
+|---|---|---|
+| `/` `<ValuePropGrid>` | exactly 3 | Hick's-Law cardinality lock at the audience router. |
+| `/retailers` `<ValuePropGrid>` | 3–5 | Runtime-checked by `<ValuePropGrid cardinality="three-to-five">`. |
+| `/retailers` `<AgentCardCluster>` | exactly 6 | Documented above; no compile-time check (cluster is a flat list). |
+| `/builders` `<ValuePropGrid>` | 3–5 | Runtime-checked; we ship 5 today. |
+| `/builders` `<CodeBlockCluster>` | exactly 3 | Documented above. |
+| `/deploy` `<DeployStepCluster>` | exactly 5 | Documented above. Two of the five are stateful. |
+| `<FeatureMatrix>` | 3–10 rows | No hard cap; readability falls off above ~10. |
+
+## A/B variation policy
+
+Composition order is **locked at v1**. A/B variations are permitted only after ≥ 4 weeks of baseline traffic on the locked composition. Reasoning: with no baseline, A/B traffic produces noise, not signal.
+
+When an A/B variation is proposed, the proposing PR must (1) cite the baseline metrics it intends to beat, (2) state the hypothesis under test, (3) state the success threshold, and (4) include rollback criteria.
+
+Any structural reorder (adding a new section, removing one, swapping two) requires an ADR-035 amendment, not just an A/B test.
+
+## Metadata shape per archetype
+
+Metadata is declared via Next.js 16 `metadata` API in each `page.tsx`. Per ADR-034:
+
+| Route | OG variant | Title pattern | Description pattern |
+|---|---|---|---|
+| `/` | `audience: neutral` | "Holiday Peak Hub — Intelligent retail on Azure" | Pick-your-lane summary. |
+| `/retailers` | warm | "Holiday Peak Hub for Retailers — outcomes, not dashboards" | Outcome-led summary citing maturity. |
+| `/builders` | cool | "Holiday Peak Hub for Builders — architecture & contracts" | Capability-led summary citing primitives. |
+| `/deploy` | cool (slate) | "Deploy Holiday Peak Hub to your Azure tenant" | Prerequisites + first-run summary. |
+
+Metadata never mixes warm and cool — each archetype's OG variant matches its audience.
+
+## References
+
+- ADR-034 — Audience-segmented IA — [`docs/architecture/adrs/adr-034-audience-segmented-ia.md`](../architecture/adrs/adr-034-audience-segmented-ia.md)
+- ADR-035 — UI design system — [`docs/architecture/adrs/adr-035-ui-design-system.md`](../architecture/adrs/adr-035-ui-design-system.md)
+- Design tokens — [`docs/ui/design-tokens.md`](./design-tokens.md)
+- CSS architecture — [`docs/ui/css-architecture.md`](./css-architecture.md)
+- Five-second test — [`docs/governance/five-second-test.md`](../governance/five-second-test.md)


### PR DESCRIPTION
## Summary

Closes #1059 — research-backed UX patterns for the four marketing-surface archetypes (`/`, `/retailers`, `/builders`, `/deploy`) consuming the F3 component library and the F2 token system.

## What landed

### Four archetype pages

| Route | Archetype | Composition order (locked at v1) |
|---|---|---|
| `/` | A: audience router (neutral) | Hero(audience-router) → ValuePropGrid(three) → CallToAction(audience-pair) |
| `/retailers` | B: warm | Hero(audience-page) → ValuePropGrid(three-to-five) → Comparator → AgentCardCluster → CallToAction(single) → CallToAction(procurement) |
| `/builders` | C: cool | Hero(audience-page) → ValuePropGrid(three-to-five) → CodeBlockCluster → FeatureMatrix → DocsCardCluster → CallToAction(audience-pair) |
| `/deploy` | D: cool (slate) | Hero(audience-page) → DeployStepCluster (5 steps, 2 stateful) → FeatureMatrix(showRegion) → DocsCardCluster → CallToAction(single) |

### 11 new molecules (composites)

All under `apps/ui/components/molecules/`:

- `Quote.tsx` — quote with required `MaturityBadge`. Audience-router renders this slot **only if a production-maturity quote exists** (currently omitted; no production reference).
- `Comparator.tsx` — before/after table; required maturity at the comparator level AND on every row.
- `AgentCard.tsx` + `AgentCardCluster.tsx` — agent surface card linking to `/builders/agents/<slug>`, plus the labelled grid wrapper.
- `DocsCard.tsx` + `DocsCardCluster.tsx` — link card into mkdocs sections, plus the labelled grid wrapper.
- `DeployStep.tsx` + `DeployStepCluster.tsx` — labelled deploy-step card and the 5-step ordered-list cluster.
- `CodeBlock.tsx` + `CodeBlockCluster.tsx` — collapsed-by-default snippet (native `<details>`) with canonical-doc link, plus the cluster wrapper.
- `FeatureMatrix.tsx` — capability matrix with availability pill (available / preview / roadmap / mocked) and required per-row maturity.

### Documentation

`docs/ui/ux-patterns.md` — comprehensive spec: per-archetype composition order, 5-second-test rubrics, anti-patterns rejected, cardinality and rhythm rules, A/B variation policy (locked at v1, A/B only after ≥ 4 weeks of baseline), and metadata-shape table.

### Tests

| Suite | Count | Purpose |
|---|---|---|
| `Quote.test.tsx` | 2 | Body / attribution / maturity-badge contract |
| `Comparator.test.tsx` | 2 | Headline / columns / rows / per-row maturity |
| `AgentCard.test.tsx` | 2 | Card props + cluster heading |
| `DocsCard.test.tsx` | 3 | Internal + external links + cluster |
| `DeployStep.test.tsx` | 2 | Ordinal / stateful flag + cluster numbering |
| `CodeBlock.test.tsx` | 2 | Collapsed-by-default + canonical link + cluster |
| `FeatureMatrix.test.tsx` | 3 | Availability pill / region column / maturity per row |
| `archetypes.test.tsx` | 19 | **Composition-order contract for all four archetypes** — pins the locked v1 layout |

`tests/a11y/audienceRouter.test.tsx` — updated to render the new `HomePage` directly (which is now sync), replacing the previous `HomeSplitHero`-only render.

## Acceptance criteria mapping

From Issue #1059:

| Criterion | Status | Notes |
|---|---|---|
| Archetype A (`/`) composition order | ✅ | Hero(audience-router, two CTAs) → ValuePropGrid(three) → CallToAction(audience-pair); no third CTA, no carousel, no autoplay video |
| Archetype B (`/retailers`) composition order | ✅ | Hero → ValuePropGrid(3–5) → Comparator → AgentCardCluster → walkthrough CTA → procurement CTA |
| Archetype C (`/builders`) composition order | ✅ | Hero(dual CTA) → ValuePropGrid(5 technical) → CodeBlockCluster (collapsed) → FeatureMatrix → DocsCardCluster → audience-pair CTA |
| Archetype D (`/deploy`) composition order | ✅ | Hero (Azure cost calculator as secondary CTA) → DeployStepCluster (5 steps, 2 stateful) → FeatureMatrix(showRegion) → DocsCardCluster → start CTA |
| `MaturityBadge` non-optional at type level | ✅ | All claim-bearing composites (`Quote`, `Comparator`, `ValueProp` quantitative, `FeatureMatrix` rows) require `maturity` |
| `ConfidenceInterval` required on quantitative `ValueProp` | ✅ | Already enforced from #1057 via discriminated union; consumer pages use it |
| `<Quote>` rendered only with production-maturity badge on `/` | ✅ | Slot exists in the archetype contract; we render no quote until one is sourced |
| 5-second-test rubric documented per archetype | ✅ | `docs/ui/ux-patterns.md` § "5-second-test rubric" per archetype |
| Composition order locked at v1; A/B only after ≥ 4 weeks | ✅ | Documented in `docs/ui/ux-patterns.md` § "A/B variation policy" |
| Metadata shape per archetype declared via Next.js 16 metadata API | ✅ | Each `page.tsx` declares its `metadata` export |
| One brand, two cognitive models | ✅ | `RetailerShell` (warm), `BuilderShell` + `DeployShell` (cool); `HomeShell` is neutral |
| en-US only | ✅ | All copy is en-US |
| Branch name `feature/<id>-ux-patterns` (ADR-018) | ✅ | `feature/1059-ux-patterns` |
| Anti-patterns rejected (no carousel, no autoplay video, no scroll-jacking, no third CTA on `/`) | ✅ | None present in any archetype |
| Procurement-tone CTA near footer of `/retailers` with Trust Center link | ✅ | `<CallToAction tone="procurement">` with RFP and Trust Center link |
| `/deploy` step 4 cost preview as range with non-contractual disclaimer; canonical Azure cost calculator link | ✅ | Step 4 summary states "estimated, varies by region; not a contractual quote"; the hero secondary CTA links to the canonical calculator |
| `/builders` CodeBlocks collapsed by default with canonical-doc link | ✅ | `CodeBlock` uses `<details>` + canonical link; cluster does not duplicate doc content |

## Validation

| Gate | Result |
|---|---|
| `yarn type-check` | ✅ clean |
| `yarn lint` (max-warnings 0) | ✅ clean |
| `yarn test` | ✅ 61 suites / **325 tests** pass (was 289 before — 36 new) |
| `yarn build` | ✅ clean (45s) |

## Out of scope (follow-ups)

- The `/contact` route and the `/docs/governance`, `/docs/architecture`, `/docs/ops` routes referenced from CTAs and DocsCards do not exist yet — those are tracked under epic #1053 and the IA epic #1020.
- The actual stateful behaviors on `/deploy` step 1 (sign-in flow) and step 4 (live cost preview) are tracked in epic #1039.
- The `/retailers/comparators`, `/retailers/use-cases/<slug>`, `/builders/agents/<slug>` routes referenced from the archetypes ship in their respective epics (#1046, #1053).

## Risk & rollback

**Risk**: medium. The home page (`/`) is restructured significantly — it no longer uses `HomeSplitHero` (which is still present in the codebase, just unused on `/`). The audience pages were placeholder text and now render the full archetype.

**Rollback**: revert this PR. The old placeholder pages and `HomeSplitHero`-based home are preserved in git history. No migrations.

**Mitigations**:

- The composition-order contract test (`archetypes.test.tsx`) pins the v1 layout — a future PR re-ordering trips the suite.
- The 5-second-test rubric is documented per archetype, so a future reviewer can render a verdict against it.
- `MaturityBadge` is non-optional at the type level on every claim-bearing composite — a future PR cannot silently ship a number without a citation or a quote without a maturity badge.
