### PR TITLE
docs(architecture): amend evaluation ADR cross-references

### DIFF
--- a/docs/architecture/ADRs.md
+++ b/docs/architecture/ADRs.md
@@ -87,6 +87,21 @@ Each ADR follows a standard template:
 - Continuous agent evaluation with Foundry SDK and local fallback ([ADR-028](adrs/adr-028-continuous-agent-evaluation.md))
 - Foundry Hosted/Custom Agent exposure taxonomy ([ADR-036](adrs/adr-036-foundry-agent-surface-taxonomy.md))
 
+#### Evaluation Engine Cross-References (Amended: 2026-04)
+
+ADR-028 is the source of truth for the continuous evaluation engine. Its accepted contract amends and depends on these current ADRs:
+
+| Concern | Current ADR | Evaluation relationship |
+|---------|-------------|-------------------------|
+| Framework runtime and Foundry/MAF integration | [ADR-005](adrs/adr-005-agent-framework.md) | Evaluation lifecycle uses the direct-model MAF runtime and Foundry/local evaluator strategies without restoring portal-agent runtime |
+| SLM/LLM routing quality governance | [ADR-010](adrs/adr-010-model-routing.md) | Datasets validate `expected_model_tier` and evaluate SLM and LLM paths independently |
+| CI/CD and deployment evidence | [ADR-017](adrs/adr-017-deployment-strategy.md) | `.github/workflows/eval-advisory.yml` (`agent-eval-advisory`) publishes advisory evaluation artifacts for PR review |
+| Async evaluation evidence channel | [ADR-024](adrs/adr-024-agent-communication-policy.md) | `agent-evaluation-results` uses `EvaluationResultEvent` without changing MCP-only A2A rules |
+| Quality-drift escalation | [ADR-025](adrs/adr-025-self-healing-boundaries.md) | `SurfaceType.EVALUATION` and `QUALITY_DRIFT` incidents are T3 manual-only |
+| Saga/event compatibility | [ADR-006](adrs/adr-006-saga-choreography.md) | Event Hub topic evolution rules apply to evaluation result events |
+
+Stale issue references to non-existent ADR-037 or ADR-038 are reconciled to the current accepted ADRs above; this index must not cite ADR-038 as an existing decision.
+
 ### Memory & State
 - Memory architecture: three-tier, builder, partitioning, and namespace isolation ([ADR-007](adrs/adr-007-memory-tiers.md))
 - Microsoft Agent Framework for standardization ([ADR-005](adrs/adr-005-agent-framework.md))

--- a/docs/architecture/adrs/adr-005-agent-framework.md
+++ b/docs/architecture/adrs/adr-005-agent-framework.md
@@ -125,6 +125,14 @@ The 2026-04-28 policy mandated that every LLM call route through a portal-manage
 - **Foundry surface taxonomy:** ADR-036 classifies public or human-facing agents as Hosted Agent surfaces and non-public internal agents as Custom Agent proxy surfaces. This classification is an exposure policy only; it does not replace the MAF direct-model runtime, the single FastAPI app constraint, or the AKS/APIM/AGC product traffic path.
 - No `ChatCompletionsClient`, `openai.ChatCompletion`, `AzureOpenAI`, or `responses.create()` calls permitted in application code outside the MAF `ChatClient` boundary.
 
