### PR TITLE
fix: pin mkdocs pygments compatibility

### DIFF
--- a/mkdocs/requirements.txt
+++ b/mkdocs/requirements.txt
@@ -7,3 +7,7 @@ mkdocs-material==9.5.50
 mkdocs-material-extensions==1.3.1
 pymdown-extensions==10.14.3
 mkdocs-autorefs==1.2.0
+# pymdown-extensions 10.14.3 passes filename=None to Pygments when
+# code blocks do not define titles. Pygments 2.20+ rejects that value,
+# which breaks the deploy-ui-swa strict MkDocs build.
+Pygments>=2.16,<2.20


### PR DESCRIPTION
## Summary
- Pins the MkDocs toolchain's transitive Pygments dependency below 2.20 for compatibility with pinned `pymdown-extensions==10.14.3`.
- Restores the `deploy-ui-swa` strict MkDocs build path that failed on the #1116 main merge.

## Validation
- `python -m mkdocs build --strict --site-dir ../apps/ui/public/docs` from `mkdocs/`
- `python -m pytest mkdocs/tests/test_rewrite_external_links.py -q`
- Pre-push gate: isort, black, pylint `--fail-on=E,F`, mypy subset, markdown link check, event schema contract check
- Pre-push gate: lib tests `1357 passed, 6 skipped`
- Pre-push gate: app tests `710 passed, 1 skipped`