### PR TITLE
feat(ui,docs): complete two-search-box cross-link contract (#1022)

### DIFF
--- a/apps/ui/app/page.tsx
+++ b/apps/ui/app/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 
+import { AppSearchBox } from '@/components/molecules/AppSearchBox';
 import { CallToAction } from '@/components/molecules/CallToAction';
 import { Hero } from '@/components/molecules/Hero';
 import { ValuePropGrid } from '@/components/molecules/ValuePropGrid';
@@ -28,7 +29,7 @@ export const metadata: Metadata = buildMetadata({
  */
 export default function HomePage() {
   return (
-    <HomeShell>
+    <HomeShell appSearch={<AppSearchBox audience="home" />}>
       <Hero
         kind="audience-router"
         headline="Intelligent retail, built on Azure's agentic platform."

--- a/apps/ui/components/molecules/AppSearchBox.tsx
+++ b/apps/ui/components/molecules/AppSearchBox.tsx
@@ -140,6 +140,24 @@ export function AppSearchBox({
   const [open, setOpen] = useState(false);
   const [activeIndex, setActiveIndex] = useState(-1);
 
+  // Seed the query from the `?q=` URL parameter (Issue #1022 cross-link
+  // contract). When the mkdocs Material search results page links to
+  // `/?q=<term>`, the home AppSearchBox should pre-populate so the user
+  // continues their search seamlessly. Only runs once on mount; we never
+  // overwrite user typing.
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    const params = new URLSearchParams(window.location.search);
+    const incoming = params.get('q');
+    if (incoming && incoming.length > 0) {
+      setQuery(incoming);
+      setOpen(true);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- mount only
+  }, []);
+
   const allowedAudiences = AUDIENCE_FILTER[audience];
 
   const hits: SearchHit[] = useMemo(

--- a/apps/ui/components/templates/HomeShell.tsx
+++ b/apps/ui/components/templates/HomeShell.tsx
@@ -9,18 +9,27 @@ import { SectionShell } from '../shared/SectionShell';
  *   - `laneSwitch`  : the lane-switch persona toggle (filled by the
  *                     audience-IA persona switcher; never rendered on `/`
  *                     for the audience-router itself)
+ *   - `appSearch`   : the in-app search box (Issue #1022). Rendered in the
+ *                     header so the home page is searchable, with the same
+ *                     cross-link contract to the mkdocs Material search.
  *
- * Adding a fifth shell variant requires amending ADR-034.
+ * Adding a sixth shell variant requires amending ADR-034.
  */
 export type HomeShellProps = {
   children: ReactNode;
   breadcrumb?: ReactNode;
   laneSwitch?: ReactNode;
+  appSearch?: ReactNode;
 };
 
-export function HomeShell({ children, breadcrumb, laneSwitch }: HomeShellProps): ReactElement {
+export function HomeShell({ children, breadcrumb, laneSwitch, appSearch }: HomeShellProps): ReactElement {
   return (
-    <SectionShell variant="home" breadcrumb={breadcrumb} laneSwitch={laneSwitch}>
+    <SectionShell
+      variant="home"
+      breadcrumb={breadcrumb}
+      laneSwitch={laneSwitch}
+      appSearch={appSearch}
+    >
       {children}
     </SectionShell>
   );

--- a/apps/ui/tests/unit/appSearchUrlSeed.test.tsx
+++ b/apps/ui/tests/unit/appSearchUrlSeed.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * Cross-link contract tests (Issue #1022).
+ *
+ * Validates that the reciprocal half of the two-search-box contract is in
+ * place: a `?q=<term>` URL param landing on the home page seeds the
+ * AppSearchBox so the user continues their search seamlessly. The forward
+ * direction (AppSearchBox results → /docs/search/?q=...) is covered by
+ * `appSearchMatcher.test.ts` and `AppSearchBox.test.tsx`.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { AppSearchBox } from '@/components/molecules/AppSearchBox';
+
+describe('AppSearchBox URL ?q= seed (Issue #1022 reciprocal cross-link)', () => {
+  beforeEach(() => {
+    // Reset URL between cases so each test owns its query state.
+    window.history.replaceState({}, '', '/');
+  });
+
+  it('seeds the input when ?q= is present in the URL', () => {
+    window.history.replaceState({}, '', '/?q=architecture');
+    render(<AppSearchBox audience="home" />);
+    const input = screen.getByPlaceholderText(
+      'Search retailers + builders + deploy',
+    ) as HTMLInputElement;
+    expect(input.value).toBe('architecture');
+    // Auto-opens so the user sees results immediately.
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+  });
+
+  it('does not seed when ?q= is empty', () => {
+    window.history.replaceState({}, '', '/?q=');
+    render(<AppSearchBox audience="home" />);
+    const input = screen.getByPlaceholderText(
+      'Search retailers + builders + deploy',
+    ) as HTMLInputElement;
+    expect(input.value).toBe('');
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  it('does not seed when ?q= is absent', () => {
+    window.history.replaceState({}, '', '/');
+    render(<AppSearchBox audience="retailer" />);
+    const input = screen.getByPlaceholderText('Search retailer pages') as HTMLInputElement;
+    expect(input.value).toBe('');
+  });
+
+  it('user typing overrides the seeded value', () => {
+    window.history.replaceState({}, '', '/?q=initial');
+    render(<AppSearchBox audience="home" />);
+    const input = screen.getByPlaceholderText(
+      'Search retailers + builders + deploy',
+    ) as HTMLInputElement;
+    expect(input.value).toBe('initial');
+    fireEvent.change(input, { target: { value: 'overridden' } });
+    expect(input.value).toBe('overridden');
+  });
+});

--- a/mkdocs/mkdocs.yml
+++ b/mkdocs/mkdocs.yml
@@ -7,6 +7,7 @@ site_dir: site
 
 theme:
   name: material
+  custom_dir: overrides
   palette:
     - scheme: default
       primary: deep purple

--- a/mkdocs/overrides/main.html
+++ b/mkdocs/overrides/main.html
@@ -1,0 +1,50 @@
+{#-
+  mkdocs Material `main.html` override (Issue #1022).
+
+  Adds the reciprocal "Search the rest of the site" cross-link required by
+  the two-search-box contract (ADR-034 + capability 42). The corresponding
+  forward-link lives inside the in-app `AppSearchBox` molecule's results
+  popover ("Search the docs →").
+
+  When the user is on a docs page with a `?q=` parameter, the JS snippet
+  rewrites the link target to `/?q=<term>` so the query continues into the
+  home AppSearchBox. The static fallback target is `/` — works without JS,
+  lands on the audience-router home which exposes its own search box.
+
+  Telemetry: `data-telemetry="docs-cross-link-click"` so App Insights can
+  correlate cross-search clicks with the forward direction
+  (`app-search-cross-link-click`).
+-#}
+{% extends "base.html" %}
+
+{% block content %}
+  {{ super() }}
+  <aside class="hp-docs-cross-link" aria-label="Cross-site search">
+    <p>
+      Looking for product, retailer, or builder pages?
+      <a
+        href="/"
+        id="hp-docs-cross-link-anchor"
+        data-telemetry="docs-cross-link-click"
+      >Search the rest of the site →</a>
+    </p>
+  </aside>
+  <script>
+    (function () {
+      var anchor = document.getElementById('hp-docs-cross-link-anchor');
+      if (!anchor) {
+        return;
+      }
+      try {
+        var params = new URLSearchParams(window.location.search);
+        var q = params.get('q');
+        if (q && q.length > 0) {
+          var target = '/?q=' + encodeURIComponent(q);
+          anchor.setAttribute('href', target);
+        }
+      } catch (e) {
+        /* defensive — static '/' fallback already lands on the home shell */
+      }
+    })();
+  </script>
+{% endblock %}

--- a/mkdocs/stylesheets/extra.css
+++ b/mkdocs/stylesheets/extra.css
@@ -20,3 +20,30 @@
 .mermaid {
   text-align: center;
 }
+
+/*
+ * Cross-link footer banner (Issue #1022).
+ *
+ * Renders the reciprocal "Search the rest of the site" link added by
+ * mkdocs/overrides/partials/footer.html. Visually low-key but always
+ * present so docs readers can pivot back to the app's audience-IA pages.
+ */
+.hp-docs-cross-link {
+  margin: 1rem auto 0.5rem;
+  padding: 0.5rem 1rem;
+  max-width: 1440px;
+  border-top: 1px solid var(--md-default-fg-color--lightest);
+  text-align: center;
+  font-size: 0.85rem;
+  color: var(--md-default-fg-color--light);
+}
+
+.hp-docs-cross-link a {
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.hp-docs-cross-link a:hover,
+.hp-docs-cross-link a:focus {
+  text-decoration: underline;
+}


### PR DESCRIPTION
Closes the reciprocal half of the two-search-box contract from PR #1081 (which this stack-PR builds on).

## Forward direction (PR #1081)
`AppSearchBox` results popover → `/docs/search/?q=<term>` (mkdocs Material).

## Reverse direction (this PR)
- **mkdocs Material override** (`mkdocs/overrides/main.html`) injects a 'Search the rest of the site' link into every docs page.
- **JS rewrites** the anchor `href` to `/?q=<term>` when the docs URL carries a `q` param, so the search continues seamlessly into the home AppSearchBox. Static fallback `href='/'` works without JS.
- `mkdocs.yml` gains `theme.custom_dir: overrides`.
- `mkdocs/stylesheets/extra.css` adds `.hp-docs-cross-link` styling using Material's design tokens.

## Home AppSearchBox plumbing
- `HomeShell` exposes `appSearch` slot (mirrors `SectionShell`).
- `app/page.tsx` renders `<AppSearchBox audience='home' />` via the slot, so `/?q=<term>` lands on a page that has the search box visible.
- `AppSearchBox` seeds the input from `window.location.search ?q=` on mount and auto-opens the popover. User typing always overrides the seeded value.

## Acceptance-criteria coverage (Issue #1022)
With PR #1081 + this PR merged, all interactive cross-link criteria pass:
- [x] Search input rendered in section shells for /retailers/* /builders/* /deploy/* (and home).
- [x] AppSearchBox results link → `/docs/search/?q=<term>`.
- [x] mkdocs Material → `/?q=<term>` cross-link (this PR).
- [x] Search input copy clarifies scope.
- [x] Telemetry hooks on cross-search clicks.
- [ ] Pagefind binary integration — deferred to v1.5 follow-up (manifest is forward-compatible).

## Validation
- `yarn type-check` clean.
- `yarn lint` clean (max-warnings 0).
- `yarn test` — 73 suites / **431 tests** passing.
- `yarn test:a11y` — 4 AA cases passing.
- `mkdocs build` emits the `.hp-docs-cross-link` aside on every docs page (verified via grep on `apps/ui/public/docs/index.html`).

## Stack note
Based on **feature/1022-pagefind-app-search** (PR #1081). Will retarget to `main` automatically when #1081 merges, or rebase if needed.