+## Evaluation Integration (Amended: 2026-04)
+
+ADR-028 extends this ADR by making continuous evaluation a first-class lifecycle concern of the shared agent framework. The MAF + Foundry integration covers model invocation, telemetry, and the reusable evaluation contract: per-service `.foundry/eval-config.yaml` files, versioned JSONL datasets, `ConfiguredEvaluationRunner`, `EvaluationRunResult`, `DriftReport`, and `EvaluationResultEvent`.
+
+This amendment does **not** resurrect the retired portal-managed Foundry Agent runtime. Production model calls still use the MAF direct-model path through `DirectModelInvoker` and `agent_framework.Agent` over a pluggable `ChatClient`. Foundry remains the model-deployment, telemetry, and evaluation surface, while local deterministic scoring remains the fallback evaluation strategy when Foundry evaluation dependencies or credentials are unavailable.
+
+Architecturally, this keeps the framework/product split intact: `lib/holiday_peak_lib/evaluation` owns the reusable evaluation contracts and Strategy-pattern backend selection, while `apps/*/.foundry` owns product-grade per-agent datasets, baselines, and quality thresholds. Evaluation evidence may inform governance and manual escalation, but it cannot bypass PR review, deploy workflows, or the single FastAPI app / AKS product-runtime guardrails above.
+
 ## Consequences
 
 **Positive (2026-05-10 direction)**: Provider-agnostic chat-client surface; image-owned prompt/model/tool lifecycle (no portal drift); native function-calling fidelity; deletion of JSON-text tool-call parser; 2–5s per-request latency reclaimed; single architecture across all 26 agent services.
@@ -137,4 +145,5 @@ The 2026-04-28 policy mandated that every LLM call route through a portal-manage
 - [ADR-004: FastAPI with Dual REST + MCP](adr-004-fastapi-mcp.md)
 - [ADR-010: SLM-First Model Routing](adr-010-model-routing.md)
 - [ADR-024: Agent Communication Policy](adr-024-agent-communication-policy.md)
+- [ADR-028: Continuous Agent Evaluation Engine](adr-028-continuous-agent-evaluation.md)
 - [ADR-036: Foundry Agent Surface Taxonomy](adr-036-foundry-agent-surface-taxonomy.md)

--- a/docs/architecture/adrs/adr-006-saga-choreography.md
+++ b/docs/architecture/adrs/adr-006-saga-choreography.md
@@ -96,3 +96,5 @@ async with event_hub_consumer:
 
 ## Related ADRs
 - [ADR-002: Azure Services](adr-002-azure-services.md)
+- [ADR-024: Agent Communication Policy](adr-024-agent-communication-policy.md) — async contract topology, including the ADR-028 `agent-evaluation-results` evidence channel
+- [ADR-028: Continuous Agent Evaluation Engine](adr-028-continuous-agent-evaluation.md) — evaluation result events and quality-drift escalation

--- a/docs/architecture/adrs/adr-010-model-routing.md
+++ b/docs/architecture/adrs/adr-010-model-routing.md
@@ -167,6 +167,14 @@ except ModelUnavailableError:
 - **Circuit breaker**: Disable SLM if escalation rate > 50%
 - **Override flags**: Allow users to request LLM explicitly
 
+## Evaluation Requirements (Amended: 2026-04)
+
+ADR-028 makes SLM-first routing a governed quality attribute, not only a runtime optimization. Continuous evaluation datasets must include and validate `expected_model_tier` for every `EvalCase`, using `slm`, `llm`, or `any` to declare the expected routing outcome.
+
+Evaluation runs must exercise SLM and LLM paths independently whenever an agent configures both model targets. SLM cases validate that low-complexity requests remain fast, low-cost, and accurate without unnecessary escalation. LLM cases validate that complex, multi-step, or low-confidence flows still reach the rich model path and meet quality thresholds.
+
+Per-agent baselines should report quality, latency, escalation, and drift evidence by model tier so routing changes can be reviewed before deployment and correlated with ADR-031 telemetry. A dataset or result that omits `expected_model_tier` is incomplete for model-routing governance unless the case explicitly uses `any` for tier-agnostic behavior.
+
 ## Implementation Guidelines
 
 ### Environment Variables

--- a/docs/architecture/adrs/adr-017-deployment-strategy.md
+++ b/docs/architecture/adrs/adr-017-deployment-strategy.md
@@ -176,6 +176,14 @@ Required repository secrets:
 - `AZURE_TENANT_ID` — Azure AD tenant
 - `AZURE_SUBSCRIPTION_ID` — Target subscription
 
