### PR TITLE
feat(#903): add AgentBuilder evaluation config

### DIFF
--- a/lib/src/holiday_peak_lib/agents/base_agent.py
+++ b/lib/src/holiday_peak_lib/agents/base_agent.py
@@ -30,6 +30,7 @@ from holiday_peak_lib.agents.memory.session_manager import (
 from holiday_peak_lib.agents.memory.warm import WarmMemory
 from holiday_peak_lib.agents.orchestration.router import RoutingStrategy
 from holiday_peak_lib.agents.telemetry_mixin import AgentTelemetryMixin
+from holiday_peak_lib.evaluation.models import EvalConfig
 from holiday_peak_lib.mcp.server import FastAPIMCPServer
 from holiday_peak_lib.self_healing import SelfHealingKernel
 from pydantic import BaseModel, ConfigDict, Field
@@ -93,6 +94,7 @@ class AgentDependencies(BaseModel):
     llm: ModelTarget | None = None
     complexity_threshold: float = 0.5
     enforce_foundry_prompt_governance: bool = True
+    evaluation_config: EvalConfig | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -155,6 +157,7 @@ class BaseRetailAgent(AgentTelemetryMixin, BaseAgent, ABC):
     llm: ModelTarget | None
     complexity_threshold: float
     enforce_foundry_prompt_governance: bool
+    evaluation_config: EvalConfig | None
 
     def __init__(self, config: AgentDependencies, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
@@ -175,6 +178,7 @@ class BaseRetailAgent(AgentTelemetryMixin, BaseAgent, ABC):
         self.llm = config.llm
         self.complexity_threshold = config.complexity_threshold
         self.enforce_foundry_prompt_governance = config.enforce_foundry_prompt_governance
+        self.evaluation_config = config.evaluation_config
         # Background task set for fire-and-forget memory operations.
         # Each agent is a stateful, long-lived object — tasks persist
         # across requests and are garbage-collected on completion.
@@ -185,10 +189,11 @@ class BaseRetailAgent(AgentTelemetryMixin, BaseAgent, ABC):
 
         if self.slm is None:
             return None
-        slm_provider = self.slm.provider
+        slm_provider = cast(str | None, self.slm.provider)
         if self.llm is None:
             return slm_provider
-        if slm_provider and self.llm.provider and slm_provider == self.llm.provider:
+        llm_provider = cast(str | None, self.llm.provider)
+        if slm_provider and llm_provider and slm_provider == llm_provider:
             return slm_provider
         return None
 
@@ -285,7 +290,7 @@ class BaseRetailAgent(AgentTelemetryMixin, BaseAgent, ABC):
 
     def _assess_complexity(self, request: dict[str, Any]) -> float:
         """Delegate to shared complexity heuristic."""
-        return assess_complexity(request)
+        return cast(float, assess_complexity(request))
 
     def _select_model(
         self,
@@ -599,7 +604,7 @@ class BaseRetailAgent(AgentTelemetryMixin, BaseAgent, ABC):
             result.setdefault("_model", target.model)
             result["_telemetry"] = telemetry
 
-        return result
+        return cast(dict[str, Any], result)
 
     async def invoke_model(
         self, request: dict[str, Any], messages: Any, **kwargs: Any
@@ -973,7 +978,7 @@ class BaseRetailAgent(AgentTelemetryMixin, BaseAgent, ABC):
                     svc,
                     elapsed,
                 )
-                return result
+                return cast(dict[str, Any], result)
             except Exception as exc:
                 elapsed = (perf_counter() - started) * 1000
                 logger.error(

--- a/lib/src/holiday_peak_lib/agents/builder.py
+++ b/lib/src/holiday_peak_lib/agents/builder.py
@@ -2,6 +2,7 @@
 
 from typing import Any, Callable
 
+from holiday_peak_lib.evaluation.models import EvalConfig
 from holiday_peak_lib.mcp.server import FastAPIMCPServer
 
 from .base_agent import AgentDependencies, BaseRetailAgent, ModelTarget
@@ -30,6 +31,7 @@ class AgentBuilder:
         self._slm: ModelTarget | None = None
         self._llm: ModelTarget | None = None
         self._complexity_threshold = 0.5
+        self._evaluation_config: EvalConfig | None = None
 
     def with_agent(self, agent_class: type[BaseRetailAgent]) -> "AgentBuilder":
         self._agent_class = agent_class
@@ -68,6 +70,10 @@ class AgentBuilder:
 
     def with_tools(self, tools: dict[str, Callable[..., Any]]) -> "AgentBuilder":
         self._tools.update(tools)
+        return self
+
+    def with_evaluation(self, config: EvalConfig) -> "AgentBuilder":
+        self._evaluation_config = config
         return self
 
     def with_models(
@@ -155,6 +161,7 @@ class AgentBuilder:
             slm=self._slm,
             llm=self._llm,
             complexity_threshold=self._complexity_threshold,
+            evaluation_config=self._evaluation_config,
         )
         agent = self._agent_class(config=deps)
         if self._memory_builder:

--- a/lib/tests/test_agents_builder.py
+++ b/lib/tests/test_agents_builder.py
@@ -1,14 +1,17 @@
 """Tests for agent builder."""
 
+# pylint: disable=redefined-outer-name
+
 from unittest.mock import Mock
 
 import pytest
-from holiday_peak_lib.agents.base_agent import BaseRetailAgent, ModelTarget
+from holiday_peak_lib.agents.base_agent import AgentDependencies, BaseRetailAgent, ModelTarget
 from holiday_peak_lib.agents.builder import AgentBuilder
 from holiday_peak_lib.agents.memory.cold import ColdMemory
 from holiday_peak_lib.agents.memory.hot import HotMemory
 from holiday_peak_lib.agents.memory.warm import WarmMemory
 from holiday_peak_lib.agents.orchestration.router import RoutingStrategy
+from holiday_peak_lib.evaluation.models import EvalConfig
 
 
 class SampleAgent(BaseRetailAgent):
@@ -22,7 +25,7 @@ class SampleAgent(BaseRetailAgent):
 def model_invoker():
     """Mock model invoker."""
 
-    async def invoker(**kwargs):
+    async def invoker(**_kwargs):
         return {"response": "test"}
 
     return invoker
@@ -86,7 +89,10 @@ class SampleAgentBuilder:
     def test_with_tool(self):
         """Test adding a single tool."""
         builder = AgentBuilder()
-        handler = lambda x: x
+
+        def handler(value):
+            return value
+
         result = builder.with_tool("test_tool", handler)
         assert result is builder
 
@@ -178,10 +184,31 @@ class SampleAgentBuilder:
 class TestBuilderChaining:
     """Test builder method chaining."""
 
+    def test_with_evaluation_returns_builder_and_passes_config(self, model_invoker):
+        """Test fluent evaluation configuration on the built agent."""
+        slm = ModelTarget(name="slm", model="test", invoker=model_invoker)
+        evaluation_config = EvalConfig(agent_name="sample-agent")
+
+        builder = AgentBuilder()
+        result = builder.with_evaluation(evaluation_config)
+        agent = builder.with_agent(SampleAgent).with_models(slm=slm).build()
+
+        assert result is builder
+        assert agent.evaluation_config == evaluation_config
+
+    def test_agent_dependencies_exposes_evaluation_config(self):
+        """Test direct access to evaluation config on AgentDependencies."""
+        evaluation_config = EvalConfig(agent_name="sample-agent")
+
+        deps = AgentDependencies(evaluation_config=evaluation_config)
+
+        assert deps.evaluation_config == evaluation_config
+
     def test_chain_all_methods(self, model_invoker):
         """Test chaining all builder methods."""
         slm = ModelTarget(name="slm", model="test", invoker=model_invoker)
         router = RoutingStrategy()
+        evaluation_config = EvalConfig(agent_name="sample-agent")
 
         builder = AgentBuilder()
         agent = (
@@ -189,12 +216,14 @@ class TestBuilderChaining:
             .with_router(router)
             .with_tool("tool1", lambda x: x)
             .with_tools({"tool2": lambda y: y})
+            .with_evaluation(evaluation_config)
             .with_models(slm=slm)
             .build()
         )
 
         assert isinstance(agent, SampleAgent)
         assert len(agent.tools) == 2
+        assert agent.evaluation_config == evaluation_config
 
     def test_order_independence(self, model_invoker):
         """Test that method call order doesn't matter."""


### PR DESCRIPTION
## Summary
- Add `AgentDependencies.evaluation_config` as an optional framework config field.
- Add `AgentBuilder.with_evaluation(config)` as an additive fluent builder method.
- Add focused tests for fluent chaining and dependency access.

Closes #903.

## Validation
- `python -m isort --check-only lib apps`
- `python -m black --check lib apps`
- `python -m pytest lib/tests/test_agents_builder.py lib/tests/test_agents_base.py -q` → 47 passed
- `python -m mypy --config-file pyproject.toml --ignore-missing-imports --follow-imports=skip lib/src/holiday_peak_lib/agents/builder.py lib/src/holiday_peak_lib/agents/base_agent.py`
- pre-push hook: full lint/test gate passed, including 1365 lib tests and 711 app tests