### PR TITLE
fix(crud-service): self-recover from transient postgres pool init errors (#911)

### DIFF
--- a/apps/crud-service/src/crud_service/repositories/base.py
+++ b/apps/crud-service/src/crud_service/repositories/base.py
@@ -290,19 +290,25 @@ class BaseRepository(Generic[T]):
 
     @classmethod
     async def check_pool_health(cls) -> tuple[str, str]:
-        """Return (status, detail) for PostgreSQL pool readiness."""
-        if cls._pool_init_error and cls._pool is None:
-            return "unhealthy", cls._pool_init_error
+        """Return (status, detail) for PostgreSQL pool readiness.
 
+        The check always re-attempts pool initialization when the pool is
+        absent. A previously cached ``_pool_init_error`` (for example, from a
+        transient IMDS hiccup at startup) is reported only when the retry
+        itself fails, so the pod is not bricked into a permanent ``unhealthy``
+        state by a single startup-time failure (#911). On success the cached
+        error is cleared so subsequent checks reflect the current pool state.
+        """
         try:
             if cls._pool is None:
                 await cls.initialize_pool()
             if cls._pool is None:
-                return "unhealthy", "Pool unavailable"
+                return "unhealthy", cls._pool_init_error or "Pool unavailable"
             async with cls._pool.acquire() as conn:
                 await conn.fetchval("SELECT 1")
+            cls._pool_init_error = None
             return "healthy", "query ok"
-        except Exception as exc:
+        except Exception as exc:  # pylint: disable=broad-except
             cls._pool_init_error = f"{type(exc).__name__}: {exc}"
             return "unhealthy", cls._pool_init_error
 

--- a/apps/crud-service/tests/unit/test_base_repository_pool_health.py
+++ b/apps/crud-service/tests/unit/test_base_repository_pool_health.py
@@ -1,0 +1,115 @@
+"""Unit tests for BaseRepository.check_pool_health recovery semantics (#911)."""
+
+import pytest
+from crud_service.repositories.base import BaseRepository
+
+
+class _FakeAcquire:
+    def __init__(self, connection):
+        self._connection = connection
+
+    async def __aenter__(self):
+        return self._connection
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakeConnection:
+    async def fetchval(self, _sql, *_args):
+        return 1
+
+
+class _FakePool:
+    def __init__(self):
+        self._connection = _FakeConnection()
+
+    def acquire(self):
+        return _FakeAcquire(self._connection)
+
+
+@pytest.fixture(autouse=True)
+def _reset_pool_state():
+    """Reset BaseRepository class state between tests so they don't leak."""
+    original_pool = BaseRepository._pool
+    original_error = BaseRepository._pool_init_error
+    BaseRepository._pool = None
+    BaseRepository._pool_init_error = None
+    yield
+    BaseRepository._pool = original_pool
+    BaseRepository._pool_init_error = original_error
+
+
+@pytest.mark.asyncio
+async def test_check_pool_health_returns_healthy_when_pool_already_initialized():
+    """Happy path: pool is up, SELECT 1 succeeds."""
+    BaseRepository._pool = _FakePool()
+    BaseRepository._pool_init_error = None
+
+    status, detail = await BaseRepository.check_pool_health()
+
+    assert status == "healthy"
+    assert detail == "query ok"
+
+
+@pytest.mark.asyncio
+async def test_check_pool_health_clears_stale_init_error_on_successful_retry(monkeypatch):
+    """Regression for #911: a transient startup error must not stick.
+
+    If ``initialize_pool`` failed earlier (cached in ``_pool_init_error``) but a
+    later retry succeeds, the readiness check must report healthy and clear the
+    cached error so subsequent callers see a clean state.
+    """
+    BaseRepository._pool = None
+    BaseRepository._pool_init_error = "TimeoutError: "
+
+    async def _fake_initialize_pool():
+        BaseRepository._pool = _FakePool()
+        BaseRepository._pool_init_error = None
+
+    monkeypatch.setattr(BaseRepository, "initialize_pool", _fake_initialize_pool)
+
+    status, detail = await BaseRepository.check_pool_health()
+
+    assert status == "healthy"
+    assert detail == "query ok"
+    assert BaseRepository._pool_init_error is None
+
+
+@pytest.mark.asyncio
+async def test_check_pool_health_reports_latest_error_when_retry_still_fails(monkeypatch):
+    """When the retry itself raises, the latest exception is reported."""
+    BaseRepository._pool = None
+    BaseRepository._pool_init_error = "TimeoutError: "
+
+    async def _failing_initialize_pool():
+        raise ConnectionError("postgres unreachable")
+
+    monkeypatch.setattr(BaseRepository, "initialize_pool", _failing_initialize_pool)
+
+    status, detail = await BaseRepository.check_pool_health()
+
+    assert status == "unhealthy"
+    assert "ConnectionError" in detail
+    assert "postgres unreachable" in detail
+    assert BaseRepository._pool_init_error == detail
+
+
+@pytest.mark.asyncio
+async def test_check_pool_health_does_not_short_circuit_on_cached_error(monkeypatch):
+    """Regression for #911: a cached error must not bypass the retry."""
+    BaseRepository._pool = None
+    BaseRepository._pool_init_error = "TimeoutError: "
+
+    init_attempts: list[int] = []
+
+    async def _counting_initialize_pool():
+        init_attempts.append(1)
+        BaseRepository._pool = _FakePool()
+        BaseRepository._pool_init_error = None
+
+    monkeypatch.setattr(BaseRepository, "initialize_pool", _counting_initialize_pool)
+
+    await BaseRepository.check_pool_health()
+
+    assert init_attempts == [1], "initialize_pool must be retried even when an error is cached"


### PR DESCRIPTION
## Closes #911

## Live diagnosis

Verified on `holidaypeakhub405-dev-aks` (running cluster):

- Flux GitRepository IS reconciled to current `main@6b75f40d` — the original `commit-rendered-manifests` failure described in #911 is no longer the active blocker.
- `holiday-peak-gitops-holiday-peak-crud` Kustomization is permanently stuck in `Reconciling/Progressing` because the `crud-service` Deployment never goes Ready.
- `holiday-peak-gitops-holiday-peak-agents` Kustomization is `False` with `dependency 'flux-system/holiday-peak-gitops-holiday-peak-crud' is not ready`, so the entire downstream pipeline is gated.
- The CRUD pod runs and `/health` returns 200, but `/ready` returns 503 with:

  ```json
  {"status":"degraded","checks":{"postgres":{"status":"unhealthy","detail":"TimeoutError: ; latest: TimeoutError: "}}}
  ```

- Inside the same pod, a fresh `DefaultAzureCredential` returns a 1980-byte Entra token in <1s and `asyncpg.connect(...)` followed by `SELECT 1` succeeds. **Postgres is reachable; only the in-process pool state is broken.**

## Root cause

`BaseRepository.check_pool_health()` short-circuited on a cached `_pool_init_error`:

```python
if cls._pool_init_error and cls._pool is None:
    return "unhealthy", cls._pool_init_error
```

A single transient IMDS hiccup at startup (`asyncio.TimeoutError`) populated `_pool_init_error` and permanently bricked the readiness check, even though every subsequent retry would have succeeded.

## Fix

`apps/crud-service/src/crud_service/repositories/base.py` — `check_pool_health` now always re-attempts `initialize_pool()` when the pool is absent. The cached error is reported only when the retry itself fails, and is cleared on success.

## Tests

- 4 new unit tests in `apps/crud-service/tests/unit/test_base_repository_pool_health.py`:
  - happy path with initialized pool
  - stale `_pool_init_error` is cleared on successful retry (regression for #911)
  - retry failure reports the latest exception
  - explicit no-short-circuit assertion (`initialize_pool` IS called even when an error is cached)
- All 6 existing `test_health.py` recovery tests continue to pass (`10/10`).
- Full crud-service suite: `265/265`.
- Pre-push gate: `705 passed` across lib + apps; isort/black/pylint/mypy/governance-link/event-schema all green.

## Operational notes

- After merge + redeploy, the cluster operator can restart the deployment to pick up the fix:

  ```
  kubectl rollout restart deployment/crud-service-crud-service -n holiday-peak-crud
  ```

- Once the CRUD pod is Ready, the Flux Kustomization will move to `Ready=True` and the `holiday-peak-agents` Kustomization will unblock automatically.
- The original `commit-rendered-manifests` failure described in #911 is no longer reproducible (Flux is on current `main`); if it returns, that's a separate workflow regression to track in a new issue.

## ADR / governance

- ADR-033 (Flux GitOps deployment model) — fix preserves the readiness contract used by the Kustomization health check (`Wait: true`, `Timeout: 10m0s`).
- No public surface change to `BaseRepository`.
