### PR TITLE
bug(#1099-followup): truth scoped entrypoint contents:write + linter workflow-level baseline

### DIFF
--- a/.github/workflows/deploy-azd-truth.yml
+++ b/.github/workflows/deploy-azd-truth.yml
@@ -43,7 +43,7 @@ on:
 
 permissions:
   id-token: write
-  contents: read
+  contents: write
 
 concurrency:
   group: deploy-azd-truth-agents
@@ -53,7 +53,7 @@ jobs:
   deploy:
     permissions:
       id-token: write
-      contents: read
+      contents: write
       issues: write
     uses: ./.github/workflows/deploy-azd.yml
     with:

--- a/scripts/ci/lint_workflow_permissions.py
+++ b/scripts/ci/lint_workflow_permissions.py
@@ -112,15 +112,32 @@ def _callee_relative_path(uses: str) -> Path:
 
 
 def _collect_callee_required_permissions(callee_doc: dict) -> Dict[str, str]:
-    """Union of all per-job ``permissions`` in the callee."""
+    """Union of effective per-job permissions in the callee.
 
-    required: Dict[str, str] = {}
+    GitHub Actions resolves a job's effective ``permissions:`` as:
+
+    * if the job declares its own ``permissions:`` map, that map applies;
+    * otherwise the workflow-level ``permissions:`` map applies.
+
+    The cap rule for nested-workflow calls operates on those EFFECTIVE
+    permissions, not just on ones that happen to be redeclared on the job.
+    A linter that ignores the workflow-level fallback will miss the case
+    where every job inherits the workflow-level grant — e.g. the
+    ``deploy-azd-truth.yml`` scoped entrypoint, where the callee
+    ``deploy-azd.yml`` declares workflow-level ``contents: write`` and
+    most jobs inherit it.
+    """
+
+    workflow_perms = _normalize_permissions(callee_doc.get("permissions"))
+    required: Dict[str, str] = dict(workflow_perms)
     jobs = callee_doc.get("jobs", {}) or {}
     for _job_id, job_def in jobs.items():
         if not isinstance(job_def, dict):
             continue
-        perms = _normalize_permissions(job_def.get("permissions"))
-        for key, level in perms.items():
+        job_perms = _normalize_permissions(job_def.get("permissions"))
+        # Effective permissions for the job = job-level if present else workflow-level.
+        effective = job_perms if job_perms else workflow_perms
+        for key, level in effective.items():
             existing = required.get(key)
             # Escalate the "needed" level if any job wants write.
             if existing is None or (level in _WRITE_LEVELS and existing not in _WRITE_LEVELS):

--- a/scripts/ci/tests/test_lint_workflow_permissions.py
+++ b/scripts/ci/tests/test_lint_workflow_permissions.py
@@ -183,3 +183,54 @@ def test_linter_handles_callee_without_per_job_permissions(tmp_path: Path) -> No
 
     result = _run_linter_in(tmp_path)
     assert result.returncode == 0
+
+
+def test_linter_includes_callee_workflow_level_permissions_in_required_set(
+    tmp_path: Path,
+) -> None:
+    """Regression: deploy-azd-truth.yml followup. Callee declares ``contents:
+    write`` only at workflow level (no per-job override); GitHub Actions
+    treats that as the effective permission for every job that omits its own
+    map. A caller granting ``contents: read`` fails GitHub's cap check ->
+    startup_failure. The linter must mirror that semantics by including
+    workflow-level callee permissions in the required-set when jobs do not
+    override.
+    """
+    _write_workflow(
+        tmp_path,
+        "callee.yml",
+        """
+        name: Callee
+        on:
+          workflow_call: {}
+        permissions:
+          id-token: write
+          contents: write
+        jobs:
+          do:
+            runs-on: ubuntu-latest
+            # no per-job ``permissions:`` -> inherits workflow-level
+            steps:
+              - run: echo inherits-contents-write
+        """,
+    )
+    _write_workflow(
+        tmp_path,
+        "caller.yml",
+        """
+        name: Caller
+        on:
+          push: {}
+        jobs:
+          invoke:
+            permissions:
+              id-token: write
+              contents: read
+            uses: ./.github/workflows/callee.yml
+        """,
+    )
+
+    result = _run_linter_in(tmp_path)
+    assert result.returncode == 1, result.stdout
+    assert "'contents: write'" in result.stderr
+    assert "startup_failure" in result.stderr


### PR DESCRIPTION
## Summary

Two issues remained after PR #1099 (issue #1099):

1. **`deploy-azd-truth.yml`** (scoped multi-truth-agent entrypoint) granted only `contents: read` at both workflow- and job-level. The reusable callee `deploy-azd.yml` declares workflow-level `contents: write` (jobs inherit it). GitHub Actions cap check rejected the run with `startup_failure` before runner allocation. Fix: grant `contents: write` at both levels in the truth entrypoint, mirroring every other per-service entrypoint.

2. **Permission-cap linter** missed this case because it only computed the union of CALLEE per-job `permissions:` maps, ignoring callee workflow-level fallback. GitHub treats workflow-level permissions as the effective permissions for any job that omits its own map. The linter now mirrors that semantics.

## Changes

| File | Change |
|---|---|
| `.github/workflows/deploy-azd-truth.yml` | `contents: read` -> `contents: write` (workflow + job level) |
| `scripts/ci/lint_workflow_permissions.py` | `_collect_callee_required_permissions` now seeds with callee workflow-level perms; per-job maps override per-key when present |
| `scripts/ci/tests/test_lint_workflow_permissions.py` | Added regression `test_linter_includes_callee_workflow_level_permissions_in_required_set` |

## Validation

- `python -m pytest scripts/ci/tests/test_lint_workflow_permissions.py -v` -> **5/5 pass**
- `python scripts/ci/lint_workflow_permissions.py` -> **OK: 1 callee workflow(s) checked, no permission-cap violations**
- `python -m black --check` + `python -m isort --check` -> clean
- `scripts/ops/pre_push_gate.py` -> **705 passed**, all 7 lint gates green

## Why this matters

PR #1099 fixed 26 of 27 per-service entrypoints (those have explicit `contents: write` at job level). The scoped truth entrypoint slipped through because the cap violation depended on a callee workflow-level permission that the linter did not yet consider. This PR closes that false-negative class so future regressions are caught at PR time.

## Related

- Closes-related #1099
- ADR-017 (Deployment Strategy / Phase 2b post-mortem)