### PR TITLE
fix(crud): disable broken postgres-auth preflight init container (#1088)

### DIFF
--- a/.kubernetes/releases/crud/crud-service.yaml
+++ b/.kubernetes/releases/crud/crud-service.yaml
@@ -58,7 +58,12 @@ spec:
       enabled: false
     preflight:
       postgresAuth:
-        enabled: true
+        # Disabled: the chart's init container assumes Alpine (apk add postgresql-client jq),
+        # but mcr.microsoft.com/azure-cli:latest is now Mariner -> apk missing -> Exit 127 ->
+        # CrashLoopBackOff. BaseRepository.check_pool_health self-recovers from transient pool
+        # init errors per fix 811fdbe6 (#911 / PR #1087), so this preflight gate is no longer
+        # load-bearing. Tracked for permanent multi-distro fix in chart in a follow-up.
+        enabled: false
     agc:
       enabled: true
       gatewayClassName: azure-alb-external


### PR DESCRIPTION
## Summary

Disable the broken `postgres-auth-preflight` init container in the CRUD HelmRelease values to restore Flux GitOps management of `crud-service`.

## Context (incident)

PR #1090 finalized the Pattern A Helm takeover for `crud-service` (per ADR-017). Flux installed the HelmRelease, and the rendered Deployment caused a rolling update because pod template hashes differed from the live `azd deploy`-applied spec.

The new pod failed to start because:

1. The chart's `postgres-auth-preflight` init container at [.kubernetes/chart/templates/deployment.yaml#L70-L156](https://github.com/Azure-Samples/holiday-peak-hub/blob/main/.kubernetes/chart/templates/deployment.yaml#L70-L156) installs `psql` and `jq` via `apk add`, assuming the base image (`mcr.microsoft.com/azure-cli:latest`) is Alpine.
2. The image is now Mariner-based, so `apk` is missing → `Exit 127` → `CrashLoopBackOff`.
3. The legacy live pod (5h+ uptime) was using a cached Alpine layer, so it kept running. Helm's rolling update pulled a fresh image and broke.

A second race (legacy ALB pruned by `kustomize-controller` after Helm adoption) compounded the impact, but that part has been recovered by re-applying the Helm-rendered manifest. Cluster currently shows CRUD `/health` 200 OK and 26/26 agents 200 OK.

## Change

Flip `preflight.postgresAuth.enabled` from `true` to `false` in [.kubernetes/releases/crud/crud-service.yaml](https://github.com/Azure-Samples/holiday-peak-hub/blob/main/.kubernetes/releases/crud/crud-service.yaml).

## Why this is safe

- `BaseRepository.check_pool_health` self-recovers from transient pool init errors per commit 811fdbe6 (PR #1087 / fixes #911). The preflight gate is no longer load-bearing.
- The `crud-service` test suite (265 tests including `test_base_repository_pool_health.py`) covers the self-healing path.
- Cluster has been operating without preflight (init container manually stripped) for ~30 minutes with no regressions.

## Post-merge plan

1. Once Flux GitRepository advances to the merge SHA, unsuspend the HelmRelease:
   `kubectl patch helmrelease crud-service -n flux-system --type=merge -p '{"spec":{"suspend":false}}'`
2. Helm will reconcile. Rendered Deployment (no init container) matches the current live drift → quiet rollout.

## Follow-ups (separate PRs)

- Chart fix: replace `apk add` with multi-distro detection (`apk`/`tdnf`/`apt-get`) or pin an Alpine-tagged `azure-cli` image, then re-enable preflight where appropriate.
- ADR-017 addendum: document the prune-vs-Helm-adopt race and add a pre-flight verification step (chart vs live spec diff) for Pattern A takeovers.

## Verification

- Pre-push gate: 1326 lib tests + 705 app tests pass; pylint 9.91/10; mypy clean.
- External AGC probe: `http://esbcc8bcfyazbbdg.fz03.alb.azure.com/health` → HTTP 200; 26/26 agent `/<service>/health` endpoints → HTTP 200.

Closes #1088 (incident remediation tracking).