### PR TITLE
fix: resolve deploy image dependency pins

### DIFF
--- a/apps/crm-support-assistance/src/requirements.txt
+++ b/apps/crm-support-assistance/src/requirements.txt
@@ -69,7 +69,7 @@ agent-framework-foundry-hosting==1.0.0a260507
     # via crm-support-assistance
 agent-framework-foundry-local==1.0.0b260409
     # via agent-framework-core
-agent-framework-github-copilot==1.0.0b260409
+agent-framework-github-copilot==1.0.0b260507
     # via agent-framework-core
 agent-framework-hyperlight==1.0.0b260519 ; (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')
     # via agent-framework-core
@@ -280,7 +280,7 @@ frozenlist==1.8.0
     #   aiosignal
 furl==2.1.4
     # via azure-functions-durable
-github-copilot-sdk==0.2.1
+github-copilot-sdk==1.0.0b2
     # via agent-framework-github-copilot
 google-api-core==2.30.3
     # via a2a-sdk

--- a/apps/ecommerce-cart-intelligence/src/requirements.txt
+++ b/apps/ecommerce-cart-intelligence/src/requirements.txt
@@ -69,7 +69,7 @@ agent-framework-foundry-hosting==1.0.0a260507
     # via ecommerce-cart-intelligence
 agent-framework-foundry-local==1.0.0b260409
     # via agent-framework-core
-agent-framework-github-copilot==1.0.0b260409
+agent-framework-github-copilot==1.0.0b260507
     # via agent-framework-core
 agent-framework-hyperlight==1.0.0b260519 ; (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')
     # via agent-framework-core
@@ -280,7 +280,7 @@ frozenlist==1.8.0
     #   aiosignal
 furl==2.1.4
     # via azure-functions-durable
-github-copilot-sdk==0.2.1
+github-copilot-sdk==1.0.0b2
     # via agent-framework-github-copilot
 google-api-core==2.30.3
     # via a2a-sdk

--- a/apps/ecommerce-catalog-search/src/requirements.txt
+++ b/apps/ecommerce-catalog-search/src/requirements.txt
@@ -69,7 +69,7 @@ agent-framework-foundry-hosting==1.0.0a260507
     # via ecommerce-catalog-search
 agent-framework-foundry-local==1.0.0b260409
     # via agent-framework-core
-agent-framework-github-copilot==1.0.0b260409
+agent-framework-github-copilot==1.0.0b260507
     # via agent-framework-core
 agent-framework-hyperlight==1.0.0b260519 ; (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')
     # via agent-framework-core
@@ -280,7 +280,7 @@ frozenlist==1.8.0
     #   aiosignal
 furl==2.1.4
     # via azure-functions-durable
-github-copilot-sdk==0.2.1
+github-copilot-sdk==1.0.0b2
     # via agent-framework-github-copilot
 google-api-core==2.30.3
     # via a2a-sdk

--- a/apps/ecommerce-checkout-support/src/requirements.txt
+++ b/apps/ecommerce-checkout-support/src/requirements.txt
@@ -69,7 +69,7 @@ agent-framework-foundry-hosting==1.0.0a260507
     # via ecommerce-checkout-support
 agent-framework-foundry-local==1.0.0b260409
     # via agent-framework-core
-agent-framework-github-copilot==1.0.0b260409
+agent-framework-github-copilot==1.0.0b260507
     # via agent-framework-core
 agent-framework-hyperlight==1.0.0b260519 ; (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')
     # via agent-framework-core
@@ -280,7 +280,7 @@ frozenlist==1.8.0
     #   aiosignal
 furl==2.1.4
     # via azure-functions-durable
-github-copilot-sdk==0.2.1
+github-copilot-sdk==1.0.0b2
     # via agent-framework-github-copilot
 google-api-core==2.30.3
     # via a2a-sdk

--- a/apps/ecommerce-order-status/src/requirements.txt
+++ b/apps/ecommerce-order-status/src/requirements.txt
@@ -69,7 +69,7 @@ agent-framework-foundry-hosting==1.0.0a260507
     # via ecommerce-order-status
 agent-framework-foundry-local==1.0.0b260409
     # via agent-framework-core
-agent-framework-github-copilot==1.0.0b260409
+agent-framework-github-copilot==1.0.0b260507
     # via agent-framework-core
 agent-framework-hyperlight==1.0.0b260519 ; (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')
     # via agent-framework-core
@@ -280,7 +280,7 @@ frozenlist==1.8.0
     #   aiosignal
 furl==2.1.4
     # via azure-functions-durable
-github-copilot-sdk==0.2.1
+github-copilot-sdk==1.0.0b2
     # via agent-framework-github-copilot
 google-api-core==2.30.3
     # via a2a-sdk

--- a/apps/ecommerce-product-detail-enrichment/src/requirements.txt
+++ b/apps/ecommerce-product-detail-enrichment/src/requirements.txt
@@ -69,7 +69,7 @@ agent-framework-foundry-hosting==1.0.0a260507
     # via ecommerce-product-detail-enrichment
 agent-framework-foundry-local==1.0.0b260409
     # via agent-framework-core
-agent-framework-github-copilot==1.0.0b260409
+agent-framework-github-copilot==1.0.0b260507
     # via agent-framework-core
 agent-framework-hyperlight==1.0.0b260519 ; (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')
     # via agent-framework-core
@@ -280,7 +280,7 @@ frozenlist==1.8.0
     #   aiosignal
 furl==2.1.4
     # via azure-functions-durable
-github-copilot-sdk==0.2.1
+github-copilot-sdk==1.0.0b2
     # via agent-framework-github-copilot
 google-api-core==2.30.3
     # via a2a-sdk

--- a/apps/inventory-health-check/src/requirements.txt
+++ b/apps/inventory-health-check/src/requirements.txt
@@ -69,7 +69,7 @@ agent-framework-foundry-hosting==1.0.0a260507
     # via inventory-health-check
 agent-framework-foundry-local==1.0.0b260409
     # via agent-framework-core
-agent-framework-github-copilot==1.0.0b260409
+agent-framework-github-copilot==1.0.0b260507
     # via agent-framework-core
 agent-framework-hyperlight==1.0.0b260507 ; (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')
     # via agent-framework-core
@@ -280,7 +280,7 @@ frozenlist==1.8.0
     #   aiosignal
 furl==2.1.4
     # via azure-functions-durable
-github-copilot-sdk==0.2.1
+github-copilot-sdk==1.0.0b2
     # via agent-framework-github-copilot
 google-api-core==2.30.3
     # via a2a-sdk
@@ -389,7 +389,7 @@ mcp==1.26.0
     #   openai-agents
 mdurl==0.1.2
     # via markdown-it-py
-mem0ai==2.0.0b2
+mem0ai==1.0.11
     # via agent-framework-mem0
 microsoft-agents-activity==0.3.1
     # via microsoft-agents-hosting-core

--- a/apps/logistics-eta-computation/src/requirements.txt
+++ b/apps/logistics-eta-computation/src/requirements.txt
@@ -69,7 +69,7 @@ agent-framework-foundry-hosting==1.0.0a260507
     # via logistics-eta-computation
 agent-framework-foundry-local==1.0.0b260409
     # via agent-framework-core
-agent-framework-github-copilot==1.0.0b260409
+agent-framework-github-copilot==1.0.0b260507
     # via agent-framework-core
 agent-framework-hyperlight==1.0.0b260519 ; (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')
     # via agent-framework-core
@@ -280,7 +280,7 @@ frozenlist==1.8.0
     #   aiosignal
 furl==2.1.4
     # via azure-functions-durable
-github-copilot-sdk==0.2.1
+github-copilot-sdk==1.0.0b2
     # via agent-framework-github-copilot
 google-api-core==2.30.3
     # via a2a-sdk

--- a/apps/logistics-returns-support/src/requirements.txt
+++ b/apps/logistics-returns-support/src/requirements.txt
@@ -69,7 +69,7 @@ agent-framework-foundry-hosting==1.0.0a260507
     # via logistics-returns-support
 agent-framework-foundry-local==1.0.0b260409
     # via agent-framework-core
-agent-framework-github-copilot==1.0.0b260409
+agent-framework-github-copilot==1.0.0b260507
     # via agent-framework-core
 agent-framework-hyperlight==1.0.0b260519 ; (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')
     # via agent-framework-core
@@ -280,7 +280,7 @@ frozenlist==1.8.0
     #   aiosignal
 furl==2.1.4
     # via azure-functions-durable
-github-copilot-sdk==0.2.1
+github-copilot-sdk==1.0.0b2
     # via agent-framework-github-copilot
 google-api-core==2.30.3
     # via a2a-sdk

--- a/apps/truth-hitl/src/requirements.txt
+++ b/apps/truth-hitl/src/requirements.txt
@@ -69,7 +69,7 @@ agent-framework-foundry-hosting==1.0.0a260507
     # via truth-hitl
 agent-framework-foundry-local==1.0.0b260409
     # via agent-framework-core
-agent-framework-github-copilot==1.0.0b260409
+agent-framework-github-copilot==1.0.0b260507
     # via agent-framework-core
 agent-framework-hyperlight==1.0.0b260519 ; (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')
     # via agent-framework-core
@@ -280,7 +280,7 @@ frozenlist==1.8.0
     #   aiosignal
 furl==2.1.4
     # via azure-functions-durable
-github-copilot-sdk==0.2.1
+github-copilot-sdk==1.0.0b2
     # via agent-framework-github-copilot
 google-api-core==2.30.3
     # via a2a-sdk


### PR DESCRIPTION
## Summary
- Resolves AKS image-build dependency resolution failures observed in deploy-azd-dev run 26296006145.
- Updates the generated agent requirements files from `agent-framework-github-copilot==1.0.0b260409` / `github-copilot-sdk==0.2.1` to the resolvable `1.0.0b260507` / `1.0.0b2` pair.
- Corrects `apps/inventory-health-check/src/requirements.txt` from `mem0ai==2.0.0b2` to `mem0ai==1.0.11`, matching `agent-framework-mem0==1.0.0b260409` (`mem0ai>=1,<2`).

## Evidence
- Failed deploy job 77415698718: `agent-framework-mem0==1.0.0b260409` requires `mem0ai>=1.0.0,<2`, but inventory pinned `mem0ai==2.0.0b2`.
- Failed deploy job 77415698594: `agent-framework-github-copilot==1.0.0b260409` depends on unpublished `github-copilot-sdk==0.2.1`.

## Validation
- `uv pip install --dry-run --python-version 3.13 --python-platform x86_64-manylinux_2_34 -r <patched requirements.txt>` for all 10 patched app requirements files.
- Pre-push gate passed: isort, black, pylint, mypy, markdown links, event schema contracts.
- `pytest lib/tests --maxfail=1`: 1357 passed, 6 skipped.
- app tests excluding UI tests: 710 passed, 1 skipped.

## Risk
- Low: generated dependency pins only; no runtime code or API contract changes.