### PR TITLE
fix(gitops): migrate all 27 services to Flux HelmRelease (Pattern A) and remove commit-rendered-manifests (closes #1088)

### DIFF
--- a/.github/workflows/deploy-azd.yml
+++ b/.github/workflows/deploy-azd.yml
@@ -2057,7 +2057,7 @@ jobs:
           POSTGRES_USER: ${{ needs.provision.outputs.POSTGRES_AUTH_MODE == 'password' && needs.provision.outputs.POSTGRES_ADMIN_USER || needs.provision.outputs.POSTGRES_USER }}
           POSTGRES_DATABASE: ${{ needs.provision.outputs.POSTGRES_DATABASE }}
 
-      - name: Upload rendered CRUD manifest for Flux commit
+      - name: Upload rendered CRUD manifest for verification
         uses: actions/upload-artifact@v4
         with:
           name: rendered-manifest-crud-service
@@ -2710,7 +2710,7 @@ jobs:
           POSTGRES_USER: ${{ needs.provision.outputs.POSTGRES_AUTH_MODE == 'password' && needs.provision.outputs.POSTGRES_ADMIN_USER || needs.provision.outputs.POSTGRES_USER }}
           POSTGRES_DATABASE: ${{ needs.provision.outputs.POSTGRES_DATABASE }}
 
-      - name: Upload rendered agent manifest for Flux commit
+      - name: Upload rendered agent manifest for verification
         if: ${{ success() }}
         uses: actions/upload-artifact@v4
         with:
@@ -2718,83 +2718,21 @@ jobs:
           path: .kubernetes/rendered/${{ matrix.service }}/all.yaml
           retention-days: 1
 
-  commit-rendered-manifests:
-    runs-on: ubuntu-latest
-    if: ${{ always() && !cancelled() && !inputs.uiOnly && (needs.deploy-crud.result == 'success' || needs.deploy-agents.result == 'success') }}
-    needs:
-      - detect-changes
-      - provision
-      - deploy-crud
-      - deploy-agents
-      - build-aks-images
-    permissions:
-      contents: write
-    steps:
-      - name: Resolve publication branch
-        id: publication-branch
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          SOURCE_REF="${DEPLOY_SOURCE_REF}"
-
-          if [[ "$SOURCE_REF" != refs/heads/* ]]; then
-            echo "::error::Rendered manifest publication requires a pushable branch ref, but DEPLOY_SOURCE_REF='$SOURCE_REF'."
-            exit 1
-          fi
-
-          BRANCH_NAME="${SOURCE_REF#refs/heads/}"
-          if [ -z "$BRANCH_NAME" ]; then
-            echo "::error::Rendered manifest publication could not resolve a branch name from DEPLOY_SOURCE_REF='$SOURCE_REF'."
-            exit 1
-          fi
-
-          echo "branch_ref=$SOURCE_REF" >> "$GITHUB_OUTPUT"
-          echo "branch_name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
-
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ steps.publication-branch.outputs.branch_ref }}
-          fetch-depth: 1
-          token: ${{ github.token }}
-
-      - name: Download rendered manifests
-        uses: actions/download-artifact@v4
-        with:
-          pattern: rendered-manifest-*
-          path: ${{ runner.temp }}/rendered-artifacts
-
-      - name: Copy rendered manifests into repo
-        shell: bash
-        run: |
-          set -euo pipefail
-          for artifact_dir in "${RUNNER_TEMP}"/rendered-artifacts/rendered-manifest-*; do
-            [ -d "$artifact_dir" ] || continue
-            svc_name=$(basename "$artifact_dir" | sed 's/^rendered-manifest-//')
-            mkdir -p ".kubernetes/rendered/${svc_name}"
-            cp "${artifact_dir}/all.yaml" ".kubernetes/rendered/${svc_name}/all.yaml"
-            echo "Copied rendered manifest for ${svc_name}"
-          done
-
-      - name: Commit rendered manifests for Flux reconciliation
-        shell: bash
-        run: |
-          set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add .kubernetes/rendered/ || true
-          if git diff --cached --quiet; then
-            echo "No rendered manifest changes to commit."
-            exit 0
-          fi
-          git commit -m "deploy: update rendered manifests [skip ci]"
-          git push origin "HEAD:refs/heads/${{ steps.publication-branch.outputs.branch_name }}"
+  # NOTE (ADR-017 amendment, Pattern A): the previous `commit-rendered-manifests`
+  # job was deleted because it pushed bot-generated manifests directly to
+  # `refs/heads/main`, which is rejected by the `main-governance-baseline`
+  # ruleset (GH013). Flux now reconciles HelmRelease CRDs from
+  # `.kubernetes/releases/{crud,agents}` and the helm-controller renders the
+  # chart in-cluster on every reconciliation, so no workflow push to main is
+  # ever required. Image tag updates remain a follow-up (planned: Flux
+  # ImageUpdateAutomation with PR bridge).
 
   wait-flux-reconciliation:
     runs-on: ubuntu-latest
-    if: ${{ !inputs.uiOnly && (needs.commit-rendered-manifests.result == 'success') }}
+    if: ${{ always() && !cancelled() && !inputs.uiOnly && (needs.deploy-crud.result == 'success' || needs.deploy-agents.result == 'success') }}
     needs:
-      - commit-rendered-manifests
+      - deploy-crud
+      - deploy-agents
       - detect-changes
     environment: ${{ inputs.githubEnvironment }}
     env:
@@ -4203,7 +4141,6 @@ jobs:
       - detect-changes
       - deploy-crud
       - deploy-agents
-      - commit-rendered-manifests
       - wait-flux-reconciliation
       - sync-apim
       - sync-apic
@@ -4299,7 +4236,6 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ always() && !cancelled() && !inputs.uiOnly }}
     needs:
-      - commit-rendered-manifests
       - wait-flux-reconciliation
       - validate-agc-readiness
       - sync-apim

--- a/.infra/modules/shared-infrastructure/shared-infrastructure.bicep
+++ b/.infra/modules/shared-infrastructure/shared-infrastructure.bicep
@@ -1218,7 +1218,9 @@ resource fluxExtension 'Microsoft.KubernetesConfiguration/extensions@2023-05-01'
   }
 }
 
-// Flux GitOps configuration — reconciles rendered manifests from the repository.
+// Flux GitOps configuration — reconciles HelmRelease CRDs from the repository.
+// Pattern A (ADR-017 amended): the helm-controller renders the chart in-cluster on
+// every reconciliation, so no workflow ever pushes rendered YAML back to main.
 resource fluxConfig 'Microsoft.KubernetesConfiguration/fluxConfigurations@2024-04-01-preview' = {
   name: 'holiday-peak-gitops'
   scope: aksClusterResource
@@ -1239,7 +1241,7 @@ resource fluxConfig 'Microsoft.KubernetesConfiguration/fluxConfigurations@2024-0
     }
     kustomizations: {
       'holiday-peak-crud': {
-        path: '.kubernetes/rendered/crud'
+        path: '.kubernetes/releases/crud'
         syncIntervalInSeconds: 300
         timeoutInSeconds: 600
         prune: true
@@ -1247,7 +1249,7 @@ resource fluxConfig 'Microsoft.KubernetesConfiguration/fluxConfigurations@2024-0
         dependsOn: []
       }
       'holiday-peak-agents': {
-        path: '.kubernetes/rendered/agents'
+        path: '.kubernetes/releases/agents'
         syncIntervalInSeconds: 300
         timeoutInSeconds: 600
         prune: true

--- a/.kubernetes/releases/agents/crm-campaign-intelligence.yaml
+++ b/.kubernetes/releases/agents/crm-campaign-intelligence.yaml
@@ -1,0 +1,105 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: crm-campaign-intelligence
+  namespace: flux-system
+spec:
+  targetNamespace: holiday-peak-agents
+  releaseName: crm-campaign-intelligence
+  interval: 5m
+  timeout: 10m
+  chart:
+    spec:
+      chart: .kubernetes/chart
+      sourceRef:
+        kind: GitRepository
+        name: holiday-peak-gitops
+        namespace: flux-system
+      interval: 5m
+  upgrade:
+    remediation:
+      retries: 3
+  install:
+    createNamespace: false
+    remediation:
+      retries: 3
+  values:
+    serviceName: crm-campaign-intelligence
+    serviceAccount:
+      create: true
+      clientId: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
+    image:
+      repository: holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/crm-campaign-intelligence-dev
+      tag: azd-deploy-1775344528
+    replicaCount: 2
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 250m
+        memory: 256Mi
+    nodeSelector:
+      agentpool: agents
+    tolerations:
+    - effect: NoSchedule
+      key: workload
+      operator: Equal
+      value: agents
+    availability:
+      strategy:
+        type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 25%
+        maxSurge: 25%
+    pdb:
+      enabled: false
+    keda:
+      enabled: false
+    agc:
+      enabled: true
+      gatewayClassName: azure-alb-external
+      hostnames:
+      - esbcc8bcfyazbbdg.fz03.alb.azure.com
+      parentRefs:
+      - name: holiday-peak-agc
+        namespace: holiday-peak-crud
+      paths:
+      - path: /crm-campaign-intelligence
+        pathType: PathPrefix
+        rewriteTo: /
+    env:
+      AI_SEARCH_AUTH_MODE: managed_identity
+      AI_SEARCH_ENDPOINT: https://holidaypeakhub405devsearch.search.windows.net
+      AI_SEARCH_INDEX: catalog-products
+      AI_SEARCH_INDEXER_NAME: search-enriched-products-indexer
+      AI_SEARCH_VECTOR_INDEX: product_search_index
+      APPLICATIONINSIGHTS_CONNECTION_STRING: InstrumentationKey=d2fb45bc-e648-4da2-9345-d278636aede5;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=d8eb64c4-956d-46ab-a02e-d481deadaa0b
+      AZURE_CLIENT_ID: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
+      AZURE_TENANT_ID: 16b3c013-d300-468d-ac64-7eda0820b6d3
+      BLOB_ACCOUNT_URL: https://holidaypeakhub405devstor.blob.core.windows.net
+      BLOB_CONTAINER: agent-memory
+      CATALOG_SEARCH_REQUIRE_AI_SEARCH: 'true'
+      COSMOS_ACCOUNT_URI: https://holidaypeakhub405-dev-cosmos.documents.azure.com:443/
+      COSMOS_CONTAINER: agent-memory
+      COSMOS_DATABASE: holiday-peak-db
+      EMBEDDING_DEPLOYMENT_NAME: text-embedding-3-large
+      EVENT_HUB_NAMESPACE: holidaypeakhub405-dev-eventhub
+      FOUNDRY_AGENT_NAME_FAST: crm-campaign-intelligence-fast
+      FOUNDRY_AGENT_NAME_RICH: crm-campaign-intelligence-rich
+      FOUNDRY_AUTO_ENSURE_ON_STARTUP: 'true'
+      FOUNDRY_STREAM: 'true'
+      AGENT_FOUNDRY_INVOKE_TIMEOUT_SECONDS: '60'
+      FOUNDRY_STRICT_ENFORCEMENT: 'false'
+      KEY_VAULT_URI: https://holidaypeakhub405-dev-kv.vault.azure.net/
+      MODEL_DEPLOYMENT_NAME_FAST: gpt-5-nano
+      MODEL_DEPLOYMENT_NAME_RICH: gpt-5
+      POSTGRES_AUTH_MODE: entra
+      POSTGRES_DATABASE: holiday_peak_crud
+      POSTGRES_HOST: holidaypeakhub405-dev-postgres.postgres.database.azure.com
+      POSTGRES_SSL: 'true'
+      POSTGRES_USER: holidaypeakhub405-dev-crud-identity
+      PROJECT_ENDPOINT: https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris
+      PROJECT_NAME: aipholidaris
+      REDIS_HOST: holidaypeakhub405-dev-redis.redis.cache.windows.net
+      REDIS_PASSWORD_SECRET_NAME: redis-primary-key

--- a/.kubernetes/releases/agents/crm-profile-aggregation.yaml
+++ b/.kubernetes/releases/agents/crm-profile-aggregation.yaml
@@ -1,0 +1,105 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: crm-profile-aggregation
+  namespace: flux-system
+spec:
+  targetNamespace: holiday-peak-agents
+  releaseName: crm-profile-aggregation
+  interval: 5m
+  timeout: 10m
+  chart:
+    spec:
+      chart: .kubernetes/chart
+      sourceRef:
+        kind: GitRepository
+        name: holiday-peak-gitops
+        namespace: flux-system
+      interval: 5m
+  upgrade:
+    remediation:
+      retries: 3
+  install:
+    createNamespace: false
+    remediation:
+      retries: 3
+  values:
+    serviceName: crm-profile-aggregation
+    serviceAccount:
+      create: true
+      clientId: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
+    image:
+      repository: holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/crm-profile-aggregation-dev
+      tag: azd-deploy-1775344626
+    replicaCount: 2
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 250m
+        memory: 256Mi
+    nodeSelector:
+      agentpool: agents
+    tolerations:
+    - effect: NoSchedule
+      key: workload
+      operator: Equal
+      value: agents
+    availability:
+      strategy:
+        type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 25%
+        maxSurge: 25%
+    pdb:
+      enabled: false
+    keda:
+      enabled: false
+    agc:
+      enabled: true
+      gatewayClassName: azure-alb-external
+      hostnames:
+      - esbcc8bcfyazbbdg.fz03.alb.azure.com
+      parentRefs:
+      - name: holiday-peak-agc
+        namespace: holiday-peak-crud
+      paths:
+      - path: /crm-profile-aggregation
+        pathType: PathPrefix
+        rewriteTo: /
+    env:
+      AI_SEARCH_AUTH_MODE: managed_identity
+      AI_SEARCH_ENDPOINT: https://holidaypeakhub405devsearch.search.windows.net
+      AI_SEARCH_INDEX: catalog-products
+      AI_SEARCH_INDEXER_NAME: search-enriched-products-indexer
+      AI_SEARCH_VECTOR_INDEX: product_search_index
+      APPLICATIONINSIGHTS_CONNECTION_STRING: InstrumentationKey=d2fb45bc-e648-4da2-9345-d278636aede5;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=d8eb64c4-956d-46ab-a02e-d481deadaa0b
+      AZURE_CLIENT_ID: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
+      AZURE_TENANT_ID: 16b3c013-d300-468d-ac64-7eda0820b6d3
+      BLOB_ACCOUNT_URL: https://holidaypeakhub405devstor.blob.core.windows.net
+      BLOB_CONTAINER: agent-memory
+      CATALOG_SEARCH_REQUIRE_AI_SEARCH: 'true'
+      COSMOS_ACCOUNT_URI: https://holidaypeakhub405-dev-cosmos.documents.azure.com:443/
+      COSMOS_CONTAINER: agent-memory
+      COSMOS_DATABASE: holiday-peak-db
+      EMBEDDING_DEPLOYMENT_NAME: text-embedding-3-large
+      EVENT_HUB_NAMESPACE: holidaypeakhub405-dev-eventhub
+      FOUNDRY_AGENT_NAME_FAST: crm-profile-aggregation-fast
+      FOUNDRY_AGENT_NAME_RICH: crm-profile-aggregation-rich
+      FOUNDRY_AUTO_ENSURE_ON_STARTUP: 'true'
+      FOUNDRY_STREAM: 'true'
+      AGENT_FOUNDRY_INVOKE_TIMEOUT_SECONDS: '60'
+      FOUNDRY_STRICT_ENFORCEMENT: 'false'
+      KEY_VAULT_URI: https://holidaypeakhub405-dev-kv.vault.azure.net/
+      MODEL_DEPLOYMENT_NAME_FAST: gpt-5-nano
+      MODEL_DEPLOYMENT_NAME_RICH: gpt-5
+      POSTGRES_AUTH_MODE: entra
+      POSTGRES_DATABASE: holiday_peak_crud
+      POSTGRES_HOST: holidaypeakhub405-dev-postgres.postgres.database.azure.com
+      POSTGRES_SSL: 'true'
+      POSTGRES_USER: holidaypeakhub405-dev-crud-identity
+      PROJECT_ENDPOINT: https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris
+      PROJECT_NAME: aipholidaris
+      REDIS_HOST: holidaypeakhub405-dev-redis.redis.cache.windows.net
+      REDIS_PASSWORD_SECRET_NAME: redis-primary-key

--- a/.kubernetes/releases/agents/crm-segmentation-personalization.yaml
+++ b/.kubernetes/releases/agents/crm-segmentation-personalization.yaml
@@ -1,0 +1,105 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: crm-segmentation-personalization
+  namespace: flux-system
+spec:
+  targetNamespace: holiday-peak-agents
+  releaseName: crm-segmentation-personalization
+  interval: 5m
+  timeout: 10m
+  chart:
+    spec:
+      chart: .kubernetes/chart
+      sourceRef:
+        kind: GitRepository
+        name: holiday-peak-gitops
+        namespace: flux-system
+      interval: 5m
+  upgrade:
+    remediation:
+      retries: 3
+  install:
+    createNamespace: false
+    remediation:
+      retries: 3
+  values:
+    serviceName: crm-segmentation-personalization
+    serviceAccount:
+      create: true
+      clientId: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
+    image:
+      repository: holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/crm-segmentation-personalization-dev
+      tag: azd-deploy-1775344793
+    replicaCount: 2
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 250m
+        memory: 256Mi
+    nodeSelector:
+      agentpool: agents
+    tolerations:
+    - effect: NoSchedule
+      key: workload
+      operator: Equal
+      value: agents
+    availability:
+      strategy:
+        type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 25%
+        maxSurge: 25%
+    pdb:
+      enabled: false
+    keda:
+      enabled: false
+    agc:
+      enabled: true
+      gatewayClassName: azure-alb-external
+      hostnames:
+      - esbcc8bcfyazbbdg.fz03.alb.azure.com
+      parentRefs:
+      - name: holiday-peak-agc
+        namespace: holiday-peak-crud
+      paths:
+      - path: /crm-segmentation-personalization
+        pathType: PathPrefix
+        rewriteTo: /
+    env:
+      AI_SEARCH_AUTH_MODE: managed_identity
+      AI_SEARCH_ENDPOINT: https://holidaypeakhub405devsearch.search.windows.net
+      AI_SEARCH_INDEX: catalog-products
+      AI_SEARCH_INDEXER_NAME: search-enriched-products-indexer
+      AI_SEARCH_VECTOR_INDEX: product_search_index
+      APPLICATIONINSIGHTS_CONNECTION_STRING: InstrumentationKey=d2fb45bc-e648-4da2-9345-d278636aede5;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=d8eb64c4-956d-46ab-a02e-d481deadaa0b
+      AZURE_CLIENT_ID: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
+      AZURE_TENANT_ID: 16b3c013-d300-468d-ac64-7eda0820b6d3
+      BLOB_ACCOUNT_URL: https://holidaypeakhub405devstor.blob.core.windows.net
+      BLOB_CONTAINER: agent-memory
+      CATALOG_SEARCH_REQUIRE_AI_SEARCH: 'true'
+      COSMOS_ACCOUNT_URI: https://holidaypeakhub405-dev-cosmos.documents.azure.com:443/
+      COSMOS_CONTAINER: agent-memory
+      COSMOS_DATABASE: holiday-peak-db
+      EMBEDDING_DEPLOYMENT_NAME: text-embedding-3-large
+      EVENT_HUB_NAMESPACE: holidaypeakhub405-dev-eventhub
+      FOUNDRY_AGENT_NAME_FAST: crm-segmentation-personalization-fast
+      FOUNDRY_AGENT_NAME_RICH: crm-segmentation-personalization-rich
+      FOUNDRY_AUTO_ENSURE_ON_STARTUP: 'true'
+      FOUNDRY_STREAM: 'true'
+      AGENT_FOUNDRY_INVOKE_TIMEOUT_SECONDS: '60'
+      FOUNDRY_STRICT_ENFORCEMENT: 'false'
+      KEY_VAULT_URI: https://holidaypeakhub405-dev-kv.vault.azure.net/
+      MODEL_DEPLOYMENT_NAME_FAST: gpt-5-nano
+      MODEL_DEPLOYMENT_NAME_RICH: gpt-5
+      POSTGRES_AUTH_MODE: entra
+      POSTGRES_DATABASE: holiday_peak_crud
+      POSTGRES_HOST: holidaypeakhub405-dev-postgres.postgres.database.azure.com
+      POSTGRES_SSL: 'true'
+      POSTGRES_USER: holidaypeakhub405-dev-crud-identity
+      PROJECT_ENDPOINT: https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris
+      PROJECT_NAME: aipholidaris
+      REDIS_HOST: holidaypeakhub405-dev-redis.redis.cache.windows.net
+      REDIS_PASSWORD_SECRET_NAME: redis-primary-key

--- a/.kubernetes/releases/agents/crm-support-assistance.yaml
+++ b/.kubernetes/releases/agents/crm-support-assistance.yaml
@@ -1,0 +1,105 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: crm-support-assistance
+  namespace: flux-system
+spec:
+  targetNamespace: holiday-peak-agents
+  releaseName: crm-support-assistance
+  interval: 5m
+  timeout: 10m
+  chart:
+    spec:
+      chart: .kubernetes/chart
+      sourceRef:
+        kind: GitRepository
+        name: holiday-peak-gitops
+        namespace: flux-system
+      interval: 5m
+  upgrade:
+    remediation:
+      retries: 3
+  install:
+    createNamespace: false
+    remediation:
+      retries: 3
+  values:
+    serviceName: crm-support-assistance
+    serviceAccount:
+      create: true
+      clientId: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
+    image:
+      repository: holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/crm-support-assistance-dev
+      tag: azd-deploy-1775345018
+    replicaCount: 2
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 250m
+        memory: 256Mi
+    nodeSelector:
+      agentpool: agents
+    tolerations:
+    - effect: NoSchedule
+      key: workload
+      operator: Equal
+      value: agents
+    availability:
+      strategy:
+        type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 25%
+        maxSurge: 25%
+    pdb:
+      enabled: false
+    keda:
+      enabled: false
+    agc:
+      enabled: true
+      gatewayClassName: azure-alb-external
+      hostnames:
+      - esbcc8bcfyazbbdg.fz03.alb.azure.com
+      parentRefs:
+      - name: holiday-peak-agc
+        namespace: holiday-peak-crud
+      paths:
+      - path: /crm-support-assistance
+        pathType: PathPrefix
+        rewriteTo: /
+    env:
+      AI_SEARCH_AUTH_MODE: managed_identity
+      AI_SEARCH_ENDPOINT: https://holidaypeakhub405devsearch.search.windows.net
+      AI_SEARCH_INDEX: catalog-products
+      AI_SEARCH_INDEXER_NAME: search-enriched-products-indexer
+      AI_SEARCH_VECTOR_INDEX: product_search_index
+      APPLICATIONINSIGHTS_CONNECTION_STRING: InstrumentationKey=d2fb45bc-e648-4da2-9345-d278636aede5;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=d8eb64c4-956d-46ab-a02e-d481deadaa0b
+      AZURE_CLIENT_ID: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
+      AZURE_TENANT_ID: 16b3c013-d300-468d-ac64-7eda0820b6d3
+      BLOB_ACCOUNT_URL: https://holidaypeakhub405devstor.blob.core.windows.net
+      BLOB_CONTAINER: agent-memory
+      CATALOG_SEARCH_REQUIRE_AI_SEARCH: 'true'
+      COSMOS_ACCOUNT_URI: https://holidaypeakhub405-dev-cosmos.documents.azure.com:443/
+      COSMOS_CONTAINER: agent-memory
+      COSMOS_DATABASE: holiday-peak-db
+      EMBEDDING_DEPLOYMENT_NAME: text-embedding-3-large
+      EVENT_HUB_NAMESPACE: holidaypeakhub405-dev-eventhub
+      FOUNDRY_AGENT_NAME_FAST: crm-support-assistance-fast
+      FOUNDRY_AGENT_NAME_RICH: crm-support-assistance-rich
+      FOUNDRY_AUTO_ENSURE_ON_STARTUP: 'true'
+      FOUNDRY_STREAM: 'true'
+      AGENT_FOUNDRY_INVOKE_TIMEOUT_SECONDS: '60'
+      FOUNDRY_STRICT_ENFORCEMENT: 'false'
+      KEY_VAULT_URI: https://holidaypeakhub405-dev-kv.vault.azure.net/
+      MODEL_DEPLOYMENT_NAME_FAST: gpt-5-nano
+      MODEL_DEPLOYMENT_NAME_RICH: gpt-5
+      POSTGRES_AUTH_MODE: entra
+      POSTGRES_DATABASE: holiday_peak_crud
+      POSTGRES_HOST: holidaypeakhub405-dev-postgres.postgres.database.azure.com
+      POSTGRES_SSL: 'true'
+      POSTGRES_USER: holidaypeakhub405-dev-crud-identity
+      PROJECT_ENDPOINT: https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris
+      PROJECT_NAME: aipholidaris
+      REDIS_HOST: holidaypeakhub405-dev-redis.redis.cache.windows.net
+      REDIS_PASSWORD_SECRET_NAME: redis-primary-key

--- a/.kubernetes/releases/agents/ecommerce-cart-intelligence.yaml
+++ b/.kubernetes/releases/agents/ecommerce-cart-intelligence.yaml
@@ -1,0 +1,105 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ecommerce-cart-intelligence
+  namespace: flux-system
+spec:
+  targetNamespace: holiday-peak-agents
+  releaseName: ecommerce-cart-intelligence
+  interval: 5m
+  timeout: 10m
+  chart:
+    spec:
+      chart: .kubernetes/chart
+      sourceRef:
+        kind: GitRepository
+        name: holiday-peak-gitops
+        namespace: flux-system
+      interval: 5m
+  upgrade:
+    remediation:
+      retries: 3
+  install:
+    createNamespace: false
+    remediation:
+      retries: 3
+  values:
+    serviceName: ecommerce-cart-intelligence
+    serviceAccount:
+      create: true
+      clientId: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
+    image:
+      repository: holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/ecommerce-cart-intelligence-dev
+      tag: azd-deploy-1775345183
+    replicaCount: 2
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 250m
+        memory: 256Mi
+    nodeSelector:
+      agentpool: agents
+    tolerations:
+    - effect: NoSchedule
+      key: workload
+      operator: Equal
+      value: agents
+    availability:
+      strategy:
+        type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 25%
+        maxSurge: 25%
+    pdb:
+      enabled: false
+    keda:
+      enabled: false
+    agc:
+      enabled: true
+      gatewayClassName: azure-alb-external
+      hostnames:
+      - esbcc8bcfyazbbdg.fz03.alb.azure.com
+      parentRefs:
+      - name: holiday-peak-agc
+        namespace: holiday-peak-crud
+      paths:
+      - path: /ecommerce-cart-intelligence
+        pathType: PathPrefix
+        rewriteTo: /
+    env:
+      AI_SEARCH_AUTH_MODE: managed_identity
+      AI_SEARCH_ENDPOINT: https://holidaypeakhub405devsearch.search.windows.net
+      AI_SEARCH_INDEX: catalog-products
+      AI_SEARCH_INDEXER_NAME: search-enriched-products-indexer
+      AI_SEARCH_VECTOR_INDEX: product_search_index
+      APPLICATIONINSIGHTS_CONNECTION_STRING: InstrumentationKey=d2fb45bc-e648-4da2-9345-d278636aede5;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=d8eb64c4-956d-46ab-a02e-d481deadaa0b
+      AZURE_CLIENT_ID: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
+      AZURE_TENANT_ID: 16b3c013-d300-468d-ac64-7eda0820b6d3
+      BLOB_ACCOUNT_URL: https://holidaypeakhub405devstor.blob.core.windows.net
+      BLOB_CONTAINER: agent-memory
+      CATALOG_SEARCH_REQUIRE_AI_SEARCH: 'true'
+      COSMOS_ACCOUNT_URI: https://holidaypeakhub405-dev-cosmos.documents.azure.com:443/
+      COSMOS_CONTAINER: agent-memory
+      COSMOS_DATABASE: holiday-peak-db
+      EMBEDDING_DEPLOYMENT_NAME: text-embedding-3-large
+      EVENT_HUB_NAMESPACE: holidaypeakhub405-dev-eventhub
+      FOUNDRY_AGENT_NAME_FAST: ecommerce-cart-intelligence-fast
+      FOUNDRY_AGENT_NAME_RICH: ecommerce-cart-intelligence-rich
+      FOUNDRY_AUTO_ENSURE_ON_STARTUP: 'true'
+      FOUNDRY_STREAM: 'true'
+      AGENT_FOUNDRY_INVOKE_TIMEOUT_SECONDS: '60'
+      FOUNDRY_STRICT_ENFORCEMENT: 'false'
+      KEY_VAULT_URI: https://holidaypeakhub405-dev-kv.vault.azure.net/
+      MODEL_DEPLOYMENT_NAME_FAST: gpt-5-nano
+      MODEL_DEPLOYMENT_NAME_RICH: gpt-5
+      POSTGRES_AUTH_MODE: entra
+      POSTGRES_DATABASE: holiday_peak_crud
+      POSTGRES_HOST: holidaypeakhub405-dev-postgres.postgres.database.azure.com
+      POSTGRES_SSL: 'true'
+      POSTGRES_USER: holidaypeakhub405-dev-crud-identity
+      PROJECT_ENDPOINT: https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris
+      PROJECT_NAME: aipholidaris
+      REDIS_HOST: holidaypeakhub405-dev-redis.redis.cache.windows.net
+      REDIS_PASSWORD_SECRET_NAME: redis-primary-key

--- a/.kubernetes/releases/agents/ecommerce-checkout-support.yaml
+++ b/.kubernetes/releases/agents/ecommerce-checkout-support.yaml
@@ -1,0 +1,105 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ecommerce-checkout-support
+  namespace: flux-system
+spec:
+  targetNamespace: holiday-peak-agents
+  releaseName: ecommerce-checkout-support
+  interval: 5m
+  timeout: 10m
+  chart:
+    spec:
+      chart: .kubernetes/chart
+      sourceRef:
+        kind: GitRepository
+        name: holiday-peak-gitops
+        namespace: flux-system
+      interval: 5m
+  upgrade:
+    remediation:
+      retries: 3
+  install:
+    createNamespace: false
+    remediation:
+      retries: 3
+  values:
+    serviceName: ecommerce-checkout-support
+    serviceAccount:
+      create: true
+      clientId: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
+    image:
+      repository: holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/ecommerce-checkout-support-dev
+      tag: azd-deploy-1775345620
+    replicaCount: 2
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 250m
+        memory: 256Mi
+    nodeSelector:
+      agentpool: agents
+    tolerations:
+    - effect: NoSchedule
+      key: workload
+      operator: Equal
+      value: agents
+    availability:
+      strategy:
+        type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 25%
+        maxSurge: 25%
+    pdb:
+      enabled: false
+    keda:
+      enabled: false
+    agc:
+      enabled: true
+      gatewayClassName: azure-alb-external
+      hostnames:
+      - esbcc8bcfyazbbdg.fz03.alb.azure.com
+      parentRefs:
+      - name: holiday-peak-agc
+        namespace: holiday-peak-crud
+      paths:
+      - path: /ecommerce-checkout-support
+        pathType: PathPrefix
+        rewriteTo: /
+    env:
+      AI_SEARCH_AUTH_MODE: managed_identity
+      AI_SEARCH_ENDPOINT: https://holidaypeakhub405devsearch.search.windows.net
+      AI_SEARCH_INDEX: catalog-products
+      AI_SEARCH_INDEXER_NAME: search-enriched-products-indexer
+      AI_SEARCH_VECTOR_INDEX: product_search_index
+      APPLICATIONINSIGHTS_CONNECTION_STRING: InstrumentationKey=d2fb45bc-e648-4da2-9345-d278636aede5;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=d8eb64c4-956d-46ab-a02e-d481deadaa0b
+      AZURE_CLIENT_ID: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
+      AZURE_TENANT_ID: 16b3c013-d300-468d-ac64-7eda0820b6d3
+      BLOB_ACCOUNT_URL: https://holidaypeakhub405devstor.blob.core.windows.net
+      BLOB_CONTAINER: agent-memory
+      CATALOG_SEARCH_REQUIRE_AI_SEARCH: 'true'
+      COSMOS_ACCOUNT_URI: https://holidaypeakhub405-dev-cosmos.documents.azure.com:443/
+      COSMOS_CONTAINER: agent-memory
+      COSMOS_DATABASE: holiday-peak-db
+      EMBEDDING_DEPLOYMENT_NAME: text-embedding-3-large
+      EVENT_HUB_NAMESPACE: holidaypeakhub405-dev-eventhub
+      FOUNDRY_AGENT_NAME_FAST: ecommerce-checkout-support-fast
+      FOUNDRY_AGENT_NAME_RICH: ecommerce-checkout-support-rich
+      FOUNDRY_AUTO_ENSURE_ON_STARTUP: 'true'
+      FOUNDRY_STREAM: 'true'
+      AGENT_FOUNDRY_INVOKE_TIMEOUT_SECONDS: '60'
+      FOUNDRY_STRICT_ENFORCEMENT: 'false'
+      KEY_VAULT_URI: https://holidaypeakhub405-dev-kv.vault.azure.net/
+      MODEL_DEPLOYMENT_NAME_FAST: gpt-5-nano
+      MODEL_DEPLOYMENT_NAME_RICH: gpt-5
+      POSTGRES_AUTH_MODE: entra
+      POSTGRES_DATABASE: holiday_peak_crud
+      POSTGRES_HOST: holidaypeakhub405-dev-postgres.postgres.database.azure.com
+      POSTGRES_SSL: 'true'
+      POSTGRES_USER: holidaypeakhub405-dev-crud-identity
+      PROJECT_ENDPOINT: https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris
+      PROJECT_NAME: aipholidaris
+      REDIS_HOST: holidaypeakhub405-dev-redis.redis.cache.windows.net
+      REDIS_PASSWORD_SECRET_NAME: redis-primary-key

--- a/.kubernetes/releases/agents/ecommerce-order-status.yaml
+++ b/.kubernetes/releases/agents/ecommerce-order-status.yaml
@@ -1,0 +1,105 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ecommerce-order-status
+  namespace: flux-system
+spec:
+  targetNamespace: holiday-peak-agents
+  releaseName: ecommerce-order-status
+  interval: 5m
+  timeout: 10m
+  chart:
+    spec:
+      chart: .kubernetes/chart
+      sourceRef:
+        kind: GitRepository
+        name: holiday-peak-gitops
+        namespace: flux-system
+      interval: 5m
+  upgrade:
+    remediation:
+      retries: 3
+  install:
+    createNamespace: false
+    remediation:
+      retries: 3
+  values:
+    serviceName: ecommerce-order-status
+    serviceAccount:
+      create: true
+      clientId: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
+    image:
+      repository: holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/ecommerce-order-status-dev
+      tag: azd-deploy-1775345850
+    replicaCount: 2
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 250m
+        memory: 256Mi
+    nodeSelector:
+      agentpool: agents
+    tolerations:
+    - effect: NoSchedule
+      key: workload
+      operator: Equal
+      value: agents
+    availability:
+      strategy:
+        type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 25%
+        maxSurge: 25%
+    pdb:
+      enabled: false
+    keda:
+      enabled: false
+    agc:
+      enabled: true
+      gatewayClassName: azure-alb-external
+      hostnames:
+      - esbcc8bcfyazbbdg.fz03.alb.azure.com
+      parentRefs:
+      - name: holiday-peak-agc
+        namespace: holiday-peak-crud
+      paths:
+      - path: /ecommerce-order-status
+        pathType: PathPrefix
+        rewriteTo: /
+    env:
+      AI_SEARCH_AUTH_MODE: managed_identity
+      AI_SEARCH_ENDPOINT: https://holidaypeakhub405devsearch.search.windows.net
+      AI_SEARCH_INDEX: catalog-products
+      AI_SEARCH_INDEXER_NAME: search-enriched-products-indexer
+      AI_SEARCH_VECTOR_INDEX: product_search_index
+      APPLICATIONINSIGHTS_CONNECTION_STRING: InstrumentationKey=d2fb45bc-e648-4da2-9345-d278636aede5;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=d8eb64c4-956d-46ab-a02e-d481deadaa0b
+      AZURE_CLIENT_ID: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
+      AZURE_TENANT_ID: 16b3c013-d300-468d-ac64-7eda0820b6d3
+      BLOB_ACCOUNT_URL: https://holidaypeakhub405devstor.blob.core.windows.net
+      BLOB_CONTAINER: agent-memory
+      CATALOG_SEARCH_REQUIRE_AI_SEARCH: 'true'
+      COSMOS_ACCOUNT_URI: https://holidaypeakhub405-dev-cosmos.documents.azure.com:443/
+      COSMOS_CONTAINER: agent-memory
+      COSMOS_DATABASE: holiday-peak-db
+      EMBEDDING_DEPLOYMENT_NAME: text-embedding-3-large
+      EVENT_HUB_NAMESPACE: holidaypeakhub405-dev-eventhub
+      FOUNDRY_AGENT_NAME_FAST: ecommerce-order-status-fast
+      FOUNDRY_AGENT_NAME_RICH: ecommerce-order-status-rich
+      FOUNDRY_AUTO_ENSURE_ON_STARTUP: 'true'
+      FOUNDRY_STREAM: 'true'
+      AGENT_FOUNDRY_INVOKE_TIMEOUT_SECONDS: '60'
+      FOUNDRY_STRICT_ENFORCEMENT: 'false'
+      KEY_VAULT_URI: https://holidaypeakhub405-dev-kv.vault.azure.net/
+      MODEL_DEPLOYMENT_NAME_FAST: gpt-5-nano
+      MODEL_DEPLOYMENT_NAME_RICH: gpt-5
+      POSTGRES_AUTH_MODE: entra
+      POSTGRES_DATABASE: holiday_peak_crud
+      POSTGRES_HOST: holidaypeakhub405-dev-postgres.postgres.database.azure.com
+      POSTGRES_SSL: 'true'
+      POSTGRES_USER: holidaypeakhub405-dev-crud-identity
+      PROJECT_ENDPOINT: https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris
+      PROJECT_NAME: aipholidaris
+      REDIS_HOST: holidaypeakhub405-dev-redis.redis.cache.windows.net
+      REDIS_PASSWORD_SECRET_NAME: redis-primary-key

--- a/.kubernetes/releases/agents/ecommerce-product-detail-enrichment.yaml
+++ b/.kubernetes/releases/agents/ecommerce-product-detail-enrichment.yaml
@@ -1,0 +1,105 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ecommerce-product-detail-enrichment
+  namespace: flux-system
+spec:
+  targetNamespace: holiday-peak-agents
+  releaseName: ecommerce-product-detail-enrichment
+  interval: 5m
+  timeout: 10m
+  chart:
+    spec:
+      chart: .kubernetes/chart
+      sourceRef:
+        kind: GitRepository
+        name: holiday-peak-gitops
+        namespace: flux-system
+      interval: 5m
+  upgrade:
+    remediation:
+      retries: 3
+  install:
+    createNamespace: false
+    remediation:
+      retries: 3
+  values:
+    serviceName: ecommerce-product-detail-enrichment
+    serviceAccount:
+      create: true
+      clientId: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
+    image:
+      repository: holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/ecommerce-product-detail-enrichment-dev
+      tag: azd-deploy-1775346091
+    replicaCount: 2
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 250m
+        memory: 256Mi
+    nodeSelector:
+      agentpool: agents
+    tolerations:
+    - effect: NoSchedule
+      key: workload
+      operator: Equal
+      value: agents
+    availability:
+      strategy:
+        type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 25%
+        maxSurge: 25%
+    pdb:
+      enabled: false
+    keda:
+      enabled: false
+    agc:
+      enabled: true
+      gatewayClassName: azure-alb-external
+      hostnames:
+      - esbcc8bcfyazbbdg.fz03.alb.azure.com
+      parentRefs:
+      - name: holiday-peak-agc
+        namespace: holiday-peak-crud
+      paths:
+      - path: /ecommerce-product-detail-enrichment
+        pathType: PathPrefix
+        rewriteTo: /
+    env:
+      AI_SEARCH_AUTH_MODE: managed_identity
+      AI_SEARCH_ENDPOINT: https://holidaypeakhub405devsearch.search.windows.net
+      AI_SEARCH_INDEX: catalog-products
+      AI_SEARCH_INDEXER_NAME: search-enriched-products-indexer
+      AI_SEARCH_VECTOR_INDEX: product_search_index
+      APPLICATIONINSIGHTS_CONNECTION_STRING: InstrumentationKey=d2fb45bc-e648-4da2-9345-d278636aede5;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=d8eb64c4-956d-46ab-a02e-d481deadaa0b
+      AZURE_CLIENT_ID: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
+      AZURE_TENANT_ID: 16b3c013-d300-468d-ac64-7eda0820b6d3
+      BLOB_ACCOUNT_URL: https://holidaypeakhub405devstor.blob.core.windows.net
+      BLOB_CONTAINER: agent-memory
+      CATALOG_SEARCH_REQUIRE_AI_SEARCH: 'true'
+      COSMOS_ACCOUNT_URI: https://holidaypeakhub405-dev-cosmos.documents.azure.com:443/
+      COSMOS_CONTAINER: agent-memory
+      COSMOS_DATABASE: holiday-peak-db
+      EMBEDDING_DEPLOYMENT_NAME: text-embedding-3-large
+      EVENT_HUB_NAMESPACE: holidaypeakhub405-dev-eventhub
+      FOUNDRY_AGENT_NAME_FAST: ecommerce-product-detail-enrichment-fast
+      FOUNDRY_AGENT_NAME_RICH: ecommerce-product-detail-enrichment-rich
+      FOUNDRY_AUTO_ENSURE_ON_STARTUP: 'true'
+      FOUNDRY_STREAM: 'true'
+      AGENT_FOUNDRY_INVOKE_TIMEOUT_SECONDS: '60'
+      FOUNDRY_STRICT_ENFORCEMENT: 'false'
+      KEY_VAULT_URI: https://holidaypeakhub405-dev-kv.vault.azure.net/
+      MODEL_DEPLOYMENT_NAME_FAST: gpt-5-nano
+      MODEL_DEPLOYMENT_NAME_RICH: gpt-5
+      POSTGRES_AUTH_MODE: entra
+      POSTGRES_DATABASE: holiday_peak_crud
+      POSTGRES_HOST: holidaypeakhub405-dev-postgres.postgres.database.azure.com
+      POSTGRES_SSL: 'true'
+      POSTGRES_USER: holidaypeakhub405-dev-crud-identity
+      PROJECT_ENDPOINT: https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris
+      PROJECT_NAME: aipholidaris
+      REDIS_HOST: holidaypeakhub405-dev-redis.redis.cache.windows.net
+      REDIS_PASSWORD_SECRET_NAME: redis-primary-key

--- a/.kubernetes/releases/agents/inventory-alerts-triggers.yaml
+++ b/.kubernetes/releases/agents/inventory-alerts-triggers.yaml
@@ -1,0 +1,105 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: inventory-alerts-triggers
+  namespace: flux-system
+spec:
+  targetNamespace: holiday-peak-agents
+  releaseName: inventory-alerts-triggers
+  interval: 5m
+  timeout: 10m
+  chart:
+    spec:
+      chart: .kubernetes/chart
+      sourceRef:
+        kind: GitRepository
+        name: holiday-peak-gitops
+        namespace: flux-system
+      interval: 5m
+  upgrade:
+    remediation:
+      retries: 3
+  install:
+    createNamespace: false
+    remediation:
+      retries: 3
+  values:
+    serviceName: inventory-alerts-triggers
+    serviceAccount:
+      create: true
+      clientId: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
+    image:
+      repository: holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/inventory-alerts-triggers-dev
+      tag: azd-deploy-1775346297
+    replicaCount: 2
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 250m
+        memory: 256Mi
+    nodeSelector:
+      agentpool: agents
+    tolerations:
+    - effect: NoSchedule
+      key: workload
+      operator: Equal
+      value: agents
+    availability:
+      strategy:
+        type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 25%
+        maxSurge: 25%
+    pdb:
+      enabled: false
+    keda:
+      enabled: false
+    agc:
+      enabled: true
+      gatewayClassName: azure-alb-external
+      hostnames:
+      - esbcc8bcfyazbbdg.fz03.alb.azure.com
+      parentRefs:
+      - name: holiday-peak-agc
+        namespace: holiday-peak-crud
+      paths:
+      - path: /inventory-alerts-triggers
+        pathType: PathPrefix
+        rewriteTo: /
+    env:
+      AI_SEARCH_AUTH_MODE: managed_identity
+      AI_SEARCH_ENDPOINT: https://holidaypeakhub405devsearch.search.windows.net
+      AI_SEARCH_INDEX: catalog-products
+      AI_SEARCH_INDEXER_NAME: search-enriched-products-indexer
+      AI_SEARCH_VECTOR_INDEX: product_search_index
+      APPLICATIONINSIGHTS_CONNECTION_STRING: InstrumentationKey=d2fb45bc-e648-4da2-9345-d278636aede5;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=d8eb64c4-956d-46ab-a02e-d481deadaa0b
+      AZURE_CLIENT_ID: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
+      AZURE_TENANT_ID: 16b3c013-d300-468d-ac64-7eda0820b6d3
+      BLOB_ACCOUNT_URL: https://holidaypeakhub405devstor.blob.core.windows.net
+      BLOB_CONTAINER: agent-memory
+      CATALOG_SEARCH_REQUIRE_AI_SEARCH: 'true'
+      COSMOS_ACCOUNT_URI: https://holidaypeakhub405-dev-cosmos.documents.azure.com:443/
+      COSMOS_CONTAINER: agent-memory
+      COSMOS_DATABASE: holiday-peak-db
+      EMBEDDING_DEPLOYMENT_NAME: text-embedding-3-large
+      EVENT_HUB_NAMESPACE: holidaypeakhub405-dev-eventhub
+      FOUNDRY_AGENT_NAME_FAST: inventory-alerts-triggers-fast
+      FOUNDRY_AGENT_NAME_RICH: inventory-alerts-triggers-rich
+      FOUNDRY_AUTO_ENSURE_ON_STARTUP: 'true'
+      FOUNDRY_STREAM: 'true'
+      AGENT_FOUNDRY_INVOKE_TIMEOUT_SECONDS: '60'
+      FOUNDRY_STRICT_ENFORCEMENT: 'false'
+      KEY_VAULT_URI: https://holidaypeakhub405-dev-kv.vault.azure.net/
+      MODEL_DEPLOYMENT_NAME_FAST: gpt-5-nano
+      MODEL_DEPLOYMENT_NAME_RICH: gpt-5
+      POSTGRES_AUTH_MODE: entra
+      POSTGRES_DATABASE: holiday_peak_crud
+      POSTGRES_HOST: holidaypeakhub405-dev-postgres.postgres.database.azure.com
+      POSTGRES_SSL: 'true'
+      POSTGRES_USER: holidaypeakhub405-dev-crud-identity
+      PROJECT_ENDPOINT: https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris
+      PROJECT_NAME: aipholidaris
+      REDIS_HOST: holidaypeakhub405-dev-redis.redis.cache.windows.net
+      REDIS_PASSWORD_SECRET_NAME: redis-primary-key

--- a/.kubernetes/releases/agents/inventory-health-check.yaml
+++ b/.kubernetes/releases/agents/inventory-health-check.yaml
@@ -1,0 +1,105 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: inventory-health-check
+  namespace: flux-system
+spec:
+  targetNamespace: holiday-peak-agents
+  releaseName: inventory-health-check
+  interval: 5m
+  timeout: 10m
+  chart:
+    spec:
+      chart: .kubernetes/chart
+      sourceRef:
+        kind: GitRepository
+        name: holiday-peak-gitops
+        namespace: flux-system
+      interval: 5m
+  upgrade:
+    remediation:
+      retries: 3
+  install:
+    createNamespace: false
+    remediation:
+      retries: 3
+  values:
+    serviceName: inventory-health-check
+    serviceAccount:
+      create: true
+      clientId: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
+    image:
+      repository: holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/inventory-health-check-dev
+      tag: azd-deploy-1775346564
+    replicaCount: 2
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 250m
+        memory: 256Mi
+    nodeSelector:
+      agentpool: agents
+    tolerations:
+    - effect: NoSchedule
+      key: workload
+      operator: Equal
+      value: agents
+    availability:
+      strategy:
+        type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 25%
+        maxSurge: 25%
+    pdb:
+      enabled: false
+    keda:
+      enabled: false
+    agc:
+      enabled: true
+      gatewayClassName: azure-alb-external
+      hostnames:
+      - esbcc8bcfyazbbdg.fz03.alb.azure.com
+      parentRefs:
+      - name: holiday-peak-agc
+        namespace: holiday-peak-crud
+      paths:
+      - path: /inventory-health-check
+        pathType: PathPrefix
+        rewriteTo: /
+    env:
+      AI_SEARCH_AUTH_MODE: managed_identity
+      AI_SEARCH_ENDPOINT: https://holidaypeakhub405devsearch.search.windows.net
+      AI_SEARCH_INDEX: catalog-products
+      AI_SEARCH_INDEXER_NAME: search-enriched-products-indexer
+      AI_SEARCH_VECTOR_INDEX: product_search_index
+      APPLICATIONINSIGHTS_CONNECTION_STRING: InstrumentationKey=d2fb45bc-e648-4da2-9345-d278636aede5;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=d8eb64c4-956d-46ab-a02e-d481deadaa0b
+      AZURE_CLIENT_ID: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
+      AZURE_TENANT_ID: 16b3c013-d300-468d-ac64-7eda0820b6d3
+      BLOB_ACCOUNT_URL: https://holidaypeakhub405devstor.blob.core.windows.net
+      BLOB_CONTAINER: agent-memory
+      CATALOG_SEARCH_REQUIRE_AI_SEARCH: 'true'
+      COSMOS_ACCOUNT_URI: https://holidaypeakhub405-dev-cosmos.documents.azure.com:443/
+      COSMOS_CONTAINER: agent-memory
+      COSMOS_DATABASE: holiday-peak-db
+      EMBEDDING_DEPLOYMENT_NAME: text-embedding-3-large
+      EVENT_HUB_NAMESPACE: holidaypeakhub405-dev-eventhub
+      FOUNDRY_AGENT_NAME_FAST: inventory-health-check-fast
+      FOUNDRY_AGENT_NAME_RICH: inventory-health-check-rich
+      FOUNDRY_AUTO_ENSURE_ON_STARTUP: 'true'
+      FOUNDRY_STREAM: 'true'
+      AGENT_FOUNDRY_INVOKE_TIMEOUT_SECONDS: '60'
+      FOUNDRY_STRICT_ENFORCEMENT: 'false'
+      KEY_VAULT_URI: https://holidaypeakhub405-dev-kv.vault.azure.net/
+      MODEL_DEPLOYMENT_NAME_FAST: gpt-5-nano
+      MODEL_DEPLOYMENT_NAME_RICH: gpt-5
+      POSTGRES_AUTH_MODE: entra
+      POSTGRES_DATABASE: holiday_peak_crud
+      POSTGRES_HOST: holidaypeakhub405-dev-postgres.postgres.database.azure.com
+      POSTGRES_SSL: 'true'
+      POSTGRES_USER: holidaypeakhub405-dev-crud-identity
+      PROJECT_ENDPOINT: https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris
+      PROJECT_NAME: aipholidaris
+      REDIS_HOST: holidaypeakhub405-dev-redis.redis.cache.windows.net
+      REDIS_PASSWORD_SECRET_NAME: redis-primary-key

--- a/.kubernetes/releases/agents/inventory-jit-replenishment.yaml
+++ b/.kubernetes/releases/agents/inventory-jit-replenishment.yaml
@@ -1,0 +1,105 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: inventory-jit-replenishment
+  namespace: flux-system
+spec:
+  targetNamespace: holiday-peak-agents
+  releaseName: inventory-jit-replenishment
+  interval: 5m
+  timeout: 10m
+  chart:
+    spec:
+      chart: .kubernetes/chart
+      sourceRef:
+        kind: GitRepository
+        name: holiday-peak-gitops
+        namespace: flux-system
+      interval: 5m
+  upgrade:
+    remediation:
+      retries: 3
+  install:
+    createNamespace: false
+    remediation:
+      retries: 3
+  values:
+    serviceName: inventory-jit-replenishment
+    serviceAccount:
+      create: true
+      clientId: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
+    image:
+      repository: holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/inventory-jit-replenishment-dev
+      tag: azd-deploy-1775346858
+    replicaCount: 2
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 250m
+        memory: 256Mi
+    nodeSelector:
+      agentpool: agents
+    tolerations:
+    - effect: NoSchedule
+      key: workload
+      operator: Equal
+      value: agents
+    availability:
+      strategy:
+        type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 25%
+        maxSurge: 25%
+    pdb:
+      enabled: false
+    keda:
+      enabled: false
+    agc:
+      enabled: true
+      gatewayClassName: azure-alb-external
+      hostnames:
+      - esbcc8bcfyazbbdg.fz03.alb.azure.com
+      parentRefs:
+      - name: holiday-peak-agc
+        namespace: holiday-peak-crud
+      paths:
+      - path: /inventory-jit-replenishment
+        pathType: PathPrefix
+        rewriteTo: /
+    env:
+      AI_SEARCH_AUTH_MODE: managed_identity
+      AI_SEARCH_ENDPOINT: https://holidaypeakhub405devsearch.search.windows.net
+      AI_SEARCH_INDEX: catalog-products
+      AI_SEARCH_INDEXER_NAME: search-enriched-products-indexer
+      AI_SEARCH_VECTOR_INDEX: product_search_index
+      APPLICATIONINSIGHTS_CONNECTION_STRING: InstrumentationKey=d2fb45bc-e648-4da2-9345-d278636aede5;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=d8eb64c4-956d-46ab-a02e-d481deadaa0b
+      AZURE_CLIENT_ID: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
+      AZURE_TENANT_ID: 16b3c013-d300-468d-ac64-7eda0820b6d3
+      BLOB_ACCOUNT_URL: https://holidaypeakhub405devstor.blob.core.windows.net
+      BLOB_CONTAINER: agent-memory
+      CATALOG_SEARCH_REQUIRE_AI_SEARCH: 'true'
+      COSMOS_ACCOUNT_URI: https://holidaypeakhub405-dev-cosmos.documents.azure.com:443/
+      COSMOS_CONTAINER: agent-memory
+      COSMOS_DATABASE: holiday-peak-db
+      EMBEDDING_DEPLOYMENT_NAME: text-embedding-3-large
+      EVENT_HUB_NAMESPACE: holidaypeakhub405-dev-eventhub
+      FOUNDRY_AGENT_NAME_FAST: inventory-jit-replenishment-fast
+      FOUNDRY_AGENT_NAME_RICH: inventory-jit-replenishment-rich
+      FOUNDRY_AUTO_ENSURE_ON_STARTUP: 'true'
+      FOUNDRY_STREAM: 'true'
+      AGENT_FOUNDRY_INVOKE_TIMEOUT_SECONDS: '60'
+      FOUNDRY_STRICT_ENFORCEMENT: 'false'
+      KEY_VAULT_URI: https://holidaypeakhub405-dev-kv.vault.azure.net/
+      MODEL_DEPLOYMENT_NAME_FAST: gpt-5-nano
+      MODEL_DEPLOYMENT_NAME_RICH: gpt-5
+      POSTGRES_AUTH_MODE: entra
+      POSTGRES_DATABASE: holiday_peak_crud
+      POSTGRES_HOST: holidaypeakhub405-dev-postgres.postgres.database.azure.com
+      POSTGRES_SSL: 'true'
+      POSTGRES_USER: holidaypeakhub405-dev-crud-identity
+      PROJECT_ENDPOINT: https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris
+      PROJECT_NAME: aipholidaris
+      REDIS_HOST: holidaypeakhub405-dev-redis.redis.cache.windows.net
+      REDIS_PASSWORD_SECRET_NAME: redis-primary-key

--- a/.kubernetes/releases/agents/inventory-reservation-validation.yaml
+++ b/.kubernetes/releases/agents/inventory-reservation-validation.yaml
@@ -1,0 +1,105 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: inventory-reservation-validation
+  namespace: flux-system
+spec:
+  targetNamespace: holiday-peak-agents
+  releaseName: inventory-reservation-validation
+  interval: 5m
+  timeout: 10m
+  chart:
+    spec:
+      chart: .kubernetes/chart
+      sourceRef:
+        kind: GitRepository
+        name: holiday-peak-gitops
+        namespace: flux-system
+      interval: 5m
+  upgrade:
+    remediation:
+      retries: 3
+  install:
+    createNamespace: false
+    remediation:
+      retries: 3
+  values:
+    serviceName: inventory-reservation-validation
+    serviceAccount:
+      create: true
+      clientId: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
+    image:
+      repository: holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/inventory-reservation-validation-dev
+      tag: azd-deploy-1775347087
+    replicaCount: 2
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 250m
+        memory: 256Mi
+    nodeSelector:
+      agentpool: agents
+    tolerations:
+    - effect: NoSchedule
+      key: workload
+      operator: Equal
+      value: agents
+    availability:
+      strategy:
+        type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 25%
+        maxSurge: 25%
+    pdb:
+      enabled: false
+    keda:
+      enabled: false
+    agc:
+      enabled: true
+      gatewayClassName: azure-alb-external
+      hostnames:
+      - esbcc8bcfyazbbdg.fz03.alb.azure.com
+      parentRefs:
+      - name: holiday-peak-agc
+        namespace: holiday-peak-crud
+      paths:
+      - path: /inventory-reservation-validation
+        pathType: PathPrefix
+        rewriteTo: /
+    env:
+      AI_SEARCH_AUTH_MODE: managed_identity
+      AI_SEARCH_ENDPOINT: https://holidaypeakhub405devsearch.search.windows.net
+      AI_SEARCH_INDEX: catalog-products
+      AI_SEARCH_INDEXER_NAME: search-enriched-products-indexer
+      AI_SEARCH_VECTOR_INDEX: product_search_index
+      APPLICATIONINSIGHTS_CONNECTION_STRING: InstrumentationKey=d2fb45bc-e648-4da2-9345-d278636aede5;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=d8eb64c4-956d-46ab-a02e-d481deadaa0b
+      AZURE_CLIENT_ID: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
+      AZURE_TENANT_ID: 16b3c013-d300-468d-ac64-7eda0820b6d3
+      BLOB_ACCOUNT_URL: https://holidaypeakhub405devstor.blob.core.windows.net
+      BLOB_CONTAINER: agent-memory
+      CATALOG_SEARCH_REQUIRE_AI_SEARCH: 'true'
+      COSMOS_ACCOUNT_URI: https://holidaypeakhub405-dev-cosmos.documents.azure.com:443/
+      COSMOS_CONTAINER: agent-memory
+      COSMOS_DATABASE: holiday-peak-db
+      EMBEDDING_DEPLOYMENT_NAME: text-embedding-3-large
+      EVENT_HUB_NAMESPACE: holidaypeakhub405-dev-eventhub
+      FOUNDRY_AGENT_NAME_FAST: inventory-reservation-validation-fast
+      FOUNDRY_AGENT_NAME_RICH: inventory-reservation-validation-rich
+      FOUNDRY_AUTO_ENSURE_ON_STARTUP: 'true'
+      FOUNDRY_STREAM: 'true'
+      AGENT_FOUNDRY_INVOKE_TIMEOUT_SECONDS: '60'
+      FOUNDRY_STRICT_ENFORCEMENT: 'false'
+      KEY_VAULT_URI: https://holidaypeakhub405-dev-kv.vault.azure.net/
+      MODEL_DEPLOYMENT_NAME_FAST: gpt-5-nano
+      MODEL_DEPLOYMENT_NAME_RICH: gpt-5
+      POSTGRES_AUTH_MODE: entra
+      POSTGRES_DATABASE: holiday_peak_crud
+      POSTGRES_HOST: holidaypeakhub405-dev-postgres.postgres.database.azure.com
+      POSTGRES_SSL: 'true'
+      POSTGRES_USER: holidaypeakhub405-dev-crud-identity
+      PROJECT_ENDPOINT: https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris
+      PROJECT_NAME: aipholidaris
+      REDIS_HOST: holidaypeakhub405-dev-redis.redis.cache.windows.net
+      REDIS_PASSWORD_SECRET_NAME: redis-primary-key

--- a/.kubernetes/releases/agents/kustomization.yaml
+++ b/.kubernetes/releases/agents/kustomization.yaml
@@ -1,10 +1,35 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-# Phase 2: Flux HelmRelease-based deployments (replaces rendered YAML).
-# Each file is a HelmRelease CRD that Flux Helm Controller reconciles in-cluster.
-# Migrated services are removed from .kubernetes/rendered/agents/kustomization.yaml.
+# Pattern A — Flux HelmRelease-based deployments (ADR-017 amended).
+# Each file is a HelmRelease CRD reconciled by the Flux helm-controller in-cluster.
+# Chart source: .kubernetes/chart, values inline per service.
+# Replaces .kubernetes/rendered/agents/ which was a workflow-emitted artifact
+# requiring a bot push to protected main (rejected by main-governance-baseline ruleset).
 resources:
+  - crm-campaign-intelligence.yaml
+  - crm-profile-aggregation.yaml
+  - crm-segmentation-personalization.yaml
+  - crm-support-assistance.yaml
+  - ecommerce-cart-intelligence.yaml
   - ecommerce-catalog-search.yaml
+  - ecommerce-checkout-support.yaml
+  - ecommerce-order-status.yaml
+  - ecommerce-product-detail-enrichment.yaml
+  - inventory-alerts-triggers.yaml
+  - inventory-health-check.yaml
+  - inventory-jit-replenishment.yaml
+  - inventory-reservation-validation.yaml
+  - logistics-carrier-selection.yaml
+  - logistics-eta-computation.yaml
+  - logistics-returns-support.yaml
+  - logistics-route-issue-detection.yaml
+  - product-management-acp-transformation.yaml
+  - product-management-assortment-optimization.yaml
+  - product-management-consistency-validation.yaml
+  - product-management-normalization-classification.yaml
+  - search-enrichment-agent.yaml
   - truth-enrichment.yaml
+  - truth-export.yaml
   - truth-hitl.yaml
+  - truth-ingestion.yaml

--- a/.kubernetes/releases/agents/logistics-carrier-selection.yaml
+++ b/.kubernetes/releases/agents/logistics-carrier-selection.yaml
@@ -1,0 +1,105 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: logistics-carrier-selection
+  namespace: flux-system
+spec:
+  targetNamespace: holiday-peak-agents
+  releaseName: logistics-carrier-selection
+  interval: 5m
+  timeout: 10m
+  chart:
+    spec:
+      chart: .kubernetes/chart
+      sourceRef:
+        kind: GitRepository
+        name: holiday-peak-gitops
+        namespace: flux-system
+      interval: 5m
+  upgrade:
+    remediation:
+      retries: 3
+  install:
+    createNamespace: false
+    remediation:
+      retries: 3
+  values:
+    serviceName: logistics-carrier-selection
+    serviceAccount:
+      create: true
+      clientId: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
+    image:
+      repository: holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/logistics-carrier-selection-dev
+      tag: azd-deploy-1775347321
+    replicaCount: 2
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 250m
+        memory: 256Mi
+    nodeSelector:
+      agentpool: agents
+    tolerations:
+    - effect: NoSchedule
+      key: workload
+      operator: Equal
+      value: agents
+    availability:
+      strategy:
+        type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 25%
+        maxSurge: 25%
+    pdb:
+      enabled: false
+    keda:
+      enabled: false
+    agc:
+      enabled: true
+      gatewayClassName: azure-alb-external
+      hostnames:
+      - esbcc8bcfyazbbdg.fz03.alb.azure.com
+      parentRefs:
+      - name: holiday-peak-agc
+        namespace: holiday-peak-crud
+      paths:
+      - path: /logistics-carrier-selection
+        pathType: PathPrefix
+        rewriteTo: /
+    env:
+      AI_SEARCH_AUTH_MODE: managed_identity
+      AI_SEARCH_ENDPOINT: https://holidaypeakhub405devsearch.search.windows.net
+      AI_SEARCH_INDEX: catalog-products
+      AI_SEARCH_INDEXER_NAME: search-enriched-products-indexer
+      AI_SEARCH_VECTOR_INDEX: product_search_index
+      APPLICATIONINSIGHTS_CONNECTION_STRING: InstrumentationKey=d2fb45bc-e648-4da2-9345-d278636aede5;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=d8eb64c4-956d-46ab-a02e-d481deadaa0b
+      AZURE_CLIENT_ID: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
+      AZURE_TENANT_ID: 16b3c013-d300-468d-ac64-7eda0820b6d3
+      BLOB_ACCOUNT_URL: https://holidaypeakhub405devstor.blob.core.windows.net
+      BLOB_CONTAINER: agent-memory
+      CATALOG_SEARCH_REQUIRE_AI_SEARCH: 'true'
+      COSMOS_ACCOUNT_URI: https://holidaypeakhub405-dev-cosmos.documents.azure.com:443/
+      COSMOS_CONTAINER: agent-memory
+      COSMOS_DATABASE: holiday-peak-db
+      EMBEDDING_DEPLOYMENT_NAME: text-embedding-3-large
+      EVENT_HUB_NAMESPACE: holidaypeakhub405-dev-eventhub
+      FOUNDRY_AGENT_NAME_FAST: logistics-carrier-selection-fast
+      FOUNDRY_AGENT_NAME_RICH: logistics-carrier-selection-rich
+      FOUNDRY_AUTO_ENSURE_ON_STARTUP: 'true'
+      FOUNDRY_STREAM: 'true'
+      AGENT_FOUNDRY_INVOKE_TIMEOUT_SECONDS: '60'
+      FOUNDRY_STRICT_ENFORCEMENT: 'false'
+      KEY_VAULT_URI: https://holidaypeakhub405-dev-kv.vault.azure.net/
+      MODEL_DEPLOYMENT_NAME_FAST: gpt-5-nano
+      MODEL_DEPLOYMENT_NAME_RICH: gpt-5
+      POSTGRES_AUTH_MODE: entra
+      POSTGRES_DATABASE: holiday_peak_crud
+      POSTGRES_HOST: holidaypeakhub405-dev-postgres.postgres.database.azure.com
+      POSTGRES_SSL: 'true'
+      POSTGRES_USER: holidaypeakhub405-dev-crud-identity
+      PROJECT_ENDPOINT: https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris
+      PROJECT_NAME: aipholidaris
+      REDIS_HOST: holidaypeakhub405-dev-redis.redis.cache.windows.net
+      REDIS_PASSWORD_SECRET_NAME: redis-primary-key

--- a/.kubernetes/releases/agents/logistics-eta-computation.yaml
+++ b/.kubernetes/releases/agents/logistics-eta-computation.yaml
@@ -1,0 +1,105 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: logistics-eta-computation
+  namespace: flux-system
+spec:
+  targetNamespace: holiday-peak-agents
+  releaseName: logistics-eta-computation
+  interval: 5m
+  timeout: 10m
+  chart:
+    spec:
+      chart: .kubernetes/chart
+      sourceRef:
+        kind: GitRepository
+        name: holiday-peak-gitops
+        namespace: flux-system
+      interval: 5m
+  upgrade:
+    remediation:
+      retries: 3
+  install:
+    createNamespace: false
+    remediation:
+      retries: 3
+  values:
+    serviceName: logistics-eta-computation
+    serviceAccount:
+      create: true
+      clientId: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
+    image:
+      repository: holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/logistics-eta-computation-dev
+      tag: azd-deploy-1775347585
+    replicaCount: 2
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 250m
+        memory: 256Mi
+    nodeSelector:
+      agentpool: agents
+    tolerations:
+    - effect: NoSchedule
+      key: workload
+      operator: Equal
+      value: agents
+    availability:
+      strategy:
+        type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 25%
+        maxSurge: 25%
+    pdb:
+      enabled: false
+    keda:
+      enabled: false
+    agc:
+      enabled: true
+      gatewayClassName: azure-alb-external
+      hostnames:
+      - esbcc8bcfyazbbdg.fz03.alb.azure.com
+      parentRefs:
+      - name: holiday-peak-agc
+        namespace: holiday-peak-crud
+      paths:
+      - path: /logistics-eta-computation
+        pathType: PathPrefix
+        rewriteTo: /
+    env:
+      AI_SEARCH_AUTH_MODE: managed_identity
+      AI_SEARCH_ENDPOINT: https://holidaypeakhub405devsearch.search.windows.net
+      AI_SEARCH_INDEX: catalog-products
+      AI_SEARCH_INDEXER_NAME: search-enriched-products-indexer
+      AI_SEARCH_VECTOR_INDEX: product_search_index
+      APPLICATIONINSIGHTS_CONNECTION_STRING: InstrumentationKey=d2fb45bc-e648-4da2-9345-d278636aede5;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=d8eb64c4-956d-46ab-a02e-d481deadaa0b
+      AZURE_CLIENT_ID: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
+      AZURE_TENANT_ID: 16b3c013-d300-468d-ac64-7eda0820b6d3
+      BLOB_ACCOUNT_URL: https://holidaypeakhub405devstor.blob.core.windows.net
+      BLOB_CONTAINER: agent-memory
+      CATALOG_SEARCH_REQUIRE_AI_SEARCH: 'true'
+      COSMOS_ACCOUNT_URI: https://holidaypeakhub405-dev-cosmos.documents.azure.com:443/
+      COSMOS_CONTAINER: agent-memory
+      COSMOS_DATABASE: holiday-peak-db
+      EMBEDDING_DEPLOYMENT_NAME: text-embedding-3-large
+      EVENT_HUB_NAMESPACE: holidaypeakhub405-dev-eventhub
+      FOUNDRY_AGENT_NAME_FAST: logistics-eta-computation-fast
+      FOUNDRY_AGENT_NAME_RICH: logistics-eta-computation-rich
+      FOUNDRY_AUTO_ENSURE_ON_STARTUP: 'true'
+      FOUNDRY_STREAM: 'true'
+      AGENT_FOUNDRY_INVOKE_TIMEOUT_SECONDS: '60'
+      FOUNDRY_STRICT_ENFORCEMENT: 'false'
+      KEY_VAULT_URI: https://holidaypeakhub405-dev-kv.vault.azure.net/
+      MODEL_DEPLOYMENT_NAME_FAST: gpt-5-nano
+      MODEL_DEPLOYMENT_NAME_RICH: gpt-5
+      POSTGRES_AUTH_MODE: entra
+      POSTGRES_DATABASE: holiday_peak_crud
+      POSTGRES_HOST: holidaypeakhub405-dev-postgres.postgres.database.azure.com
+      POSTGRES_SSL: 'true'
+      POSTGRES_USER: holidaypeakhub405-dev-crud-identity
+      PROJECT_ENDPOINT: https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris
+      PROJECT_NAME: aipholidaris
+      REDIS_HOST: holidaypeakhub405-dev-redis.redis.cache.windows.net
+      REDIS_PASSWORD_SECRET_NAME: redis-primary-key

--- a/.kubernetes/releases/agents/logistics-returns-support.yaml
+++ b/.kubernetes/releases/agents/logistics-returns-support.yaml
@@ -1,0 +1,105 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: logistics-returns-support
+  namespace: flux-system
+spec:
+  targetNamespace: holiday-peak-agents
+  releaseName: logistics-returns-support
+  interval: 5m
+  timeout: 10m
+  chart:
+    spec:
+      chart: .kubernetes/chart
+      sourceRef:
+        kind: GitRepository
+        name: holiday-peak-gitops
+        namespace: flux-system
+      interval: 5m
+  upgrade:
+    remediation:
+      retries: 3
+  install:
+    createNamespace: false
+    remediation:
+      retries: 3
+  values:
+    serviceName: logistics-returns-support
+    serviceAccount:
+      create: true
+      clientId: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
+    image:
+      repository: holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/logistics-returns-support-dev
+      tag: azd-deploy-1775347833
+    replicaCount: 2
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 250m
+        memory: 256Mi
+    nodeSelector:
+      agentpool: agents
+    tolerations:
+    - effect: NoSchedule
+      key: workload
+      operator: Equal
+      value: agents
+    availability:
+      strategy:
+        type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 25%
+        maxSurge: 25%
+    pdb:
+      enabled: false
+    keda:
+      enabled: false
+    agc:
+      enabled: true
+      gatewayClassName: azure-alb-external
+      hostnames:
+      - esbcc8bcfyazbbdg.fz03.alb.azure.com
+      parentRefs:
+      - name: holiday-peak-agc
+        namespace: holiday-peak-crud
+      paths:
+      - path: /logistics-returns-support
+        pathType: PathPrefix
+        rewriteTo: /
+    env:
+      AI_SEARCH_AUTH_MODE: managed_identity
+      AI_SEARCH_ENDPOINT: https://holidaypeakhub405devsearch.search.windows.net
+      AI_SEARCH_INDEX: catalog-products
+      AI_SEARCH_INDEXER_NAME: search-enriched-products-indexer
+      AI_SEARCH_VECTOR_INDEX: product_search_index
+      APPLICATIONINSIGHTS_CONNECTION_STRING: InstrumentationKey=d2fb45bc-e648-4da2-9345-d278636aede5;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=d8eb64c4-956d-46ab-a02e-d481deadaa0b
+      AZURE_CLIENT_ID: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
+      AZURE_TENANT_ID: 16b3c013-d300-468d-ac64-7eda0820b6d3
+      BLOB_ACCOUNT_URL: https://holidaypeakhub405devstor.blob.core.windows.net
+      BLOB_CONTAINER: agent-memory
+      CATALOG_SEARCH_REQUIRE_AI_SEARCH: 'true'
+      COSMOS_ACCOUNT_URI: https://holidaypeakhub405-dev-cosmos.documents.azure.com:443/
+      COSMOS_CONTAINER: agent-memory
+      COSMOS_DATABASE: holiday-peak-db
+      EMBEDDING_DEPLOYMENT_NAME: text-embedding-3-large
+      EVENT_HUB_NAMESPACE: holidaypeakhub405-dev-eventhub
+      FOUNDRY_AGENT_NAME_FAST: logistics-returns-support-fast
+      FOUNDRY_AGENT_NAME_RICH: logistics-returns-support-rich
+      FOUNDRY_AUTO_ENSURE_ON_STARTUP: 'true'
+      FOUNDRY_STREAM: 'true'
+      AGENT_FOUNDRY_INVOKE_TIMEOUT_SECONDS: '60'
+      FOUNDRY_STRICT_ENFORCEMENT: 'false'
+      KEY_VAULT_URI: https://holidaypeakhub405-dev-kv.vault.azure.net/
+      MODEL_DEPLOYMENT_NAME_FAST: gpt-5-nano
+      MODEL_DEPLOYMENT_NAME_RICH: gpt-5
+      POSTGRES_AUTH_MODE: entra
+      POSTGRES_DATABASE: holiday_peak_crud
+      POSTGRES_HOST: holidaypeakhub405-dev-postgres.postgres.database.azure.com
+      POSTGRES_SSL: 'true'
+      POSTGRES_USER: holidaypeakhub405-dev-crud-identity
+      PROJECT_ENDPOINT: https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris
+      PROJECT_NAME: aipholidaris
+      REDIS_HOST: holidaypeakhub405-dev-redis.redis.cache.windows.net
+      REDIS_PASSWORD_SECRET_NAME: redis-primary-key

--- a/.kubernetes/releases/agents/logistics-route-issue-detection.yaml
+++ b/.kubernetes/releases/agents/logistics-route-issue-detection.yaml
@@ -1,0 +1,105 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: logistics-route-issue-detection
+  namespace: flux-system
+spec:
+  targetNamespace: holiday-peak-agents
+  releaseName: logistics-route-issue-detection
+  interval: 5m
+  timeout: 10m
+  chart:
+    spec:
+      chart: .kubernetes/chart
+      sourceRef:
+        kind: GitRepository
+        name: holiday-peak-gitops
+        namespace: flux-system
+      interval: 5m
+  upgrade:
+    remediation:
+      retries: 3
+  install:
+    createNamespace: false
+    remediation:
+      retries: 3
+  values:
+    serviceName: logistics-route-issue-detection
+    serviceAccount:
+      create: true
+      clientId: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
+    image:
+      repository: holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/logistics-route-issue-detection-dev
+      tag: azd-deploy-1775348087
+    replicaCount: 2
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 250m
+        memory: 256Mi
+    nodeSelector:
+      agentpool: agents
+    tolerations:
+    - effect: NoSchedule
+      key: workload
+      operator: Equal
+      value: agents
+    availability:
+      strategy:
+        type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 25%
+        maxSurge: 25%
+    pdb:
+      enabled: false
+    keda:
+      enabled: false
+    agc:
+      enabled: true
+      gatewayClassName: azure-alb-external
+      hostnames:
+      - esbcc8bcfyazbbdg.fz03.alb.azure.com
+      parentRefs:
+      - name: holiday-peak-agc
+        namespace: holiday-peak-crud
+      paths:
+      - path: /logistics-route-issue-detection
+        pathType: PathPrefix
+        rewriteTo: /
+    env:
+      AI_SEARCH_AUTH_MODE: managed_identity
+      AI_SEARCH_ENDPOINT: https://holidaypeakhub405devsearch.search.windows.net
+      AI_SEARCH_INDEX: catalog-products
+      AI_SEARCH_INDEXER_NAME: search-enriched-products-indexer
+      AI_SEARCH_VECTOR_INDEX: product_search_index
+      APPLICATIONINSIGHTS_CONNECTION_STRING: InstrumentationKey=d2fb45bc-e648-4da2-9345-d278636aede5;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=d8eb64c4-956d-46ab-a02e-d481deadaa0b
+      AZURE_CLIENT_ID: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
+      AZURE_TENANT_ID: 16b3c013-d300-468d-ac64-7eda0820b6d3
+      BLOB_ACCOUNT_URL: https://holidaypeakhub405devstor.blob.core.windows.net
+      BLOB_CONTAINER: agent-memory
+      CATALOG_SEARCH_REQUIRE_AI_SEARCH: 'true'
+      COSMOS_ACCOUNT_URI: https://holidaypeakhub405-dev-cosmos.documents.azure.com:443/
+      COSMOS_CONTAINER: agent-memory
+      COSMOS_DATABASE: holiday-peak-db
+      EMBEDDING_DEPLOYMENT_NAME: text-embedding-3-large
+      EVENT_HUB_NAMESPACE: holidaypeakhub405-dev-eventhub
+      FOUNDRY_AGENT_NAME_FAST: logistics-route-issue-detection-fast
+      FOUNDRY_AGENT_NAME_RICH: logistics-route-issue-detection-rich
+      FOUNDRY_AUTO_ENSURE_ON_STARTUP: 'true'
+      FOUNDRY_STREAM: 'true'
+      AGENT_FOUNDRY_INVOKE_TIMEOUT_SECONDS: '60'
+      FOUNDRY_STRICT_ENFORCEMENT: 'false'
+      KEY_VAULT_URI: https://holidaypeakhub405-dev-kv.vault.azure.net/
+      MODEL_DEPLOYMENT_NAME_FAST: gpt-5-nano
+      MODEL_DEPLOYMENT_NAME_RICH: gpt-5
+      POSTGRES_AUTH_MODE: entra
+      POSTGRES_DATABASE: holiday_peak_crud
+      POSTGRES_HOST: holidaypeakhub405-dev-postgres.postgres.database.azure.com
+      POSTGRES_SSL: 'true'
+      POSTGRES_USER: holidaypeakhub405-dev-crud-identity
+      PROJECT_ENDPOINT: https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris
+      PROJECT_NAME: aipholidaris
+      REDIS_HOST: holidaypeakhub405-dev-redis.redis.cache.windows.net
+      REDIS_PASSWORD_SECRET_NAME: redis-primary-key

--- a/.kubernetes/releases/agents/product-management-acp-transformation.yaml
+++ b/.kubernetes/releases/agents/product-management-acp-transformation.yaml
@@ -1,0 +1,105 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: product-management-acp-transformation
+  namespace: flux-system
+spec:
+  targetNamespace: holiday-peak-agents
+  releaseName: product-management-acp-transformation
+  interval: 5m
+  timeout: 10m
+  chart:
+    spec:
+      chart: .kubernetes/chart
+      sourceRef:
+        kind: GitRepository
+        name: holiday-peak-gitops
+        namespace: flux-system
+      interval: 5m
+  upgrade:
+    remediation:
+      retries: 3
+  install:
+    createNamespace: false
+    remediation:
+      retries: 3
+  values:
+    serviceName: product-management-acp-transformation
+    serviceAccount:
+      create: true
+      clientId: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
+    image:
+      repository: holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/product-management-acp-transformation-dev
+      tag: azd-deploy-1775348336
+    replicaCount: 2
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 250m
+        memory: 256Mi
+    nodeSelector:
+      agentpool: agents
+    tolerations:
+    - effect: NoSchedule
+      key: workload
+      operator: Equal
+      value: agents
+    availability:
+      strategy:
+        type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 25%
+        maxSurge: 25%
+    pdb:
+      enabled: false
+    keda:
+      enabled: false
+    agc:
+      enabled: true
+      gatewayClassName: azure-alb-external
+      hostnames:
+      - esbcc8bcfyazbbdg.fz03.alb.azure.com
+      parentRefs:
+      - name: holiday-peak-agc
+        namespace: holiday-peak-crud
+      paths:
+      - path: /product-management-acp-transformation
+        pathType: PathPrefix
+        rewriteTo: /
+    env:
+      AI_SEARCH_AUTH_MODE: managed_identity
+      AI_SEARCH_ENDPOINT: https://holidaypeakhub405devsearch.search.windows.net
+      AI_SEARCH_INDEX: catalog-products
+      AI_SEARCH_INDEXER_NAME: search-enriched-products-indexer
+      AI_SEARCH_VECTOR_INDEX: product_search_index
+      APPLICATIONINSIGHTS_CONNECTION_STRING: InstrumentationKey=d2fb45bc-e648-4da2-9345-d278636aede5;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=d8eb64c4-956d-46ab-a02e-d481deadaa0b
+      AZURE_CLIENT_ID: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
+      AZURE_TENANT_ID: 16b3c013-d300-468d-ac64-7eda0820b6d3
+      BLOB_ACCOUNT_URL: https://holidaypeakhub405devstor.blob.core.windows.net
+      BLOB_CONTAINER: agent-memory
+      CATALOG_SEARCH_REQUIRE_AI_SEARCH: 'true'
+      COSMOS_ACCOUNT_URI: https://holidaypeakhub405-dev-cosmos.documents.azure.com:443/
+      COSMOS_CONTAINER: agent-memory
+      COSMOS_DATABASE: holiday-peak-db
+      EMBEDDING_DEPLOYMENT_NAME: text-embedding-3-large
+      EVENT_HUB_NAMESPACE: holidaypeakhub405-dev-eventhub
+      FOUNDRY_AGENT_NAME_FAST: product-management-acp-transformation-fast
+      FOUNDRY_AGENT_NAME_RICH: product-management-acp-transformation-rich
+      FOUNDRY_AUTO_ENSURE_ON_STARTUP: 'true'
+      FOUNDRY_STREAM: 'true'
+      AGENT_FOUNDRY_INVOKE_TIMEOUT_SECONDS: '60'
+      FOUNDRY_STRICT_ENFORCEMENT: 'false'
+      KEY_VAULT_URI: https://holidaypeakhub405-dev-kv.vault.azure.net/
+      MODEL_DEPLOYMENT_NAME_FAST: gpt-5-nano
+      MODEL_DEPLOYMENT_NAME_RICH: gpt-5
+      POSTGRES_AUTH_MODE: entra
+      POSTGRES_DATABASE: holiday_peak_crud
+      POSTGRES_HOST: holidaypeakhub405-dev-postgres.postgres.database.azure.com
+      POSTGRES_SSL: 'true'
+      POSTGRES_USER: holidaypeakhub405-dev-crud-identity
+      PROJECT_ENDPOINT: https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris
+      PROJECT_NAME: aipholidaris
+      REDIS_HOST: holidaypeakhub405-dev-redis.redis.cache.windows.net
+      REDIS_PASSWORD_SECRET_NAME: redis-primary-key

--- a/.kubernetes/releases/agents/product-management-assortment-optimization.yaml
+++ b/.kubernetes/releases/agents/product-management-assortment-optimization.yaml
@@ -1,0 +1,105 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: product-management-assortment-optimization
+  namespace: flux-system
+spec:
+  targetNamespace: holiday-peak-agents
+  releaseName: product-management-assortment-optimization
+  interval: 5m
+  timeout: 10m
+  chart:
+    spec:
+      chart: .kubernetes/chart
+      sourceRef:
+        kind: GitRepository
+        name: holiday-peak-gitops
+        namespace: flux-system
+      interval: 5m
+  upgrade:
+    remediation:
+      retries: 3
+  install:
+    createNamespace: false
+    remediation:
+      retries: 3
+  values:
+    serviceName: product-management-assortment-optimization
+    serviceAccount:
+      create: true
+      clientId: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
+    image:
+      repository: holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/product-management-assortment-optimization-dev
+      tag: azd-deploy-1775348550
+    replicaCount: 2
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 250m
+        memory: 256Mi
+    nodeSelector:
+      agentpool: agents
+    tolerations:
+    - effect: NoSchedule
+      key: workload
+      operator: Equal
+      value: agents
+    availability:
+      strategy:
+        type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 25%
+        maxSurge: 25%
+    pdb:
+      enabled: false
+    keda:
+      enabled: false
+    agc:
+      enabled: true
+      gatewayClassName: azure-alb-external
+      hostnames:
+      - esbcc8bcfyazbbdg.fz03.alb.azure.com
+      parentRefs:
+      - name: holiday-peak-agc
+        namespace: holiday-peak-crud
+      paths:
+      - path: /product-management-assortment-optimization
+        pathType: PathPrefix
+        rewriteTo: /
+    env:
+      AI_SEARCH_AUTH_MODE: managed_identity
+      AI_SEARCH_ENDPOINT: https://holidaypeakhub405devsearch.search.windows.net
+      AI_SEARCH_INDEX: catalog-products
+      AI_SEARCH_INDEXER_NAME: search-enriched-products-indexer
+      AI_SEARCH_VECTOR_INDEX: product_search_index
+      APPLICATIONINSIGHTS_CONNECTION_STRING: InstrumentationKey=d2fb45bc-e648-4da2-9345-d278636aede5;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=d8eb64c4-956d-46ab-a02e-d481deadaa0b
+      AZURE_CLIENT_ID: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
+      AZURE_TENANT_ID: 16b3c013-d300-468d-ac64-7eda0820b6d3
+      BLOB_ACCOUNT_URL: https://holidaypeakhub405devstor.blob.core.windows.net
+      BLOB_CONTAINER: agent-memory
+      CATALOG_SEARCH_REQUIRE_AI_SEARCH: 'true'
+      COSMOS_ACCOUNT_URI: https://holidaypeakhub405-dev-cosmos.documents.azure.com:443/
+      COSMOS_CONTAINER: agent-memory
+      COSMOS_DATABASE: holiday-peak-db
+      EMBEDDING_DEPLOYMENT_NAME: text-embedding-3-large
+      EVENT_HUB_NAMESPACE: holidaypeakhub405-dev-eventhub
+      FOUNDRY_AGENT_NAME_FAST: product-management-assortment-optimization-fast
+      FOUNDRY_AGENT_NAME_RICH: product-management-assortment-optimization-rich
+      FOUNDRY_AUTO_ENSURE_ON_STARTUP: 'true'
+      FOUNDRY_STREAM: 'true'
+      AGENT_FOUNDRY_INVOKE_TIMEOUT_SECONDS: '60'
+      FOUNDRY_STRICT_ENFORCEMENT: 'false'
+      KEY_VAULT_URI: https://holidaypeakhub405-dev-kv.vault.azure.net/
+      MODEL_DEPLOYMENT_NAME_FAST: gpt-5-nano
+      MODEL_DEPLOYMENT_NAME_RICH: gpt-5
+      POSTGRES_AUTH_MODE: entra
+      POSTGRES_DATABASE: holiday_peak_crud
+      POSTGRES_HOST: holidaypeakhub405-dev-postgres.postgres.database.azure.com
+      POSTGRES_SSL: 'true'
+      POSTGRES_USER: holidaypeakhub405-dev-crud-identity
+      PROJECT_ENDPOINT: https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris
+      PROJECT_NAME: aipholidaris
+      REDIS_HOST: holidaypeakhub405-dev-redis.redis.cache.windows.net
+      REDIS_PASSWORD_SECRET_NAME: redis-primary-key

--- a/.kubernetes/releases/agents/product-management-consistency-validation.yaml
+++ b/.kubernetes/releases/agents/product-management-consistency-validation.yaml
@@ -1,0 +1,105 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: product-management-consistency-validation
+  namespace: flux-system
+spec:
+  targetNamespace: holiday-peak-agents
+  releaseName: product-management-consistency-validation
+  interval: 5m
+  timeout: 10m
+  chart:
+    spec:
+      chart: .kubernetes/chart
+      sourceRef:
+        kind: GitRepository
+        name: holiday-peak-gitops
+        namespace: flux-system
+      interval: 5m
+  upgrade:
+    remediation:
+      retries: 3
+  install:
+    createNamespace: false
+    remediation:
+      retries: 3
+  values:
+    serviceName: product-management-consistency-validation
+    serviceAccount:
+      create: true
+      clientId: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
+    image:
+      repository: holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/product-management-consistency-validation-dev
+      tag: azd-deploy-1775348779
+    replicaCount: 2
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 250m
+        memory: 256Mi
+    nodeSelector:
+      agentpool: agents
+    tolerations:
+    - effect: NoSchedule
+      key: workload
+      operator: Equal
+      value: agents
+    availability:
+      strategy:
+        type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 25%
+        maxSurge: 25%
+    pdb:
+      enabled: false
+    keda:
+      enabled: false
+    agc:
+      enabled: true
+      gatewayClassName: azure-alb-external
+      hostnames:
+      - esbcc8bcfyazbbdg.fz03.alb.azure.com
+      parentRefs:
+      - name: holiday-peak-agc
+        namespace: holiday-peak-crud
+      paths:
+      - path: /product-management-consistency-validation
+        pathType: PathPrefix
+        rewriteTo: /
+    env:
+      AI_SEARCH_AUTH_MODE: managed_identity
+      AI_SEARCH_ENDPOINT: https://holidaypeakhub405devsearch.search.windows.net
+      AI_SEARCH_INDEX: catalog-products
+      AI_SEARCH_INDEXER_NAME: search-enriched-products-indexer
+      AI_SEARCH_VECTOR_INDEX: product_search_index
+      APPLICATIONINSIGHTS_CONNECTION_STRING: InstrumentationKey=d2fb45bc-e648-4da2-9345-d278636aede5;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=d8eb64c4-956d-46ab-a02e-d481deadaa0b
+      AZURE_CLIENT_ID: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
+      AZURE_TENANT_ID: 16b3c013-d300-468d-ac64-7eda0820b6d3
+      BLOB_ACCOUNT_URL: https://holidaypeakhub405devstor.blob.core.windows.net
+      BLOB_CONTAINER: agent-memory
+      CATALOG_SEARCH_REQUIRE_AI_SEARCH: 'true'
+      COSMOS_ACCOUNT_URI: https://holidaypeakhub405-dev-cosmos.documents.azure.com:443/
+      COSMOS_CONTAINER: agent-memory
+      COSMOS_DATABASE: holiday-peak-db
+      EMBEDDING_DEPLOYMENT_NAME: text-embedding-3-large
+      FOUNDRY_AGENT_NAME_FAST: product-management-consistency-validation-fast
+      FOUNDRY_AGENT_NAME_RICH: product-management-consistency-validation-rich
+      FOUNDRY_AUTO_ENSURE_ON_STARTUP: 'true'
+      FOUNDRY_STREAM: 'true'
+      AGENT_FOUNDRY_INVOKE_TIMEOUT_SECONDS: '60'
+      FOUNDRY_STRICT_ENFORCEMENT: 'false'
+      KEY_VAULT_URI: https://holidaypeakhub405-dev-kv.vault.azure.net/
+      MODEL_DEPLOYMENT_NAME_FAST: gpt-5-nano
+      MODEL_DEPLOYMENT_NAME_RICH: gpt-5
+      PLATFORM_JOBS_EVENT_HUB_NAMESPACE: holidaypeakhub405-dev-jobs-eh
+      POSTGRES_AUTH_MODE: entra
+      POSTGRES_DATABASE: holiday_peak_crud
+      POSTGRES_HOST: holidaypeakhub405-dev-postgres.postgres.database.azure.com
+      POSTGRES_SSL: 'true'
+      POSTGRES_USER: holidaypeakhub405-dev-crud-identity
+      PROJECT_ENDPOINT: https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris
+      PROJECT_NAME: aipholidaris
+      REDIS_HOST: holidaypeakhub405-dev-redis.redis.cache.windows.net
+      REDIS_PASSWORD_SECRET_NAME: redis-primary-key

--- a/.kubernetes/releases/agents/product-management-normalization-classification.yaml
+++ b/.kubernetes/releases/agents/product-management-normalization-classification.yaml
@@ -1,0 +1,105 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: product-management-normalization-classification
+  namespace: flux-system
+spec:
+  targetNamespace: holiday-peak-agents
+  releaseName: product-management-normalization-classification
+  interval: 5m
+  timeout: 10m
+  chart:
+    spec:
+      chart: .kubernetes/chart
+      sourceRef:
+        kind: GitRepository
+        name: holiday-peak-gitops
+        namespace: flux-system
+      interval: 5m
+  upgrade:
+    remediation:
+      retries: 3
+  install:
+    createNamespace: false
+    remediation:
+      retries: 3
+  values:
+    serviceName: product-management-normalization-classification
+    serviceAccount:
+      create: true
+      clientId: e9c11fac-45b3-4057-8477-1d96703eaae4
+    image:
+      repository: holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/product-management-normalization-classification-dev
+      tag: azd-deploy-1775349002
+    replicaCount: 2
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 250m
+        memory: 256Mi
+    nodeSelector:
+      agentpool: agents
+    tolerations:
+    - effect: NoSchedule
+      key: workload
+      operator: Equal
+      value: agents
+    availability:
+      strategy:
+        type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 25%
+        maxSurge: 25%
+    pdb:
+      enabled: false
+    keda:
+      enabled: false
+    agc:
+      enabled: true
+      gatewayClassName: azure-alb-external
+      hostnames:
+      - esbcc8bcfyazbbdg.fz03.alb.azure.com
+      parentRefs:
+      - name: holiday-peak-agc
+        namespace: holiday-peak-crud
+      paths:
+      - path: /product-management-normalization-classification
+        pathType: PathPrefix
+        rewriteTo: /
+    env:
+      AI_SEARCH_AUTH_MODE: managed_identity
+      AI_SEARCH_ENDPOINT: https://holidaypeakhub405devsearch.search.windows.net
+      AI_SEARCH_INDEX: catalog-products
+      AI_SEARCH_INDEXER_NAME: search-enriched-products-indexer
+      AI_SEARCH_VECTOR_INDEX: product_search_index
+      APPLICATIONINSIGHTS_CONNECTION_STRING: InstrumentationKey=d2fb45bc-e648-4da2-9345-d278636aede5;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=d8eb64c4-956d-46ab-a02e-d481deadaa0b
+      AZURE_CLIENT_ID: e9c11fac-45b3-4057-8477-1d96703eaae4
+      AZURE_TENANT_ID: 16b3c013-d300-468d-ac64-7eda0820b6d3
+      BLOB_ACCOUNT_URL: https://holidaypeakhub405devstor.blob.core.windows.net
+      BLOB_CONTAINER: agent-memory
+      CATALOG_SEARCH_REQUIRE_AI_SEARCH: 'true'
+      COSMOS_ACCOUNT_URI: https://holidaypeakhub405-dev-cosmos.documents.azure.com:443/
+      COSMOS_CONTAINER: agent-memory
+      COSMOS_DATABASE: holiday-peak-db
+      EMBEDDING_DEPLOYMENT_NAME: text-embedding-3-large
+      EVENT_HUB_NAMESPACE: holidaypeakhub405-dev-eventhub
+      FOUNDRY_AGENT_NAME_FAST: product-management-normalization-classification-fast
+      FOUNDRY_AGENT_NAME_RICH: product-management-normalization-classification-rich
+      FOUNDRY_AUTO_ENSURE_ON_STARTUP: 'true'
+      FOUNDRY_STREAM: 'true'
+      AGENT_FOUNDRY_INVOKE_TIMEOUT_SECONDS: '60'
+      FOUNDRY_STRICT_ENFORCEMENT: 'false'
+      KEY_VAULT_URI: https://holidaypeakhub405-dev-kv.vault.azure.net/
+      MODEL_DEPLOYMENT_NAME_FAST: gpt-5-nano
+      MODEL_DEPLOYMENT_NAME_RICH: gpt-5
+      POSTGRES_AUTH_MODE: entra
+      POSTGRES_DATABASE: holiday_peak_crud
+      POSTGRES_HOST: holidaypeakhub405-dev-postgres.postgres.database.azure.com
+      POSTGRES_SSL: 'true'
+      POSTGRES_USER: holidaypeakhub405-dev-crud-identity
+      PROJECT_ENDPOINT: https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris
+      PROJECT_NAME: aipholidaris
+      REDIS_HOST: holidaypeakhub405-dev-redis.redis.cache.windows.net
+      REDIS_PASSWORD_SECRET_NAME: redis-primary-key

--- a/.kubernetes/releases/agents/search-enrichment-agent.yaml
+++ b/.kubernetes/releases/agents/search-enrichment-agent.yaml
@@ -1,0 +1,107 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: search-enrichment-agent
+  namespace: flux-system
+spec:
+  targetNamespace: holiday-peak-agents
+  releaseName: search-enrichment-agent
+  interval: 5m
+  timeout: 10m
+  chart:
+    spec:
+      chart: .kubernetes/chart
+      sourceRef:
+        kind: GitRepository
+        name: holiday-peak-gitops
+        namespace: flux-system
+      interval: 5m
+  upgrade:
+    remediation:
+      retries: 3
+  install:
+    createNamespace: false
+    remediation:
+      retries: 3
+  values:
+    serviceName: search-enrichment-agent
+    serviceAccount:
+      create: true
+      clientId: e9c11fac-45b3-4057-8477-1d96703eaae4
+    image:
+      repository: holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/search-enrichment-agent-dev
+      tag: azd-deploy-1775349482
+    replicaCount: 2
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 250m
+        memory: 256Mi
+    nodeSelector:
+      agentpool: agents
+    tolerations:
+    - effect: NoSchedule
+      key: workload
+      operator: Equal
+      value: agents
+    availability:
+      strategy:
+        type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 25%
+        maxSurge: 25%
+    pdb:
+      enabled: false
+    keda:
+      enabled: false
+    agc:
+      enabled: true
+      gatewayClassName: azure-alb-external
+      hostnames:
+      - esbcc8bcfyazbbdg.fz03.alb.azure.com
+      parentRefs:
+      - name: holiday-peak-agc
+        namespace: holiday-peak-crud
+      paths:
+      - path: /search-enrichment-agent
+        pathType: PathPrefix
+        rewriteTo: /
+    env:
+      AI_SEARCH_AUTH_MODE: managed_identity
+      AI_SEARCH_ENDPOINT: https://holidaypeakhub405devsearch.search.windows.net
+      AI_SEARCH_INDEX: catalog-products
+      AI_SEARCH_INDEXER_NAME: search-enriched-products-indexer
+      AI_SEARCH_VECTOR_INDEX: product_search_index
+      APPLICATIONINSIGHTS_CONNECTION_STRING: InstrumentationKey=d2fb45bc-e648-4da2-9345-d278636aede5;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=d8eb64c4-956d-46ab-a02e-d481deadaa0b
+      AZURE_CLIENT_ID: e9c11fac-45b3-4057-8477-1d96703eaae4
+      AZURE_TENANT_ID: 16b3c013-d300-468d-ac64-7eda0820b6d3
+      BLOB_ACCOUNT_URL: https://holidaypeakhub405devstor.blob.core.windows.net
+      BLOB_CONTAINER: agent-memory
+      CATALOG_SEARCH_REQUIRE_AI_SEARCH: 'true'
+      COSMOS_ACCOUNT_URI: https://holidaypeakhub405-dev-cosmos.documents.azure.com:443/
+      COSMOS_CONTAINER: agent-memory
+      COSMOS_DATABASE: holiday-peak-db
+      EMBEDDING_DEPLOYMENT_NAME: text-embedding-3-large
+      FOUNDRY_AGENT_NAME_FAST: search-enrichment-agent-fast
+      FOUNDRY_AGENT_NAME_RICH: search-enrichment-agent-rich
+      FOUNDRY_AUTO_ENSURE_ON_STARTUP: 'true'
+      FOUNDRY_STREAM: 'true'
+      AGENT_FOUNDRY_INVOKE_TIMEOUT_SECONDS: '60'
+      FOUNDRY_STRICT_ENFORCEMENT: 'false'
+      KEY_VAULT_URI: https://holidaypeakhub405-dev-kv.vault.azure.net/
+      MODEL_DEPLOYMENT_NAME_FAST: gpt-5-nano
+      MODEL_DEPLOYMENT_NAME_RICH: gpt-5
+      PLATFORM_JOBS_EVENT_HUB_NAMESPACE: holidaypeakhub405-dev-jobs-eh
+      POSTGRES_AUTH_MODE: entra
+      POSTGRES_DATABASE: holiday_peak_crud
+      POSTGRES_HOST: holidaypeakhub405-dev-postgres.postgres.database.azure.com
+      POSTGRES_SSL: 'true'
+      POSTGRES_USER: holidaypeakhub405-dev-crud-identity
+      PROJECT_ENDPOINT: https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris
+      PROJECT_NAME: aipholidaris
+      REDIS_HOST: holidaypeakhub405-dev-redis.redis.cache.windows.net
+      REDIS_PASSWORD_SECRET_NAME: redis-primary-key
+      SEARCH_ENRICHMENT_EVENT_HUB_CONSUMER_GROUP: search-enrichment-consumer
+      SEARCH_ENRICHMENT_EVENT_HUB_NAME: search-enrichment-jobs

--- a/.kubernetes/releases/agents/truth-export.yaml
+++ b/.kubernetes/releases/agents/truth-export.yaml
@@ -1,0 +1,116 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: truth-export
+  namespace: flux-system
+spec:
+  targetNamespace: holiday-peak-agents
+  releaseName: truth-export
+  interval: 5m
+  timeout: 10m
+  chart:
+    spec:
+      chart: .kubernetes/chart
+      sourceRef:
+        kind: GitRepository
+        name: holiday-peak-gitops
+        namespace: flux-system
+      interval: 5m
+  upgrade:
+    remediation:
+      retries: 3
+  install:
+    createNamespace: false
+    remediation:
+      retries: 3
+  values:
+    serviceName: truth-export
+    serviceAccount:
+      create: true
+      clientId: e9c11fac-45b3-4057-8477-1d96703eaae4
+    image:
+      repository: holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/truth-export-dev
+      tag: azd-deploy-1775350303
+    replicaCount: 2
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 250m
+        memory: 256Mi
+    nodeSelector:
+      agentpool: agents
+    tolerations:
+    - effect: NoSchedule
+      key: workload
+      operator: Equal
+      value: agents
+    availability:
+      strategy:
+        type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 25%
+        maxSurge: 25%
+    pdb:
+      enabled: false
+    keda:
+      enabled: false
+    agc:
+      enabled: true
+      gatewayClassName: azure-alb-external
+      hostnames:
+      - esbcc8bcfyazbbdg.fz03.alb.azure.com
+      parentRefs:
+      - name: holiday-peak-agc
+        namespace: holiday-peak-crud
+      paths:
+      - path: /truth-export
+        pathType: PathPrefix
+        rewriteTo: /
+    container:
+      command:
+      - uvicorn
+      args:
+      - truth_export.main:app
+      - --host
+      - 0.0.0.0
+      - --port
+      - '8000'
+    env:
+      AI_SEARCH_AUTH_MODE: managed_identity
+      AI_SEARCH_ENDPOINT: https://holidaypeakhub405devsearch.search.windows.net
+      AI_SEARCH_INDEX: catalog-products
+      AI_SEARCH_INDEXER_NAME: search-enriched-products-indexer
+      AI_SEARCH_VECTOR_INDEX: product_search_index
+      APPLICATIONINSIGHTS_CONNECTION_STRING: InstrumentationKey=d2fb45bc-e648-4da2-9345-d278636aede5;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=d8eb64c4-956d-46ab-a02e-d481deadaa0b
+      AZURE_CLIENT_ID: e9c11fac-45b3-4057-8477-1d96703eaae4
+      AZURE_TENANT_ID: 16b3c013-d300-468d-ac64-7eda0820b6d3
+      BLOB_ACCOUNT_URL: https://holidaypeakhub405devstor.blob.core.windows.net
+      BLOB_CONTAINER: agent-memory
+      CATALOG_SEARCH_REQUIRE_AI_SEARCH: 'true'
+      COSMOS_ACCOUNT_URI: https://holidaypeakhub405-dev-cosmos.documents.azure.com:443/
+      COSMOS_CONTAINER: agent-memory
+      COSMOS_DATABASE: holiday-peak-db
+      EMBEDDING_DEPLOYMENT_NAME: text-embedding-3-large
+      FOUNDRY_AGENT_NAME_FAST: truth-export-fast
+      FOUNDRY_AGENT_NAME_RICH: truth-export-rich
+      FOUNDRY_AUTO_ENSURE_ON_STARTUP: 'true'
+      FOUNDRY_STREAM: 'true'
+      AGENT_FOUNDRY_INVOKE_TIMEOUT_SECONDS: '60'
+      FOUNDRY_STRICT_ENFORCEMENT: 'false'
+      KEY_VAULT_URI: https://holidaypeakhub405-dev-kv.vault.azure.net/
+      MODEL_DEPLOYMENT_NAME_FAST: gpt-5-nano
+      MODEL_DEPLOYMENT_NAME_RICH: gpt-5
+      PLATFORM_JOBS_EVENT_HUB_NAMESPACE: holidaypeakhub405-dev-jobs-eh
+      POSTGRES_AUTH_MODE: entra
+      POSTGRES_DATABASE: holiday_peak_crud
+      POSTGRES_HOST: holidaypeakhub405-dev-postgres.postgres.database.azure.com
+      POSTGRES_SSL: 'true'
+      POSTGRES_USER: holidaypeakhub405-dev-crud-identity
+      PROJECT_ENDPOINT: https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris
+      PROJECT_NAME: aipholidaris
+      REDIS_HOST: holidaypeakhub405-dev-redis.redis.cache.windows.net
+      REDIS_PASSWORD_SECRET_NAME: redis-primary-key
+      TRUTH_EVENT_HUB_CONSUMER_GROUP: export-engine
+      TRUTH_EVENT_HUB_NAME: export-jobs

--- a/.kubernetes/releases/agents/truth-ingestion.yaml
+++ b/.kubernetes/releases/agents/truth-ingestion.yaml
@@ -1,0 +1,110 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: truth-ingestion
+  namespace: flux-system
+spec:
+  targetNamespace: holiday-peak-agents
+  releaseName: truth-ingestion
+  interval: 5m
+  timeout: 10m
+  chart:
+    spec:
+      chart: .kubernetes/chart
+      sourceRef:
+        kind: GitRepository
+        name: holiday-peak-gitops
+        namespace: flux-system
+      interval: 5m
+  upgrade:
+    remediation:
+      retries: 3
+  install:
+    createNamespace: false
+    remediation:
+      retries: 3
+  values:
+    serviceName: truth-ingestion
+    serviceAccount:
+      create: true
+      clientId: e9c11fac-45b3-4057-8477-1d96703eaae4
+    image:
+      repository: holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/truth-ingestion-dev
+      tag: azd-deploy-1775349769
+    replicaCount: 2
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 250m
+        memory: 256Mi
+    nodeSelector:
+      agentpool: agents
+    tolerations:
+    - effect: NoSchedule
+      key: workload
+      operator: Equal
+      value: agents
+    availability:
+      strategy:
+        type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 25%
+        maxSurge: 25%
+    pdb:
+      enabled: false
+    keda:
+      enabled: false
+    agc:
+      enabled: true
+      gatewayClassName: azure-alb-external
+      hostnames:
+      - esbcc8bcfyazbbdg.fz03.alb.azure.com
+      parentRefs:
+      - name: holiday-peak-agc
+        namespace: holiday-peak-crud
+      paths:
+      - path: /truth-ingestion
+        pathType: PathPrefix
+        rewriteTo: /
+    deployment:
+      selectorIncludeCanary: true
+    env:
+      AI_SEARCH_AUTH_MODE: managed_identity
+      AI_SEARCH_ENDPOINT: https://holidaypeakhub405devsearch.search.windows.net
+      AI_SEARCH_INDEX: catalog-products
+      AI_SEARCH_INDEXER_NAME: search-enriched-products-indexer
+      AI_SEARCH_VECTOR_INDEX: product_search_index
+      APPLICATIONINSIGHTS_CONNECTION_STRING: InstrumentationKey=d2fb45bc-e648-4da2-9345-d278636aede5;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=d8eb64c4-956d-46ab-a02e-d481deadaa0b
+      AZURE_CLIENT_ID: e9c11fac-45b3-4057-8477-1d96703eaae4
+      AZURE_TENANT_ID: 16b3c013-d300-468d-ac64-7eda0820b6d3
+      BLOB_ACCOUNT_URL: https://holidaypeakhub405devstor.blob.core.windows.net
+      BLOB_CONTAINER: agent-memory
+      CATALOG_SEARCH_REQUIRE_AI_SEARCH: 'true'
+      COSMOS_ACCOUNT_URI: https://holidaypeakhub405-dev-cosmos.documents.azure.com:443/
+      COSMOS_AUDIT_CONTAINER: audit
+      COSMOS_CONTAINER: products
+      COSMOS_DATABASE: holiday-peak-db
+      EMBEDDING_DEPLOYMENT_NAME: text-embedding-3-large
+      FOUNDRY_AGENT_NAME_FAST: truth-ingestion-fast
+      FOUNDRY_AGENT_NAME_RICH: truth-ingestion-rich
+      FOUNDRY_AUTO_ENSURE_ON_STARTUP: 'true'
+      FOUNDRY_STREAM: 'true'
+      AGENT_FOUNDRY_INVOKE_TIMEOUT_SECONDS: '60'
+      FOUNDRY_STRICT_ENFORCEMENT: 'false'
+      KEY_VAULT_URI: https://holidaypeakhub405-dev-kv.vault.azure.net/
+      MODEL_DEPLOYMENT_NAME_FAST: gpt-5-nano
+      MODEL_DEPLOYMENT_NAME_RICH: gpt-5
+      PLATFORM_JOBS_EVENT_HUB_NAMESPACE: holidaypeakhub405-dev-jobs-eh
+      POSTGRES_AUTH_MODE: entra
+      POSTGRES_DATABASE: holiday_peak_crud
+      POSTGRES_HOST: holidaypeakhub405-dev-postgres.postgres.database.azure.com
+      POSTGRES_SSL: 'true'
+      POSTGRES_USER: holidaypeakhub405-dev-crud-identity
+      PROJECT_ENDPOINT: https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris
+      PROJECT_NAME: aipholidaris
+      REDIS_HOST: holidaypeakhub405-dev-redis.redis.cache.windows.net
+      REDIS_PASSWORD_SECRET_NAME: redis-primary-key
+      TRUTH_EVENT_HUB_CONSUMER_GROUP: ingestion-group
+      TRUTH_EVENT_HUB_NAME: ingest-jobs

--- a/.kubernetes/releases/crud/crud-service.yaml
+++ b/.kubernetes/releases/crud/crud-service.yaml
@@ -1,0 +1,120 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: crud-service
+  namespace: flux-system
+spec:
+  targetNamespace: holiday-peak-crud
+  releaseName: crud-service
+  interval: 5m
+  timeout: 10m
+  chart:
+    spec:
+      chart: .kubernetes/chart
+      sourceRef:
+        kind: GitRepository
+        name: holiday-peak-gitops
+        namespace: flux-system
+      interval: 5m
+  upgrade:
+    remediation:
+      retries: 3
+  install:
+    createNamespace: false
+    remediation:
+      retries: 3
+  values:
+    serviceName: crud-service
+    serviceAccount:
+      create: true
+      clientId: b09349cf-547f-409f-8b96-f3288ddedf34
+    image:
+      repository: holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/crud-service-dev
+      tag: azd-deploy-1775825425
+    replicaCount: 1
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 250m
+        memory: 256Mi
+    nodeSelector:
+      agentpool: crud
+    tolerations:
+    - effect: NoSchedule
+      key: workload
+      operator: Equal
+      value: crud
+    availability:
+      strategy:
+        type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 100%
+        maxSurge: 1
+    pdb:
+      enabled: false
+    keda:
+      enabled: false
+    preflight:
+      postgresAuth:
+        enabled: true
+    agc:
+      enabled: true
+      gatewayClassName: azure-alb-external
+      hostnames:
+      - esbcc8bcfyazbbdg.fz03.alb.azure.com
+      parentRefs:
+      - name: holiday-peak-agc
+        namespace: holiday-peak-crud
+      paths:
+      - path: /health
+        pathType: PathPrefix
+      - path: /api
+        pathType: PathPrefix
+      sharedResources:
+        create: true
+        namespace: holiday-peak-crud
+        applicationLoadBalancerName: holiday-peak-agc
+        gatewayName: holiday-peak-agc
+        subnetId: /subscriptions/150e82e8-25db-4f1a-8e04-a2f6a77d26c4/resourceGroups/holidaypeakhub405-dev-rg/providers/Microsoft.Network/virtualNetworks/holidaypeakhub405-dev-vnet/subnets/agc
+        allowedRouteNamespaces: All
+        listeners:
+        - name: http
+          protocol: HTTP
+          port: 80
+          hostname: esbcc8bcfyazbbdg.fz03.alb.azure.com
+    env:
+      AI_SEARCH_AUTH_MODE: managed_identity
+      AI_SEARCH_ENDPOINT: https://holidaypeakhub405devsearch.search.windows.net
+      AI_SEARCH_INDEX: catalog-products
+      AI_SEARCH_INDEXER_NAME: search-enriched-products-indexer
+      AI_SEARCH_VECTOR_INDEX: product_search_index
+      APPLICATIONINSIGHTS_CONNECTION_STRING: InstrumentationKey=d2fb45bc-e648-4da2-9345-d278636aede5;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=d8eb64c4-956d-46ab-a02e-d481deadaa0b
+      AZURE_CLIENT_ID: b09349cf-547f-409f-8b96-f3288ddedf34
+      AZURE_TENANT_ID: 16b3c013-d300-468d-ac64-7eda0820b6d3
+      BLOB_ACCOUNT_URL: https://holidaypeakhub405devstor.blob.core.windows.net
+      BLOB_CONTAINER: agent-memory
+      CATALOG_SEARCH_REQUIRE_AI_SEARCH: 'true'
+      COSMOS_ACCOUNT_URI: https://holidaypeakhub405-dev-cosmos.documents.azure.com:443/
+      COSMOS_CONTAINER: agent-memory
+      COSMOS_DATABASE: holiday-peak-db
+      EMBEDDING_DEPLOYMENT_NAME: text-embedding-3-large
+      EVENT_HUB_NAMESPACE: holidaypeakhub405-dev-eventhub
+      FOUNDRY_AUTO_ENSURE_ON_STARTUP: 'true'
+      FOUNDRY_STREAM: 'true'
+      AGENT_FOUNDRY_INVOKE_TIMEOUT_SECONDS: '60'
+      FOUNDRY_STRICT_ENFORCEMENT: 'false'
+      KEY_VAULT_URI: https://holidaypeakhub405-dev-kv.vault.azure.net/
+      MODEL_DEPLOYMENT_NAME_FAST: gpt-5-nano
+      MODEL_DEPLOYMENT_NAME_RICH: gpt-5
+      POSTGRES_AUTH_MODE: entra
+      POSTGRES_DATABASE: holiday_peak_crud
+      POSTGRES_HOST: holidaypeakhub405-dev-postgres.postgres.database.azure.com
+      POSTGRES_PORT: '5432'
+      POSTGRES_SSL: 'true'
+      POSTGRES_USER: holidaypeakhub405-dev-crud-identity
+      PROJECT_ENDPOINT: https://holidaypeakhub405devais.services.ai.azure.com/api/projects/aipholidaris
+      PROJECT_NAME: aipholidaris
+      REDIS_HOST: holidaypeakhub405-dev-redis.redis.cache.windows.net
+      REDIS_PASSWORD_SECRET_NAME: redis-primary-key

--- a/.kubernetes/releases/crud/kustomization.yaml
+++ b/.kubernetes/releases/crud/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Pattern A — Flux HelmRelease-based deployment for the transactional CRUD service.
+# Owns the shared AGC ApplicationLoadBalancer + Gateway used by all routed services.
+# See ADR-017 for the canonical deployment topology.
+resources:
+  - crud-service.yaml

--- a/docs/architecture/adrs/adr-017-deployment-strategy.md
+++ b/docs/architecture/adrs/adr-017-deployment-strategy.md
@@ -3,6 +3,7 @@
 **Status**: Accepted (Revised)  
 **Date**: 2026-02  
 **Updated**: 2026-04-28 — Consolidated Flux CD deployment decision into unified deployment ADR. Infrastructure provisioning via `azd provision`; application deployment via Flux CD.  
+**Updated**: 2026-05-21 — Phase 2 completed: rolled out HelmRelease-driven reconciliation to all 27 AKS services (1 CRUD + 26 agents). Removed the `commit-rendered-manifests` workflow seam that pushed bot commits to protected `main` (rejected by `main-governance-baseline` ruleset, GH013). Flux now reconciles `.kubernetes/releases/{crud,agents}` exclusively.  
 **Deciders**: Architecture Team, Ricardo Cataldi  
 **Tags**: infrastructure, deployment, ci-cd, azd, helm, aks, gitops, flux, helmrelease
 
@@ -350,11 +351,48 @@ Phase 2: CI pushes image to ACR → Flux HelmRelease renders in-cluster from cha
 - E2E test: 200 OK, 5 results, correct image and env vars deployed
 - Timeout env vars (`INTELLIGENT_PIPELINE_TIMEOUT_SECONDS=120`, etc.) confirmed
 
-#### Phase 2b (Future): Image Automation
+##### Phase 2 Completion (2026-05-21)
 
-- Flux `ImageRepository` + `ImagePolicy` + `ImageUpdateAutomation` for ACR tag updates
-- Eliminates CI committing image tags; Flux watches ACR directly
-- Branch deployment support via HelmRelease targeting different sourceRef
+Pattern A (Flux HelmRelease + in-cluster Helm rendering) is the canonical AKS
+deployment surface for the entire product. Trigger was the `commit-rendered-manifests`
+job in `deploy-azd.yml` repeatedly failing to push bot-generated rendered manifests
+to `refs/heads/main` (`main-governance-baseline` ruleset, GitHub `GH013`).
+Bypass-actor and orphan-branch alternatives were rejected as anti-patterns.
+
+What landed:
+
+- **27 HelmReleases** in git: 1 CRUD (`.kubernetes/releases/crud/crud-service.yaml`),
+  26 agents (`.kubernetes/releases/agents/<service>.yaml`). Generator script preserves
+  every env var, resource limit, AGC route, command/args override, and UAMI binding
+  read from the previously deployed cluster state.
+- **Bicep `fluxConfig`** switched from `.kubernetes/rendered/{crud,agents}` to
+  `.kubernetes/releases/{crud,agents}`. CRUD kustomization runs first; agents
+  kustomization depends on it.
+- **Workflow `deploy-azd.yml`**: removed `commit-rendered-manifests` job and rewired
+  `wait-flux-reconciliation` to depend on `deploy-crud` / `deploy-agents` directly.
+  No workflow ever pushes back to `main`.
+- **Image tag policy**: HelmRelease YAML carries the immutable image tag for the
+  current desired state. New deploys still build + push to ACR via `azd deploy`,
+  and the existing kubectl-apply path rolls the new image. Within 5 minutes Flux
+  reconciles the HelmRelease and may revert if the image tag in the YAML is older
+  — image automation closes this gap (see Phase 2b).
+
+Why this resolves the protected-branch problem permanently:
+
+- The helm-controller renders the chart in-cluster on every reconciliation. There
+  is no rendered YAML in git, so no bot commit to `main` is ever required to
+  reflect a deploy.
+- The HelmRelease YAML is the single source of truth for desired state. It is
+  edited via normal PRs, which clears the ruleset.
+
+#### Phase 2b (Next): Image Automation
+
+- Flux `ImageRepository` + `ImagePolicy` + `ImageUpdateAutomation` for ACR tag updates.
+- For protected branches, image-update commits arrive as auto-merging PRs (PR-bridge
+  pattern) instead of direct pushes — same protection model as human edits.
+- Eliminates the residual drift window where Flux can revert a freshly applied
+  image to the older tag still recorded in the HelmRelease YAML.
+- Branch deployment support via HelmRelease targeting different sourceRef.
 
 #### Why Flux over Argo CD
 


### PR DESCRIPTION
## Summary

Closes #1088. Migrates all 27 AKS services to Pattern A (Flux `HelmRelease` CRDs reconciled in-cluster) and removes the workflow seam that triggered `GH013 Repository rule violations` on every `deploy-azd` run.

## Why

`deploy-azd.yml::commit-rendered-manifests` pushed bot-rendered manifests directly to `refs/heads/main`. The `main-governance-baseline` ruleset (id `14638366`) rejects every such push. Bypass-actor and orphan-branch alternatives were rejected as anti-patterns.

## What changed

- Generated 24 new agent `HelmRelease` YAMLs + 1 new CRUD `HelmRelease` (joining the 3 pre-existing pilots: `ecommerce-catalog-search`, `truth-enrichment`, `truth-hitl`) — **27 services total**.
- `.kubernetes/releases/agents/kustomization.yaml` and `.kubernetes/releases/crud/kustomization.yaml` list all resources.
- `shared-infrastructure.bicep::fluxConfig` now points at `.kubernetes/releases/{crud,agents}` (was `.kubernetes/rendered/{crud,agents}`).
- Deleted the entire `commit-rendered-manifests` job from `deploy-azd.yml` and rewired `wait-flux-reconciliation`, `watchdog-apim-agc-swa-drift`, and `restore-flux-source-default-branch` `needs:` references.
- Renamed remaining manifest upload steps from `...for Flux commit` to `...for verification`.
- ADR-017 amended with `Phase 2 completion (2026-05-21)` and a follow-up `Phase 2b: image automation` plan.

## Validation (local)

- `helm template` passes against `.kubernetes/chart` for **all 27** `HelmRelease` value blocks.
- `kubectl kustomize` resolves both directories (1 + 26 resources).
- `yaml.safe_load` of `deploy-azd.yml` succeeds; only one remaining mention of `commit-rendered-manifests` (an explanatory comment).
- `scripts/ci/validate_k8s_name_length.py` passes.
- Pre-push hook full pass: isort, black, pylint 9.91/10, mypy, markdown-links, event-schema-contracts, **1326 lib tests**, **705 app tests**.

## Post-merge verification (gating `deploy-azd`)

- [ ] `deploy-azd` workflow run is **green** with no `commit-rendered-manifests` step.
- [ ] Bicep redeploys; both Kustomizations (`holiday-peak-gitops-holiday-peak-{crud,agents}`) reach `Ready=True`.
- [ ] All 27 `HelmReleases` reach `Ready=True`.
- [ ] All 27 pods report `1/1 Running` in `holiday-peak-{crud,agents}`.
- [ ] AGC health probes succeed for CRUD `/health` and `/ready` and a sample of agents.

## Out of scope (follow-up issues)

- **Phase 2b: Image automation** via Flux `ImageRepository` + `ImagePolicy` + `ImageUpdateAutomation` with PR-bridge — closes the residual drift window where `azd deploy`'s `kubectl apply` may be reverted by Flux to the older HelmRelease-pinned tag.
- Removal of `.kubernetes/rendered/` and predeploy `render-helm.sh` hooks once Phase 2b is in place.
