### PR TITLE
feat(deploy): align Flux HelmReleases with build path + add image-tag PR bridge (#990)

### DIFF
--- a/.github/workflows/deploy-azd.yml
+++ b/.github/workflows/deploy-azd.yml
@@ -2717,14 +2717,130 @@ jobs:
           path: .kubernetes/rendered/${{ matrix.service }}/all.yaml
           retention-days: 1
 
-  # NOTE (ADR-017 amendment, Pattern A): the previous `commit-rendered-manifests`
-  # job was deleted because it pushed bot-generated manifests directly to
-  # `refs/heads/main`, which is rejected by the `main-governance-baseline`
-  # ruleset (GH013). Flux now reconciles HelmRelease CRDs from
-  # `.kubernetes/releases/{crud,agents}` and the helm-controller renders the
-  # chart in-cluster on every reconciliation, so no workflow push to main is
-  # ever required. Image tag updates remain a follow-up (planned: Flux
-  # ImageUpdateAutomation with PR bridge).
+  # ADR-017 amendment, Pattern A — image-tag PR bridge.
+  #
+  # The previous ``commit-rendered-manifests`` job pushed bot-generated YAML
+  # straight at ``refs/heads/main``, which the ``main-governance-baseline``
+  # ruleset (GH013) rejects. Flux now reconciles HelmRelease CRDs from
+  # ``.kubernetes/releases/{crud,agents}`` and the helm-controller renders the
+  # chart in-cluster on every reconciliation. To close the loop without
+  # pushing to ``main``, the build emits ``tested-image-*`` artifacts holding
+  # the immutable ACR reference for each service. The job below consumes those
+  # artifacts and opens a single image-bump PR per deploy, so Flux picks up
+  # the new images on the next reconcile after the PR is merged.
+  open-image-tag-bump-pr:
+    runs-on: ubuntu-latest
+    # Run only when at least one of the deploy matrices actually produced new
+    # tested images and the run was not cancelled. The bridge intentionally
+    # does NOT depend on ``success()`` of every deploy slot — partial deploys
+    # (e.g., a single matrix entry flaked) should still surface the bumps for
+    # the services that did succeed.
+    if: ${{ always() && !cancelled() && !inputs.uiOnly && (needs.deploy-crud.result == 'success' || needs.deploy-agents.result == 'success') }}
+    needs:
+      - deploy-crud
+      - deploy-agents
+      - detect-changes
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      DEPLOY_ENV: ${{ inputs.environment }}
+      # ``env.DEPLOY_SOURCE_SHA`` is not visible inside job-level ``env:`` so
+      # we re-derive the same expression used at the workflow level.
+      DEPLOY_SHA: ${{ inputs.sourceSha != '' && inputs.sourceSha || github.sha }}
+      DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+    steps:
+      - name: Checkout default branch
+        uses: actions/checkout@v4
+        with:
+          # The bridge edits Flux source-of-truth files on the default branch
+          # so the PR diff reflects only the image bumps from this deploy.
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Download tested-image artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/tested-images
+          pattern: tested-image-*
+
+      - name: Apply HelmRelease image bumps
+        id: update
+        shell: bash
+        env:
+          RUNNER_TEMP: ${{ runner.temp }}
+        run: |
+          set -euo pipefail
+          changed=0
+          declare -a updated_services=()
+          for dir in "${RUNNER_TEMP}/tested-images"/tested-image-*; do
+            [ -d "$dir" ] || continue
+            svc=$(basename "$dir" | sed 's/^tested-image-//')
+            ref_file="$dir/image-ref.txt"
+            if [ ! -f "$ref_file" ]; then
+              echo "::warning::no image-ref.txt for ${svc} — skipping"
+              continue
+            fi
+            image_ref=$(tr -d '\r\n' < "$ref_file")
+            # image_ref shape: ``<registry>/<svc>@sha256:<digest>``. The
+            # registry path is the durable identifier; the tag is the SHA we
+            # already pushed alongside the digest in ``build-aks-images``.
+            repo="${image_ref%@*}"
+            tag="${DEPLOY_SHA}"
+            if [ "$svc" = "crud-service" ]; then
+              target=".kubernetes/releases/crud/${svc}.yaml"
+            else
+              target=".kubernetes/releases/agents/${svc}.yaml"
+            fi
+            if [ ! -f "$target" ]; then
+              echo "::warning::no HelmRelease found for ${svc} at ${target}"
+              continue
+            fi
+            python3 scripts/ci/update_helmrelease_image.py "$target" "$repo" "$tag"
+            if ! git diff --quiet -- "$target"; then
+              updated_services+=("$svc")
+              changed=$((changed + 1))
+            fi
+          done
+          echo "changed_count=${changed}" >> "$GITHUB_OUTPUT"
+          if [ "${changed}" -gt 0 ]; then
+            printf 'updated_services=%s\n' "${updated_services[*]}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open or refresh PR
+        if: ${{ steps.update.outputs.changed_count != '0' }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPDATED_SERVICES: ${{ steps.update.outputs.updated_services }}
+        run: |
+          set -euo pipefail
+          short="${DEPLOY_SHA:0:12}"
+          branch="chore/image-bump-${DEPLOY_ENV}-${short}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c "$branch"
+          git add .kubernetes/releases
+          git commit -m "chore(deploy): bump ${DEPLOY_ENV} HelmRelease image tags to ${short}" \
+                     -m "Triggered by deploy-azd run ${{ github.run_id }}. Services: ${UPDATED_SERVICES}. Merge to roll new images via Flux reconciliation."
+          git push -f origin "$branch"
+          existing=$(gh pr list --state open --head "$branch" --base "${DEFAULT_BRANCH:-main}" --json number --jq '.[0].number // ""' 2>/dev/null || echo '')
+          if [ -z "${existing}" ]; then
+            gh pr create \
+              --base "${DEFAULT_BRANCH:-main}" \
+              --head "$branch" \
+              --title "chore(deploy): bump ${DEPLOY_ENV} HelmRelease image tags to ${short}" \
+              --body "Auto-generated by [deploy-azd run ${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+
+          Updates HelmRelease \`image.repository\` and \`image.tag\` to the freshly built & tested images at SHA \`${DEPLOY_SHA}\` for environment **${DEPLOY_ENV}**.
+
+          **Services updated (${{ steps.update.outputs.changed_count }}):** ${UPDATED_SERVICES}
+
+          Merging this PR triggers Flux reconciliation, which rolls the new images. No additional action required after merge."
+          else
+            echo "PR #${existing} already open against ${branch}; force-pushed branch HEAD."
+          fi
 
   wait-flux-reconciliation:
     runs-on: ubuntu-latest

--- a/.kubernetes/releases/agents/crm-campaign-intelligence.yaml
+++ b/.kubernetes/releases/agents/crm-campaign-intelligence.yaml
@@ -29,8 +29,8 @@ spec:
       create: true
       clientId: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
     image:
-      repository: holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/crm-campaign-intelligence-dev
-      tag: azd-deploy-1775344528
+      repository: holidaypeakhub405devacr.azurecr.io/crm-campaign-intelligence
+      tag: 808d48227b08ceaf9f2d820010e02edf5250b57f
     replicaCount: 2
     resources:
       limits:

--- a/.kubernetes/releases/agents/crm-profile-aggregation.yaml
+++ b/.kubernetes/releases/agents/crm-profile-aggregation.yaml
@@ -29,8 +29,8 @@ spec:
       create: true
       clientId: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
     image:
-      repository: holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/crm-profile-aggregation-dev
-      tag: azd-deploy-1775344626
+      repository: holidaypeakhub405devacr.azurecr.io/crm-profile-aggregation
+      tag: 808d48227b08ceaf9f2d820010e02edf5250b57f
     replicaCount: 2
     resources:
       limits:

--- a/.kubernetes/releases/agents/crm-segmentation-personalization.yaml
+++ b/.kubernetes/releases/agents/crm-segmentation-personalization.yaml
@@ -29,8 +29,8 @@ spec:
       create: true
       clientId: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
     image:
-      repository: holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/crm-segmentation-personalization-dev
-      tag: azd-deploy-1775344793
+      repository: holidaypeakhub405devacr.azurecr.io/crm-segmentation-personalization
+      tag: 808d48227b08ceaf9f2d820010e02edf5250b57f
     replicaCount: 2
     resources:
       limits:

--- a/.kubernetes/releases/agents/crm-support-assistance.yaml
+++ b/.kubernetes/releases/agents/crm-support-assistance.yaml
@@ -29,8 +29,8 @@ spec:
       create: true
       clientId: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
     image:
-      repository: holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/crm-support-assistance-dev
-      tag: azd-deploy-1775345018
+      repository: holidaypeakhub405devacr.azurecr.io/crm-support-assistance
+      tag: 808d48227b08ceaf9f2d820010e02edf5250b57f
     replicaCount: 2
     resources:
       limits:

--- a/.kubernetes/releases/agents/ecommerce-cart-intelligence.yaml
+++ b/.kubernetes/releases/agents/ecommerce-cart-intelligence.yaml
@@ -29,8 +29,8 @@ spec:
       create: true
       clientId: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
     image:
-      repository: holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/ecommerce-cart-intelligence-dev
-      tag: azd-deploy-1775345183
+      repository: holidaypeakhub405devacr.azurecr.io/ecommerce-cart-intelligence
+      tag: 808d48227b08ceaf9f2d820010e02edf5250b57f
     replicaCount: 2
     resources:
       limits:

--- a/.kubernetes/releases/agents/ecommerce-catalog-search.yaml
+++ b/.kubernetes/releases/agents/ecommerce-catalog-search.yaml
@@ -32,8 +32,8 @@ spec:
       clientId: "036f4fd2-9093-4948-b0dd-beb5c87aa6dc"
 
     image:
-      repository: holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/ecommerce-catalog-search-dev
-      tag: deterministic-fanout-20260420-190823
+      repository: holidaypeakhub405devacr.azurecr.io/ecommerce-catalog-search
+      tag: 808d48227b08ceaf9f2d820010e02edf5250b57f
 
     replicaCount: 1
 

--- a/.kubernetes/releases/agents/ecommerce-checkout-support.yaml
+++ b/.kubernetes/releases/agents/ecommerce-checkout-support.yaml
@@ -29,8 +29,8 @@ spec:
       create: true
       clientId: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
     image:
-      repository: holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/ecommerce-checkout-support-dev
-      tag: azd-deploy-1775345620
+      repository: holidaypeakhub405devacr.azurecr.io/ecommerce-checkout-support
+      tag: 808d48227b08ceaf9f2d820010e02edf5250b57f
     replicaCount: 2
     resources:
       limits:

--- a/.kubernetes/releases/agents/ecommerce-order-status.yaml
+++ b/.kubernetes/releases/agents/ecommerce-order-status.yaml
@@ -29,8 +29,8 @@ spec:
       create: true
       clientId: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
     image:
-      repository: holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/ecommerce-order-status-dev
-      tag: azd-deploy-1775345850
+      repository: holidaypeakhub405devacr.azurecr.io/ecommerce-order-status
+      tag: 808d48227b08ceaf9f2d820010e02edf5250b57f
     replicaCount: 2
     resources:
       limits:

--- a/.kubernetes/releases/agents/ecommerce-product-detail-enrichment.yaml
+++ b/.kubernetes/releases/agents/ecommerce-product-detail-enrichment.yaml
@@ -29,8 +29,8 @@ spec:
       create: true
       clientId: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
     image:
-      repository: holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/ecommerce-product-detail-enrichment-dev
-      tag: azd-deploy-1775346091
+      repository: holidaypeakhub405devacr.azurecr.io/ecommerce-product-detail-enrichment
+      tag: 808d48227b08ceaf9f2d820010e02edf5250b57f
     replicaCount: 2
     resources:
       limits:

--- a/.kubernetes/releases/agents/inventory-alerts-triggers.yaml
+++ b/.kubernetes/releases/agents/inventory-alerts-triggers.yaml
@@ -29,8 +29,8 @@ spec:
       create: true
       clientId: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
     image:
-      repository: holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/inventory-alerts-triggers-dev
-      tag: azd-deploy-1775346297
+      repository: holidaypeakhub405devacr.azurecr.io/inventory-alerts-triggers
+      tag: 808d48227b08ceaf9f2d820010e02edf5250b57f
     replicaCount: 2
     resources:
       limits:

--- a/.kubernetes/releases/agents/inventory-health-check.yaml
+++ b/.kubernetes/releases/agents/inventory-health-check.yaml
@@ -29,8 +29,8 @@ spec:
       create: true
       clientId: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
     image:
-      repository: holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/inventory-health-check-dev
-      tag: azd-deploy-1775346564
+      repository: holidaypeakhub405devacr.azurecr.io/inventory-health-check
+      tag: 808d48227b08ceaf9f2d820010e02edf5250b57f
     replicaCount: 2
     resources:
       limits:

--- a/.kubernetes/releases/agents/inventory-jit-replenishment.yaml
+++ b/.kubernetes/releases/agents/inventory-jit-replenishment.yaml
@@ -29,8 +29,8 @@ spec:
       create: true
       clientId: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
     image:
-      repository: holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/inventory-jit-replenishment-dev
-      tag: azd-deploy-1775346858
+      repository: holidaypeakhub405devacr.azurecr.io/inventory-jit-replenishment
+      tag: 808d48227b08ceaf9f2d820010e02edf5250b57f
     replicaCount: 2
     resources:
       limits:

--- a/.kubernetes/releases/agents/inventory-reservation-validation.yaml
+++ b/.kubernetes/releases/agents/inventory-reservation-validation.yaml
@@ -29,8 +29,8 @@ spec:
       create: true
       clientId: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
     image:
-      repository: holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/inventory-reservation-validation-dev
-      tag: azd-deploy-1775347087
+      repository: holidaypeakhub405devacr.azurecr.io/inventory-reservation-validation
+      tag: 808d48227b08ceaf9f2d820010e02edf5250b57f
     replicaCount: 2
     resources:
       limits:

--- a/.kubernetes/releases/agents/logistics-carrier-selection.yaml
+++ b/.kubernetes/releases/agents/logistics-carrier-selection.yaml
@@ -29,8 +29,8 @@ spec:
       create: true
       clientId: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
     image:
-      repository: holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/logistics-carrier-selection-dev
-      tag: azd-deploy-1775347321
+      repository: holidaypeakhub405devacr.azurecr.io/logistics-carrier-selection
+      tag: 808d48227b08ceaf9f2d820010e02edf5250b57f
     replicaCount: 2
     resources:
       limits:

--- a/.kubernetes/releases/agents/logistics-eta-computation.yaml
+++ b/.kubernetes/releases/agents/logistics-eta-computation.yaml
@@ -29,8 +29,8 @@ spec:
       create: true
       clientId: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
     image:
-      repository: holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/logistics-eta-computation-dev
-      tag: azd-deploy-1775347585
+      repository: holidaypeakhub405devacr.azurecr.io/logistics-eta-computation
+      tag: 808d48227b08ceaf9f2d820010e02edf5250b57f
     replicaCount: 2
     resources:
       limits:

--- a/.kubernetes/releases/agents/logistics-returns-support.yaml
+++ b/.kubernetes/releases/agents/logistics-returns-support.yaml
@@ -29,8 +29,8 @@ spec:
       create: true
       clientId: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
     image:
-      repository: holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/logistics-returns-support-dev
-      tag: azd-deploy-1775347833
+      repository: holidaypeakhub405devacr.azurecr.io/logistics-returns-support
+      tag: 808d48227b08ceaf9f2d820010e02edf5250b57f
     replicaCount: 2
     resources:
       limits:

--- a/.kubernetes/releases/agents/logistics-route-issue-detection.yaml
+++ b/.kubernetes/releases/agents/logistics-route-issue-detection.yaml
@@ -29,8 +29,8 @@ spec:
       create: true
       clientId: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
     image:
-      repository: holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/logistics-route-issue-detection-dev
-      tag: azd-deploy-1775348087
+      repository: holidaypeakhub405devacr.azurecr.io/logistics-route-issue-detection
+      tag: 808d48227b08ceaf9f2d820010e02edf5250b57f
     replicaCount: 2
     resources:
       limits:

--- a/.kubernetes/releases/agents/product-management-acp-transformation.yaml
+++ b/.kubernetes/releases/agents/product-management-acp-transformation.yaml
@@ -29,8 +29,8 @@ spec:
       create: true
       clientId: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
     image:
-      repository: holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/product-management-acp-transformation-dev
-      tag: azd-deploy-1775348336
+      repository: holidaypeakhub405devacr.azurecr.io/product-management-acp-transformation
+      tag: 808d48227b08ceaf9f2d820010e02edf5250b57f
     replicaCount: 2
     resources:
       limits:

--- a/.kubernetes/releases/agents/product-management-assortment-optimization.yaml
+++ b/.kubernetes/releases/agents/product-management-assortment-optimization.yaml
@@ -29,8 +29,8 @@ spec:
       create: true
       clientId: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
     image:
-      repository: holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/product-management-assortment-optimization-dev
-      tag: azd-deploy-1775348550
+      repository: holidaypeakhub405devacr.azurecr.io/product-management-assortment-optimization
+      tag: 808d48227b08ceaf9f2d820010e02edf5250b57f
     replicaCount: 2
     resources:
       limits:

--- a/.kubernetes/releases/agents/product-management-consistency-validation.yaml
+++ b/.kubernetes/releases/agents/product-management-consistency-validation.yaml
@@ -29,8 +29,8 @@ spec:
       create: true
       clientId: 036f4fd2-9093-4948-b0dd-beb5c87aa6dc
     image:
-      repository: holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/product-management-consistency-validation-dev
-      tag: azd-deploy-1775348779
+      repository: holidaypeakhub405devacr.azurecr.io/product-management-consistency-validation
+      tag: 808d48227b08ceaf9f2d820010e02edf5250b57f
     replicaCount: 2
     resources:
       limits:

--- a/.kubernetes/releases/agents/product-management-normalization-classification.yaml
+++ b/.kubernetes/releases/agents/product-management-normalization-classification.yaml
@@ -29,8 +29,8 @@ spec:
       create: true
       clientId: e9c11fac-45b3-4057-8477-1d96703eaae4
     image:
-      repository: holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/product-management-normalization-classification-dev
-      tag: azd-deploy-1775349002
+      repository: holidaypeakhub405devacr.azurecr.io/product-management-normalization-classification
+      tag: 808d48227b08ceaf9f2d820010e02edf5250b57f
     replicaCount: 2
     resources:
       limits:

--- a/.kubernetes/releases/agents/search-enrichment-agent.yaml
+++ b/.kubernetes/releases/agents/search-enrichment-agent.yaml
@@ -29,8 +29,8 @@ spec:
       create: true
       clientId: e9c11fac-45b3-4057-8477-1d96703eaae4
     image:
-      repository: holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/search-enrichment-agent-dev
-      tag: azd-deploy-1775349482
+      repository: holidaypeakhub405devacr.azurecr.io/search-enrichment-agent
+      tag: 808d48227b08ceaf9f2d820010e02edf5250b57f
     replicaCount: 2
     resources:
       limits:

--- a/.kubernetes/releases/agents/truth-enrichment.yaml
+++ b/.kubernetes/releases/agents/truth-enrichment.yaml
@@ -32,8 +32,8 @@ spec:
       clientId: "e9c11fac-45b3-4057-8477-1d96703eaae4"
 
     image:
-      repository: holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/truth-enrichment-dev
-      tag: azd-deploy-1775350057
+      repository: holidaypeakhub405devacr.azurecr.io/truth-enrichment
+      tag: 808d48227b08ceaf9f2d820010e02edf5250b57f
 
     replicaCount: 2
 

--- a/.kubernetes/releases/agents/truth-export.yaml
+++ b/.kubernetes/releases/agents/truth-export.yaml
@@ -29,8 +29,8 @@ spec:
       create: true
       clientId: e9c11fac-45b3-4057-8477-1d96703eaae4
     image:
-      repository: holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/truth-export-dev
-      tag: azd-deploy-1775350303
+      repository: holidaypeakhub405devacr.azurecr.io/truth-export
+      tag: 808d48227b08ceaf9f2d820010e02edf5250b57f
     replicaCount: 2
     resources:
       limits:

--- a/.kubernetes/releases/agents/truth-hitl.yaml
+++ b/.kubernetes/releases/agents/truth-hitl.yaml
@@ -32,8 +32,8 @@ spec:
       clientId: "e9c11fac-45b3-4057-8477-1d96703eaae4"
 
     image:
-      repository: holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/truth-hitl-dev
-      tag: azd-deploy-1775350566
+      repository: holidaypeakhub405devacr.azurecr.io/truth-hitl
+      tag: 808d48227b08ceaf9f2d820010e02edf5250b57f
 
     replicaCount: 2
 

--- a/.kubernetes/releases/agents/truth-ingestion.yaml
+++ b/.kubernetes/releases/agents/truth-ingestion.yaml
@@ -29,8 +29,8 @@ spec:
       create: true
       clientId: e9c11fac-45b3-4057-8477-1d96703eaae4
     image:
-      repository: holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/truth-ingestion-dev
-      tag: azd-deploy-1775349769
+      repository: holidaypeakhub405devacr.azurecr.io/truth-ingestion
+      tag: 808d48227b08ceaf9f2d820010e02edf5250b57f
     replicaCount: 2
     resources:
       limits:

--- a/.kubernetes/releases/crud/crud-service.yaml
+++ b/.kubernetes/releases/crud/crud-service.yaml
@@ -29,8 +29,8 @@ spec:
       create: true
       clientId: b09349cf-547f-409f-8b96-f3288ddedf34
     image:
-      repository: holidaypeakhub405devacr.azurecr.io/holiday-peak-hub/crud-service-dev
-      tag: azd-deploy-1775825425
+      repository: holidaypeakhub405devacr.azurecr.io/crud-service
+      tag: 808d48227b08ceaf9f2d820010e02edf5250b57f
     replicaCount: 1
     resources:
       limits:

--- a/scripts/ci/update_helmrelease_image.py
+++ b/scripts/ci/update_helmrelease_image.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Update a Flux HelmRelease's top-level ``spec.values.image`` block in place.
+
+The HelmRelease files under ``.kubernetes/releases/{agents,crud}`` are the
+Flux source of truth that the helm-controller reconciles. After each
+successful deploy of the dev cluster, the CI workflow opens a PR using
+this script to bump ``image.repository`` and ``image.tag`` to point at the
+freshly built and tested artifact in ACR. Pinning by tag (rather than
+digest) keeps the diff readable; digest pinning can be layered on later
+without changing this script's CLI contract.
+
+This script intentionally performs a *surgical* edit — line by line — to
+avoid reflowing the YAML, dropping comments, or reordering keys (any of
+which a YAML round-trip via PyYAML/ruamel would do unless carefully
+configured). The chart only honours the *first* ``image:`` block at four-
+space indent (the top-level ``spec.values.image``), so scanning until the
+first match suffices.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+_IMAGE_BLOCK_RE = re.compile(r"^    image:\s*$")
+_REPO_RE = re.compile(r"^(\s+)repository:\s+\S+\s*$")
+_TAG_RE = re.compile(r"^(\s+)tag:\s+\S+\s*$")
+_SIBLING_RE = re.compile(r"^    \S")
+
+
+def update_helmrelease(path: Path, repository: str, tag: str) -> bool:
+    """Edit ``path`` to set ``image.repository`` and ``image.tag``.
+
+    Returns ``True`` when the file content changed, ``False`` otherwise.
+    Raises ``ValueError`` when the expected image block is missing.
+    """
+    original = path.read_text(encoding="utf-8")
+    # Preserve line endings of the source file; the workflow normalises to LF.
+    lines = original.splitlines()
+    inside = False
+    replaced_repo = False
+    replaced_tag = False
+    for index, line in enumerate(lines):
+        if not inside and _IMAGE_BLOCK_RE.match(line):
+            inside = True
+            continue
+        if not inside:
+            continue
+        if not replaced_repo and (match := _REPO_RE.match(line)):
+            lines[index] = f"{match.group(1)}repository: {repository}"
+            replaced_repo = True
+            continue
+        if not replaced_tag and (match := _TAG_RE.match(line)):
+            lines[index] = f"{match.group(1)}tag: {tag}"
+            replaced_tag = True
+        if replaced_repo and replaced_tag:
+            break
+        # Bail when the cursor leaves the image block (sibling key at four
+        # spaces of indent that is not ``image:`` itself).
+        if _SIBLING_RE.match(line):
+            inside = False
+    if not replaced_repo:
+        raise ValueError(f"image.repository not found in {path}")
+    if not replaced_tag:
+        raise ValueError(f"image.tag not found in {path}")
+    updated = "\n".join(lines) + "\n"
+    if updated == original:
+        return False
+    path.write_text(updated, encoding="utf-8", newline="\n")
+    return True
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("path", type=Path, help="HelmRelease YAML to edit")
+    parser.add_argument("repository", help="ACR repository, e.g. acr.azurecr.io/svc")
+    parser.add_argument("tag", help="Image tag (commit SHA)")
+    args = parser.parse_args(argv)
+    if not args.path.is_file():
+        print(f"::error::HelmRelease not found: {args.path}", file=sys.stderr)
+        return 1
+    try:
+        changed = update_helmrelease(args.path, args.repository, args.tag)
+    except ValueError as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 2
+    print(f"{'updated' if changed else 'unchanged'}: {args.path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Close the GitOps loop between the build pipeline (which already pushes images
to ACR on every dev deploy) and Flux's source-of-truth HelmReleases (which
were still pinned to the legacy path that predates PR #1089).

### The gap this PR fixes

`deploy-azd.yml` build job today pushes images to
`<acr>/<svc>:<sha>` (root-prefix path, SHA-tagged). Every HelmRelease was
still pinned to the legacy
`<acr>/holiday-peak-hub/<svc>-dev:azd-deploy-<unix-ts>` path that was
introduced before Pattern A. Result: Flux reconciled on the old image and
the cluster kept serving the April 4 build even after the MAF direct-model
migration (PR #1093) merged.

### What changes

1. **Re-points 27 HelmReleases** (26 agents + `crud-service`) at the actual
   build path that the workflow already pushes to, pinned to the current
   `main` SHA `808d48227b08`. Two-line diff per file. Once this PR merges,
   Flux will reconcile the freshly built images that are sitting in ACR.

2. **Adds `open-image-tag-bump-pr` job** to `deploy-azd.yml`. After a dev
   deploy succeeds it consumes the `tested-image-*` artifacts the build
   step already produces, edits the matching
   `.kubernetes/releases/{agents,crud}/<svc>.yaml` files via
   `scripts/ci/update_helmrelease_image.py`, and opens (or refreshes) a
   `chore/image-bump-<env>-<sha12>` PR against `main`. Operator merges the
   PR; Flux picks up the change. Respects the GH013 main-branch ruleset —
   the workflow never pushes to `main` itself.

3. **New helper `scripts/ci/update_helmrelease_image.py`** — surgical
   line-level edit (PyYAML round-trips would reflow comments). 10/10
   pylint, black/isort clean, byte-identical idempotent on no-op.

### How the bridge works

```
build-aks-images (matrix)
        │ pushes <acr>/<svc>:<sha>
        │ uploads tested-image-<svc> artifact (image-ref.txt)
        ▼
deploy-crud / deploy-agents
        │
        ▼
open-image-tag-bump-pr         ← NEW job
        │ download tested-image-* artifacts
        │ for each: scripts/ci/update_helmrelease_image.py <yaml> <repo> <sha>
        │ commit + push chore/image-bump-<env>-<sha12>
        │ gh pr create  (or update existing PR)
        ▼
operator merges → Flux reconciles → pods roll over to new image
```

### Refs

* ADR-017 — Pattern A Flux GitOps (render-only, no in-cluster commits).
* PR #1089 — Pattern A migration that introduced the gap.
* PR #1093 — Issue #990 direct-model migration whose images are sitting in
  ACR waiting to be reconciled.
* Issue #990.

### Test plan

* [x] `python -m black --check` clean on `update_helmrelease_image.py`
* [x] `python -m isort --check-only` clean
* [x] `python -m pylint` 10.00/10
* [x] Helper is byte-identical idempotent on no-op (SHA256 match before/after)
* [x] All 27 HelmReleases diff is exactly 2 lines (`repository:` + `tag:`)
* [x] YAML lints clean on the workflow change
* [ ] CI gates (lint, test, ui-quality, contract, audits, CodeQL) — pending
* [ ] After merge: Flux reconciles within ~5 min; pods roll over to
  `<acr>/<svc>:808d48227b08...` (will validate post-merge)