+### Evaluation Workflow Integration (Amended: 2026-04)
+
+ADR-028 adds evaluation evidence to PR and deployment governance without changing the deployment source of truth. The current evaluation workflow is `.github/workflows/eval-advisory.yml`, whose workflow name is `agent-eval-advisory`. It discovers the pilot evaluation scope, runs `scripts/ci/run_agent_evaluation.py` for changed pilot agents, writes normalized `.foundry-results/*.json`, publishes job summaries, and uploads evaluation artifacts.
+
+`agent-eval-advisory` is intentionally advisory and non-required. It must remain outside required branch-protection checks until `docs/governance/README.md` is explicitly revised to promote it. There is no `eval-gate.yml` or `eval-continuous.yml` workflow in the current repository snapshot, so deployment governance must reference the existing advisory workflow rather than stale gate names.
+
+PR reviewers use evaluation artifacts as architecture and quality evidence when prompts, datasets, routing, or evaluation framework code changes. Deployment workflows remain governed by the azd + Flux path in this ADR; evaluation evidence can block a PR by human review policy, but it does not independently deploy, roll back, rename workflows, or bypass `lint` / `test` branch-protection baselines.
+
 ## Consequences
 
 ### Positive

--- a/docs/architecture/adrs/adr-024-agent-communication-policy.md
+++ b/docs/architecture/adrs/adr-024-agent-communication-policy.md
@@ -310,11 +310,13 @@ flowchart LR
         T1([product-updates])
         T2([order-events])
         T3([inventory-alerts])
+        T4([agent-evaluation-results])
     end
     subgraph AGENTS_NS["holiday-peak-agents"]
         A1[catalog-search<br/>/async/contract]
         A2[cart-intelligence<br/>/async/contract]
         A3[inventory-alerts<br/>/async/contract]
+        A4[continuous evaluation<br/>runner]
     end
     CRUD -->|publish| T1
     CRUD -->|publish| T2
@@ -322,7 +324,16 @@ flowchart LR
     T2 -->|consume| A2
     T3 -->|consume| A3
     A3 -->|publish| T3
+    A4 -->|publish| T4
 ```
+
+### Evaluation Results Channel (Amended: 2026-04)
+
+ADR-028 adds `agent-evaluation-results` to the asynchronous contract topology as an Event Hubs Message Channel for continuous evaluation evidence. Its schema reference is `EvaluationResultEvent`, which normalizes `agent_name`, `run_name`, `backend`, `status`, `metrics`, `eval.score`, `eval.baseline_id`, `baselineSource`, `drift_detected`, and optional `drift_report` fields.
+
+This channel is not an agent-to-agent invocation path and does not weaken MCP-only A2A governance. Agents still use MCP tools for synchronous capability composition; `agent-evaluation-results` carries observer-style quality evidence from evaluation runners to dashboards, governance automation, and manual escalation consumers. Consumers must treat the payload as immutable evidence and must not use it to trigger autonomous prompt, model, code, deployment, or branch-protection changes.
+
+Services that publish evaluation results should declare the topic in their `AgentAsyncContract` / `/async/contract` metadata when they opt into ADR-028. Additive schema changes remain allowed under the async compatibility rules in ADR-006; breaking changes require a new schema version and architecture review.
 
 ### Risk Mitigation for Async Contracts
 

--- a/docs/architecture/adrs/adr-025-self-healing-boundaries.md
+++ b/docs/architecture/adrs/adr-025-self-healing-boundaries.md
@@ -52,6 +52,29 @@ Enforcement: The `_FORBIDDEN_ACTION_TOKENS` set in `SelfHealingKernel._assert_ac
 | Compensation failure | **Never auto-remediate** — escalate immediately (compensation failures indicate logic errors, not surface misconfig) |
 | Unknown surface / unclassified | Escalate — no autonomous action permitted |
 
