### PR TITLE
test(a11y): extend axe-core AA gate to 14 audience-IA deep pages (#1019)

### DIFF
--- a/apps/ui/tests/a11y/audienceDeepPages.test.tsx
+++ b/apps/ui/tests/a11y/audienceDeepPages.test.tsx
@@ -1,0 +1,177 @@
+/**
+ * ui-axe-core — WCAG 2.2 AA gate on the audience-IA deep pages (Issue #1019).
+ *
+ * Sister suite to `audienceRouter.test.tsx`. The landings (home + retailer +
+ * builder + deploy) are covered there. This suite extends the gate to the
+ * deep pages that shipped in the audience-IA wave (PR #1076 retailers, PR
+ * #1077 builders, PR #1078 deploy) so every audience-IA route group has
+ * AA-grade chrome — including the AppSearchBox combobox added in PR #1081.
+ *
+ * The dynamic /deploy/track/[id] page requires route params and is covered
+ * by `pagesRender.test.tsx` already; we exclude it here so the gate stays
+ * deterministic and fast.
+ */
+import './jest-axe.d';
+
+import '@testing-library/jest-dom';
+
+import { render } from '@testing-library/react';
+import { toHaveNoViolations } from 'jest-axe';
+
+import RetailerLayout from '@/app/(retailer)/layout';
+import RetailerValuePage from '@/app/(retailer)/retailers/value/page';
+import RetailerAgentsPage from '@/app/(retailer)/retailers/agents/page';
+import RetailerRoiPage from '@/app/(retailer)/retailers/roi/page';
+import RetailerComparatorsPage from '@/app/(retailer)/retailers/comparators/page';
+import RetailerCaseStudiesPage from '@/app/(retailer)/retailers/case-studies/page';
+import RetailerSecurityPage from '@/app/(retailer)/retailers/security/page';
+
+import BuilderLayout from '@/app/(builder)/layout';
+import BuilderArchitecturePage from '@/app/(builder)/builders/architecture/page';
+import BuilderAdrsPage from '@/app/(builder)/builders/adrs/page';
+import BuilderPatternsPage from '@/app/(builder)/builders/patterns/page';
+import BuilderTelemetryPage from '@/app/(builder)/builders/telemetry/page';
+import BuilderEnablementPage from '@/app/(builder)/builders/enablement/page';
+
+import DeployLayout from '@/app/(deploy)/layout';
+import DeployCatalogPage from '@/app/(deploy)/deploy/catalog/page';
+import DeployConfigurePage from '@/app/(deploy)/deploy/configure/page';
+import DeployPreflightPage from '@/app/(deploy)/deploy/preflight/page';
+
+import { axeAA } from './axeConfig';
+
+expect.extend(toHaveNoViolations);
+
+describe('ui-axe-core deep-page coverage — WCAG 2.2 AA gate (ADR-034 §7)', () => {
+  describe('retailer (warm palette)', () => {
+    it('/retailers/value has zero AA violations', async () => {
+      const { container } = render(
+        <RetailerLayout>
+          <RetailerValuePage />
+        </RetailerLayout>,
+      );
+      expect(await axeAA(container)).toHaveNoViolations();
+    });
+
+    it('/retailers/agents has zero AA violations', async () => {
+      const { container } = render(
+        <RetailerLayout>
+          <RetailerAgentsPage />
+        </RetailerLayout>,
+      );
+      expect(await axeAA(container)).toHaveNoViolations();
+    });
+
+    it('/retailers/roi has zero AA violations', async () => {
+      const { container } = render(
+        <RetailerLayout>
+          <RetailerRoiPage />
+        </RetailerLayout>,
+      );
+      expect(await axeAA(container)).toHaveNoViolations();
+    });
+
+    it('/retailers/comparators has zero AA violations', async () => {
+      const { container } = render(
+        <RetailerLayout>
+          <RetailerComparatorsPage />
+        </RetailerLayout>,
+      );
+      expect(await axeAA(container)).toHaveNoViolations();
+    });
+
+    it('/retailers/case-studies has zero AA violations', async () => {
+      const { container } = render(
+        <RetailerLayout>
+          <RetailerCaseStudiesPage />
+        </RetailerLayout>,
+      );
+      expect(await axeAA(container)).toHaveNoViolations();
+    });
+
+    it('/retailers/security has zero AA violations', async () => {
+      const { container } = render(
+        <RetailerLayout>
+          <RetailerSecurityPage />
+        </RetailerLayout>,
+      );
+      expect(await axeAA(container)).toHaveNoViolations();
+    });
+  });
+
+  describe('builder (cool palette)', () => {
+    it('/builders/architecture has zero AA violations', async () => {
+      const { container } = render(
+        <BuilderLayout>
+          <BuilderArchitecturePage />
+        </BuilderLayout>,
+      );
+      expect(await axeAA(container)).toHaveNoViolations();
+    });
+
+    it('/builders/adrs has zero AA violations', async () => {
+      const { container } = render(
+        <BuilderLayout>
+          <BuilderAdrsPage />
+        </BuilderLayout>,
+      );
+      expect(await axeAA(container)).toHaveNoViolations();
+    });
+
+    it('/builders/patterns has zero AA violations', async () => {
+      const { container } = render(
+        <BuilderLayout>
+          <BuilderPatternsPage />
+        </BuilderLayout>,
+      );
+      expect(await axeAA(container)).toHaveNoViolations();
+    });
+
+    it('/builders/telemetry has zero AA violations', async () => {
+      const { container } = render(
+        <BuilderLayout>
+          <BuilderTelemetryPage />
+        </BuilderLayout>,
+      );
+      expect(await axeAA(container)).toHaveNoViolations();
+    });
+
+    it('/builders/enablement has zero AA violations', async () => {
+      const { container } = render(
+        <BuilderLayout>
+          <BuilderEnablementPage />
+        </BuilderLayout>,
+      );
+      expect(await axeAA(container)).toHaveNoViolations();
+    });
+  });
+
+  describe('deploy (neutral palette)', () => {
+    it('/deploy/catalog has zero AA violations', async () => {
+      const { container } = render(
+        <DeployLayout>
+          <DeployCatalogPage />
+        </DeployLayout>,
+      );
+      expect(await axeAA(container)).toHaveNoViolations();
+    });
+
+    it('/deploy/configure has zero AA violations', async () => {
+      const { container } = render(
+        <DeployLayout>
+          <DeployConfigurePage />
+        </DeployLayout>,
+      );
+      expect(await axeAA(container)).toHaveNoViolations();
+    });
+
+    it('/deploy/preflight has zero AA violations', async () => {
+      const { container } = render(
+        <DeployLayout>
+          <DeployPreflightPage />
+        </DeployLayout>,
+      );
+      expect(await axeAA(container)).toHaveNoViolations();
+    });
+  });
+});


### PR DESCRIPTION
Extends the `ui-axe-core` CI gate (Issue #1019, ADR-034 §7) from the 4 audience landings to **all 14 audience-IA deep pages** that shipped in the audience-IA wave (PRs #1076, #1077, #1078).

## Coverage delta
| Lane | Before | After |
|------|--------|-------|
| home | 1 | 1 |
| retailer | 1 (landing) | 1 + 6 deep |
| builder | 1 (landing) | 1 + 5 deep |
| deploy | 1 (landing) | 1 + 3 deep |
| **Total** | **4** | **18** |

## What is gated
Each test renders the page **inside its actual route-group layout** so the `[data-section]` token scoping and `audience-*` scoping are in effect — same render path the route uses at runtime. axe-core asserts zero WCAG 2.2 AA violations.

- `/retailers/value /agents /roi /comparators /case-studies /security`
- `/builders/architecture /adrs /patterns /telemetry /enablement`
- `/deploy/catalog /configure /preflight`

Dynamic `/deploy/track/[id]` requires route params and is covered by `pagesRender.test.tsx` instead — keeping this suite deterministic + ~10s.

## Validation
- `yarn test:a11y` — **18 cases passing** (4 existing + 14 new), 12s wall clock.
- `yarn type-check` clean.
- `yarn lint` clean (max-warnings 0).