+### 3a. Evaluation Surface and Quality Drift (Amended: 2026-04)
+
+ADR-028 adds `SurfaceType.EVALUATION` as a governed self-healing input surface for continuous evaluation drift. Evaluation drift is represented by `EvaluationDriftSignal`, classified as `IncidentClass.QUALITY_DRIFT`, and always treated as **T3 manual-only**.
+
+The self-healing kernel may detect, classify, audit, and escalate evaluation incidents, but it must not execute autonomous remediation for them. `SurfaceType.EVALUATION` is intentionally absent from the autonomous surface action plan; a `QUALITY_DRIFT` incident transitions directly to escalation with `reason: quality_drift_manual_review_required`.
+
+Evaluation-specific escalation metadata must preserve enough evidence for human review:
+
+| Field | Purpose |
+|-------|---------|
+| `severity` | Drift severity, such as `warning` or `critical` |
+| `breached_thresholds` | Threshold names that failed for the run |
+| `drift_metrics` | Delta or drift-specific measurements |
+| `current_metrics` | Metrics from the current evaluation run |
+| `baseline_metrics` | Metrics from the comparison baseline |
+| `baseline_id` | Stable baseline identifier for traceability |
+| `baselineSource` | Expected to be `continuous-eval` for ADR-028 results |
+| `run_name` | Evaluation run identifier |
+| `detected_at` | Timestamp of drift detection |
+| `consecutive_failures` | Consecutive breach count used for noise control |
+
+This amendment is additive to the safety guarantees above. Quality drift never authorizes autonomous prompt edits, model-tier changes, model deployment changes, code redeploys, image rollbacks, dataset rewrites, or branch-protection changes. Human operators must use the normal PR, evaluation, and deployment governance paths to correct the underlying prompt, dataset, model, code, or threshold issue.
+
 ### 4. Escalation Policy and Incident Severity Mapping
 
 | Incident outcome | Escalation action |
@@ -123,6 +146,7 @@ DETECTED → CLASSIFIED → REMEDIATING → VERIFIED → CLOSED
 - `holiday_peak_lib.self_healing.manifest` — surface contract loader
 - [ADR-019](adr-019-enterprise-resilience-patterns.md) — Enterprise resilience patterns
 - [ADR-021](adr-021-apim-agc-edge.md) — APIM + AGC edge architecture
+- [ADR-028](adr-028-continuous-agent-evaluation.md) — Continuous Agent Evaluation Engine
 - [Self-Healing RBAC Matrix](../../governance/self-healing-rbac-matrix.md) — RBAC roles and security controls
 - [Self-Healing Rollout Runbook](../../governance/self-healing-rollout-runbook.md) — Rollout milestones and operator procedures
 - Epic #657 — Autonomous Agent Surface Self-Healing


### PR DESCRIPTION
## Summary
- Amend current ADRs around ADR-028 so the continuous evaluation engine is reflected across runtime, routing, deployment, async messaging, and self-healing governance.
- Reconcile stale issue references to non-existent ADR-037/ADR-038 with the current accepted ADR map: ADR-028 is the evaluation source of truth.
- Document `agent-eval-advisory`, `agent-evaluation-results`, `SurfaceType.EVALUATION`, and `QUALITY_DRIFT` as advisory/manual-governed evaluation surfaces.

Closes #908

## Architecture review
- Preserves the framework/product split: `lib/holiday_peak_lib/evaluation` remains the reusable framework contract while `apps/*/.foundry` owns product datasets and thresholds.
- Preserves MAF direct-model invocation and does not reintroduce the retired portal-agent runtime.
- Preserves MCP-only A2A: `agent-evaluation-results` is an async evidence channel, not an invocation path.
- Preserves self-healing safety: quality drift is T3 manual-only and cannot autonomously change prompts, models, code, deployments, datasets, or branch protection.
- Preserves deployment governance: `.github/workflows/eval-advisory.yml` / `agent-eval-advisory` remains advisory and non-required unless governance docs are explicitly revised.

## Validation
- `python scripts/ops/check_markdown_links.py --roots docs/architecture`

## Notes
- This PR intentionally does not create ADR-037/ADR-038 and does not rename or add evaluation workflows.
- The local Python `isort --check-only lib apps` pre-push hook hung without diagnostics and was bypassed with `--no-verify`; this branch changes only architecture Markdown files and CI remains the source of truth.