### PR TITLE
feat(agents): MAF native tool-calling + asb-v1 setup contract

### DIFF
--- a/.github/prompts/repository-hygiene-cleanup.prompt.md
+++ b/.github/prompts/repository-hygiene-cleanup.prompt.md
@@ -1,11 +1,13 @@
 ---
 name: "Repository Hygiene Cleanup"
-description: "Execute full repository hygiene: snapshot work queues, close stale PRs/issues, prune local and remote branches, verify clean state."
+description: "Execute repository hygiene: snapshot work queues, close only incorporated PRs/issues with evidence, prune eligible branches, verify clean state."
 agent: "TechLeadOrchestrator"
-argument-hint: "Optionally specify which steps to run (e.g. 'PRs only', 'branches only') or say 'full cleanup' for the complete runbook."
+argument-hint: "Optionally specify which steps to run (e.g. 'incorporated issues only', 'branches only') or say 'full cleanup' for the complete runbook."
 ---
 
 Execute the repository hygiene cleanup runbook defined in `docs/governance/repository-hygiene-cleanup.md`.
+
+Important: this workflow does **not** bulk-abandon work. A PR or Issue may be closed only when its change/report is already incorporated into `main`, superseded by incorporated work, or explicitly abandoned by the maintainer with evidence recorded in the closure comment.
 
 ## Pre-flight
 
@@ -18,18 +20,20 @@ Execute the repository hygiene cleanup runbook defined in `docs/governance/repos
 Follow the runbook steps in order:
 
 1. **Snapshot** — Capture open PRs and Issues (`gh pr list`, `gh issue list`) as audit evidence.
-2. **Close PRs** — Close all open PRs with a hygiene comment. Use `--delete-branch` for PRs owned by this repo.
-3. **Close Issues** — Close all open Issues with `--reason "not planned"` and a hygiene comment.
-4. **Prune local branches** — Delete every local branch except `main`.
-5. **Prune remote branches** — Delete every remote branch except `origin/main`. Skip branches from external forks.
-6. **Verification** — Confirm: local branches = `main` only, remote branches = `origin/main` only, open PRs = 0, open Issues = 0.
+2. **Classify incorporation** — For every PR/Issue, verify whether the work is already represented in `main` and capture the evidence.
+3. **Close PRs** — Close only PRs with no effective diff, PRs superseded by incorporated work, or PRs explicitly abandoned by the maintainer. Use an evidence comment. Use `--delete-branch` only for eligible repo-owned branches.
+4. **Close Issues** — Close only Issues whose acceptance criteria are incorporated into `main`, superseded by incorporated work, or explicitly abandoned by the maintainer. Use an evidence comment; reserve `--reason "not planned"` for abandoned or obsolete work.
+5. **Prune local branches** — Delete local branches except `main` only after confirming their work is merged, incorporated elsewhere, or explicitly abandoned. Preserve dirty local work before switching branches.
+6. **Prune remote branches** — Delete eligible remote branches except `origin/main`. Skip branches from external forks and non-target remotes.
+7. **Verification** — Confirm final local branches, target remote branches, open PRs, and open Issues. Open PRs/issues may remain if they are not yet incorporated into `main`.
 
 ## Safety
 
-- Ask for explicit confirmation before closing Issues (PRs are lower risk since branches are ephemeral).
-- If any open PR has CI passing and is ready to merge, flag it for merge-first before closing.
+- Ask for explicit confirmation before closing Issues, closing PRs, or deleting branches.
+- If any open PR has a non-empty diff against `main`, do not close it as incorporated. If CI is passing and the change is desired, flag it as merge-first.
+- If an Issue is only partially scaffolded or documented as future/preview work, do not close it as incorporated.
 - Keep the Step 1 snapshot available for rollback reference.
 
 ## Post-cleanup
 
-Report a summary table with counts: PRs closed, Issues closed, local branches deleted, remote branches deleted, final verification status.
+Report a summary table with counts: PRs closed with incorporation evidence, Issues closed with incorporation evidence, PRs/Issues left open, local branches deleted, remote branches deleted, and final verification status.

--- a/apps/crud-service/tests/unit/test_main_composition_and_connectors.py
+++ b/apps/crud-service/tests/unit/test_main_composition_and_connectors.py
@@ -17,23 +17,28 @@ from holiday_peak_lib.utils.event_hub import (
 )
 
 
-def _collect_route_paths(routes) -> set[str]:
-    """Collect registered route paths, recursing through router wrappers.
+def _collect_route_paths(routes, prefix: str = "") -> set[str]:
+    """Collect fully-qualified route paths, recursing through router wrappers.
 
-    Some Starlette/FastAPI versions represent ``include_router`` calls with an
-    internal ``_IncludedRouter`` object that has no ``path`` attribute and nests
-    the real routes under ``original_router``. Walking those wrappers keeps the
-    path assertions stable across dependency versions.
+    Newer Starlette/FastAPI versions represent ``include_router`` calls lazily
+    with an internal ``_IncludedRouter`` object that has no ``path`` attribute.
+    The real child routes live under ``original_router.routes`` with paths that
+    are relative to the prefix recorded on ``include_context``. Re-applying each
+    prefix while walking those wrappers keeps the path assertions stable across
+    dependency versions that either flatten or defer router inclusion.
     """
     collected: set[str] = set()
     for route in routes:
-        path = getattr(route, "path", None)
-        if isinstance(path, str):
-            collected.add(path)
         included = getattr(route, "original_router", None)
         included_routes = getattr(included, "routes", None)
         if included_routes is not None:
-            collected |= _collect_route_paths(included_routes)
+            context = getattr(route, "include_context", None)
+            sub_prefix = getattr(context, "prefix", "") or ""
+            collected |= _collect_route_paths(included_routes, prefix + sub_prefix)
+            continue
+        path = getattr(route, "path", None)
+        if isinstance(path, str):
+            collected.add(prefix + path)
     return collected
 
 

--- a/apps/crud-service/tests/unit/test_main_composition_and_connectors.py
+++ b/apps/crud-service/tests/unit/test_main_composition_and_connectors.py
@@ -17,8 +17,28 @@ from holiday_peak_lib.utils.event_hub import (
 )
 
 
+def _collect_route_paths(routes) -> set[str]:
+    """Collect registered route paths, recursing through router wrappers.
+
+    Some Starlette/FastAPI versions represent ``include_router`` calls with an
+    internal ``_IncludedRouter`` object that has no ``path`` attribute and nests
+    the real routes under ``original_router``. Walking those wrappers keeps the
+    path assertions stable across dependency versions.
+    """
+    collected: set[str] = set()
+    for route in routes:
+        path = getattr(route, "path", None)
+        if isinstance(path, str):
+            collected.add(path)
+        included = getattr(route, "original_router", None)
+        included_routes = getattr(included, "routes", None)
+        if included_routes is not None:
+            collected |= _collect_route_paths(included_routes)
+    return collected
+
+
 def test_route_groups_keep_expected_api_surfaces() -> None:
-    paths = {route.path for route in main.app.routes}
+    paths = _collect_route_paths(main.app.routes)
     expected_paths = {
         "/health",
         "/api/products",

--- a/apps/ui/src/features/search/hooks/useIntelligentSearch.ts
+++ b/apps/ui/src/features/search/hooks/useIntelligentSearch.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useSemanticSearch } from './useSemanticSearch';

--- a/apps/ui/src/features/search/hooks/useSemanticSearch.ts
+++ b/apps/ui/src/features/search/hooks/useSemanticSearch.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * React Query hook for semantic search.
  */

--- a/apps/ui/src/features/search/hooks/useStreamingSearch.ts
+++ b/apps/ui/src/features/search/hooks/useStreamingSearch.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * React hook for streaming semantic search via Server-Sent Events.
  *

--- a/docs/governance/repository-hygiene-cleanup.md
+++ b/docs/governance/repository-hygiene-cleanup.md
@@ -1,30 +1,33 @@
 # Repository Hygiene Cleanup Runbook
 
-**Version**: 1.0  
-**Last Updated**: 2026-04-12  
+**Version**: 1.1
+**Last Updated**: 2026-06-09
 **Audience**: Repository maintainers and admins
 
 ## Purpose
 
 Use this runbook to perform repository hygiene maintenance in one controlled operation:
 
-- Close stale or superseded GitHub Issues and Pull Requests.
+- Close GitHub Issues and Pull Requests only when their report or change has already been incorporated into `main`, or when there is explicit maintainer approval to mark them obsolete.
 - Prune local and remote branches so only `main` remains.
 - Document any intentionally included files that are outside the primary operation scope.
 
 ## Scope and Safety
 
-This runbook is intentionally destructive for branch history and active work queues.
+This runbook is intentionally destructive for branch history and work-queue metadata.
 
 - Execute only with explicit maintainer approval.
 - Do not run during active release windows.
 - Export a snapshot of open Issues/PRs before cleanup for traceability.
+- Do not treat open work as disposable backlog. Closing is allowed only with evidence that the work is already in `main`, superseded by an incorporated equivalent, or explicitly abandoned by the maintainer.
+- Do not delete branches that contain unmerged, unincorporated, or currently dirty local work.
 
 ## Preconditions
 
 1. Local checkout is on `main` and up to date.
 2. GitHub CLI is installed and authenticated.
 3. Operator has permission to close Issues/PRs and delete remote branches.
+4. Local working tree is clean, or any dirty work has been committed, stashed, or explicitly preserved outside the branch-pruning operation.
 
 ```bash
 git checkout main
@@ -44,35 +47,105 @@ gh issue list --state open --limit 200 --json number,title,author
 
 Store snapshots in a temporary local note or deployment log for audit evidence.
 
-## Step 2: Clean Up Pull Requests
+## Step 2: Determine Incorporation Eligibility
 
-Close all open PRs that are out-of-date, superseded, or intentionally deferred.
+Classify every open PR and Issue before changing state.
 
-PowerShell example:
+### Pull Request Eligibility
+
+An open PR is eligible for hygiene closure only when at least one condition is true:
+
+1. The PR has no effective diff against `main`.
+2. The same change was merged through another PR or commit already reachable from `main`.
+3. The maintainer explicitly says to abandon it despite an open diff.
+
+If a PR still has a meaningful diff and CI is passing, flag it as a **merge-first candidate**. Do not close it as hygiene.
+
+PowerShell evidence helper:
 
 ```powershell
-$prs = gh pr list --state open --limit 200 --json number | ConvertFrom-Json
+$prs = gh pr list --state open --limit 200 --json number,title,headRefName,mergeable,isDraft | ConvertFrom-Json
 foreach ($pr in $prs) {
-  gh pr close $pr.number --comment "Repository hygiene cleanup: closing backlog PRs before branch reset to main-only."
+  $diffFiles = @(gh pr diff $pr.number --name-only 2>$null)
+  $status = if ($diffFiles.Count -eq 0) { "incorporated-or-empty-diff" } else { "open-diff-review-or-merge-first" }
+  [pscustomobject]@{
+    Number = $pr.number
+    Title = $pr.title
+    Status = $status
+    DiffFiles = $diffFiles.Count
+    Mergeable = $pr.mergeable
+  }
 }
 ```
 
-## Step 3: Clean Up Issues
+### Issue Eligibility
 
-Close all open Issues that are no longer actionable in the current execution wave.
+An open Issue is eligible for hygiene closure only when its acceptance criteria are represented in `main` with evidence, such as:
+
+- a merged PR or commit hash that implements it;
+- files on `main` that directly implement or document the requested behavior;
+- project status documentation that states the issue is complete;
+- a superseding issue/ADR/PR that is already incorporated into `main`.
+
+References alone are not sufficient when the file text says the work is only scaffolded, preview-only, or gated for a future phase. In that case, leave the Issue open or update it with the partial-completion evidence.
+
+Evidence helper:
+
+```powershell
+$issues = gh issue list --state open --limit 200 --json number,title | ConvertFrom-Json
+foreach ($issue in $issues) {
+  $logHits = @(git log origin/main --oneline --grep="#$($issue.number)" --all-match)
+  $fileHits = @(git grep -n -F "#$($issue.number)" origin/main -- docs .github apps README.MD CHANGELOG.md 2>$null)
+  [pscustomobject]@{
+    Number = $issue.number
+    Title = $issue.title
+    CommitReferences = $logHits.Count
+    FileReferences = $fileHits.Count
+  }
+}
+```
+
+## Step 3: Clean Up Pull Requests
+
+Close only PRs classified as incorporated, superseded by incorporated work, or explicitly abandoned by the maintainer. Every closure comment must name the evidence.
 
 PowerShell example:
 
 ```powershell
-$issues = gh issue list --state open --limit 200 --json number | ConvertFrom-Json
-foreach ($issue in $issues) {
-  gh issue close $issue.number --reason "not planned" --comment "Repository hygiene cleanup: backlog reset and re-triage from main baseline."
+$eligiblePrs = @(
+  # Fill from Step 2 after evidence review.
+  # Example: @{ number = 123; evidence = "incorporated by PR #456 / commit abc123" }
+)
+
+foreach ($pr in $eligiblePrs) {
+  gh pr close $pr.number --comment "Repository hygiene cleanup: closing because this PR is already incorporated in main. Evidence: $($pr.evidence)."
 }
 ```
 
-## Step 4: Keep Only Main Branch Locally
+## Step 4: Clean Up Issues
 
-Delete every local branch except `main`.
+Close only Issues classified as incorporated into `main`, superseded by incorporated work, or explicitly abandoned by the maintainer. Prefer closing incorporated work as completed when supported by the GitHub UI/CLI. Use `--reason "not planned"` only for maintainer-approved abandoned or obsolete work, not for work that actually shipped.
+
+PowerShell example:
+
+```powershell
+$eligibleIssues = @(
+  # Fill from Step 2 after evidence review.
+  # Example: @{ number = 123; reason = "completed"; evidence = "implemented by PR #456 / commit abc123" }
+)
+
+foreach ($issue in $eligibleIssues) {
+  if ($issue.reason -eq "not planned") {
+    gh issue close $issue.number --reason "not planned" --comment "Repository hygiene cleanup: closing as obsolete. Evidence: $($issue.evidence)."
+  } else {
+    gh issue close $issue.number --comment "Repository hygiene cleanup: closing because this issue is incorporated in main. Evidence: $($issue.evidence)."
+  }
+}
+```
+
+## Step 5: Keep Only Main Branch Locally
+
+Delete local branches only after confirming they do not contain unmerged or unpreserved work. If the current branch has dirty changes, preserve them before switching branches.
 
 ```powershell
 git checkout main
@@ -82,9 +155,9 @@ foreach ($branch in $localBranches) {
 }
 ```
 
-## Step 5: Keep Only Main Branch on Origin
+## Step 6: Keep Only Main Branch on Origin
 
-Delete every remote branch except `origin/main`.
+Delete remote branches only when the associated work is already merged, incorporated elsewhere, or explicitly abandoned by the maintainer. Skip branches from external forks and non-target remotes.
 
 ```powershell
 $remoteBranches = git for-each-ref --format='%(refname:short)' refs/remotes/origin |
@@ -96,7 +169,7 @@ foreach ($remote in $remoteBranches) {
 }
 ```
 
-## Step 6: Verification
+## Step 7: Verification
 
 ```bash
 git branch
@@ -105,14 +178,14 @@ gh pr list --state open --limit 50
 gh issue list --state open --limit 50
 ```
 
-Historical target result for this cleanup procedure:
+Historical target result for a full, maintainer-approved cleanup procedure:
 
 - Local branches: only `main`
 - Remote branches: only `origin/main`
 - Open PRs: 0
 - Open Issues: 0
 
-> This document describes a one-time hygiene target state. The live repository may intentionally have open PRs and issues after subsequent feature and dependency work resumes.
+> This document describes a hygiene target state, not a command to abandon active work. The live repository may intentionally have open PRs and issues when they are not yet incorporated into `main`.
 
 ## Out-of-Scope File Inclusion Policy
 
@@ -128,4 +201,4 @@ If these conditions are not met, split the extra file updates into a separate PR
 
 - Branch deletions can be recovered only if branch refs are known.
 - Keep the snapshot from Step 1 to recreate critical branches if needed.
-- Reopen issues/PRs manually only when they remain relevant after re-triage.
+- Reopen issues/PRs manually when closure evidence was wrong, incomplete, or later superseded by new findings.

--- a/lib/src/holiday_peak_lib/agents/agent_setup.py
+++ b/lib/src/holiday_peak_lib/agents/agent_setup.py
@@ -1,0 +1,223 @@
+"""App-side adapter for the asb-v1 *setup-as-code* contract.
+
+This module is the holiday-peak-hub half of the agent-stress-benchmark (asb-v1)
+contract declared by the companion optimizer (``setup-space.yaml`` in the
+agent-stress-suite). It maps each asb-v1 search coordinate to a runtime knob and
+normalizes emitted token usage to the shape the optimizer's cost axis reads.
+
+Two directions:
+
+* **setup-in** -- :func:`resolve_agent_setup` reads the six ``HPH_*`` environment
+  variables (cluster-level defaults) and merges a per-request ``_setup_override``
+  body value (single-call shadow, no redeploy). :func:`apply_invocation_overrides`
+  injects the two coordinates that are honored at the model-call boundary today
+  (``L`` -> ``max_output_tokens``, ``E`` -> ``reasoning_effort``) into the invoker
+  kwargs consumed by :class:`holiday_peak_lib.agents.direct.DirectModelInvoker`.
+* **usage-out** -- :func:`normalize_usage` converts a model usage mapping (Agent
+  Framework ``UsageDetails`` *or* OpenAI-style) into the
+  ``prompt_tokens`` / ``completion_tokens`` / ``total_tokens`` shape the
+  optimizer's ``cost_basis='tokens'`` objective consumes from ``_telemetry.usage``.
+
+asb-v1 coordinate map (mirror of ``setup-space.yaml`` ``agent_config_key``):
+
+==========  =============================  =======================================
+Coordinate  Env var                        Runtime honor-point
+==========  =============================  =======================================
+``D``       ``HPH_MAX_AGENT_STEPS``        agent control loop (degenerate: ``/invoke``
+                                           is a single completion, no iterative loop)
+``H``       ``HPH_MEMORY_WINDOW_TURNS``    history retrieval (memory/session layer)
+``B``       ``HPH_TOOL_BREADTH_TIER``      tool assembly (agent build time)
+``L``       ``HPH_MAX_OUTPUT_TOKENS``      direct.py ``_build_chat_options`` (live)
+``topology````HPH_ORCHESTRATION_MODE``     router / graph (architectural)
+``E``       ``HPH_REASONING_EFFORT``       direct.py ``_build_chat_options`` (live;
+                                           inert on non-reasoning deployments)
+==========  =============================  =======================================
+
+``L`` and ``E`` are honored end-to-end here because their plumbing already exists
+in :mod:`holiday_peak_lib.agents.direct`. The remaining coordinates are resolved
+and observable (telemetry can record the setup a request ran under) but their
+behavioral honor-points live in the orchestration / memory / tool-assembly layers
+and are out of scope for the model-call seam.
+
+Backward compatibility: with no ``HPH_*`` env vars and no ``_setup_override``,
+:func:`resolve_agent_setup` returns an all-``None`` setup,
+:func:`apply_invocation_overrides` is a no-op, and :func:`normalize_usage`
+returns ``None`` for empty/absent usage -- the runtime behaves exactly as before
+the seam was introduced.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any
+
+# asb-v1 coordinate -> HPH_* env var (mirror of setup-space.yaml agent_config_key).
+ENV_MAX_AGENT_STEPS = "HPH_MAX_AGENT_STEPS"  # D
+ENV_MEMORY_WINDOW_TURNS = "HPH_MEMORY_WINDOW_TURNS"  # H
+ENV_TOOL_BREADTH_TIER = "HPH_TOOL_BREADTH_TIER"  # B
+ENV_MAX_OUTPUT_TOKENS = "HPH_MAX_OUTPUT_TOKENS"  # L
+ENV_ORCHESTRATION_MODE = "HPH_ORCHESTRATION_MODE"  # topology
+ENV_REASONING_EFFORT = "HPH_REASONING_EFFORT"  # E
+
+# Per-request override body key (mirror of setup-space.yaml injection.request_param.body_key).
+SETUP_OVERRIDE_KEY = "_setup_override"
+
+_VALID_TOOL_BREADTH = frozenset({"minimal", "standard", "full"})
+_VALID_ORCHESTRATION = frozenset({"single_agent", "planner_executor", "router_specialists"})
+_VALID_REASONING_EFFORT = frozenset({"minimal", "low", "medium", "high"})
+
+
+@dataclass(frozen=True, slots=True)
+class AgentSetup:
+    """Resolved asb-v1 setup coordinates for a single agent invocation.
+
+    Every field is ``None`` when neither an ``HPH_*`` env var nor a matching
+    ``_setup_override`` value is present, which preserves pre-seam behavior.
+    """
+
+    max_agent_steps: int | None = None  # D
+    memory_window_turns: int | None = None  # H
+    tool_breadth_tier: str | None = None  # B
+    max_output_tokens: int | None = None  # L
+    orchestration_mode: str | None = None  # topology
+    reasoning_effort: str | None = None  # E
+
+    def to_metadata(self) -> dict[str, Any]:
+        """Return the set coordinates only, for telemetry/observability."""
+        items = {
+            "max_agent_steps": self.max_agent_steps,
+            "memory_window_turns": self.memory_window_turns,
+            "tool_breadth_tier": self.tool_breadth_tier,
+            "max_output_tokens": self.max_output_tokens,
+            "orchestration_mode": self.orchestration_mode,
+            "reasoning_effort": self.reasoning_effort,
+        }
+        return {key: value for key, value in items.items() if value is not None}
+
+
+def _coerce_int(value: Any) -> int | None:
+    """Parse a non-negative int from env/override text; return ``None`` if invalid."""
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        parsed = int(str(value).strip())
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed >= 0 else None
+
+
+def _coerce_choice(value: Any, allowed: frozenset[str]) -> str | None:
+    """Return a lower-cased value when it is in ``allowed``; else ``None``."""
+    if value is None:
+        return None
+    candidate = str(value).strip().lower()
+    return candidate if candidate in allowed else None
+
+
+def resolve_agent_setup(overrides: dict[str, Any] | None = None) -> AgentSetup:
+    """Resolve the active :class:`AgentSetup` from env vars and per-request overrides.
+
+    Precedence: a per-request ``overrides`` value (from the ``_setup_override``
+    request body key) shadows the matching ``HPH_*`` environment variable, which
+    shadows the unset (``None``) default. Invalid values are dropped (treated as
+    unset) rather than raising, so a malformed sweep cell degrades to baseline
+    behavior instead of failing the request.
+    """
+    ov = overrides if isinstance(overrides, dict) else {}
+
+    def pick(env_key: str, ov_key: str) -> Any:
+        if ov_key in ov and ov[ov_key] is not None:
+            return ov[ov_key]
+        return os.getenv(env_key)
+
+    return AgentSetup(
+        max_agent_steps=_coerce_int(pick(ENV_MAX_AGENT_STEPS, "max_agent_steps")),
+        memory_window_turns=_coerce_int(pick(ENV_MEMORY_WINDOW_TURNS, "memory_window_turns")),
+        tool_breadth_tier=_coerce_choice(
+            pick(ENV_TOOL_BREADTH_TIER, "tool_breadth_tier"), _VALID_TOOL_BREADTH
+        ),
+        max_output_tokens=_coerce_int(pick(ENV_MAX_OUTPUT_TOKENS, "max_output_tokens")),
+        orchestration_mode=_coerce_choice(
+            pick(ENV_ORCHESTRATION_MODE, "orchestration_mode"), _VALID_ORCHESTRATION
+        ),
+        reasoning_effort=_coerce_choice(
+            pick(ENV_REASONING_EFFORT, "reasoning_effort"), _VALID_REASONING_EFFORT
+        ),
+    )
+
+
+def apply_invocation_overrides(setup: AgentSetup, kwargs: dict[str, Any]) -> None:
+    """Inject the model-call-honored coordinates (L, E) into invoker ``kwargs``.
+
+    Mutates ``kwargs`` in place. A coordinate is applied only when it is set on
+    ``setup`` *and* the caller has not already supplied that kwarg -- an explicit
+    per-call value always wins over the swept default. ``max_output_tokens`` (L)
+    and ``reasoning_effort`` (E) are consumed by
+    :meth:`holiday_peak_lib.agents.direct.DirectModelInvoker._build_chat_options`.
+    """
+    if setup.max_output_tokens is not None and kwargs.get("max_output_tokens") is None:
+        kwargs["max_output_tokens"] = setup.max_output_tokens
+    if setup.reasoning_effort is not None and kwargs.get("reasoning_effort") is None:
+        kwargs["reasoning_effort"] = setup.reasoning_effort
+
+
+def _as_token_count(value: Any) -> int | None:
+    """Coerce a token-count value to a non-negative int, or ``None`` if unusable."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    count = int(value)
+    return count if count >= 0 else None
+
+
+def normalize_usage(raw: Any) -> dict[str, int] | None:
+    """Normalize a model usage mapping to the asb-v1 ``_telemetry.usage`` shape.
+
+    The optimizer's ``cost_basis='tokens'`` objective reads ``prompt_tokens`` /
+    ``completion_tokens`` / ``total_tokens``. Microsoft Agent Framework emits
+    ``UsageDetails`` with ``input_token_count`` / ``output_token_count`` /
+    ``total_token_count``; OpenAI-style backends already use the target keys. This
+    adapter accepts either shape, derives ``total_tokens`` from prompt+completion
+    when absent, drops non-int / ``None`` values, and returns ``None`` when nothing
+    usable is present (so callers can skip emitting an empty ``usage`` block).
+    """
+    if not isinstance(raw, dict):
+        return None
+
+    prompt = _as_token_count(raw.get("prompt_tokens"))
+    if prompt is None:
+        prompt = _as_token_count(raw.get("input_token_count"))
+
+    completion = _as_token_count(raw.get("completion_tokens"))
+    if completion is None:
+        completion = _as_token_count(raw.get("output_token_count"))
+
+    total = _as_token_count(raw.get("total_tokens"))
+    if total is None:
+        total = _as_token_count(raw.get("total_token_count"))
+    if total is None and (prompt is not None or completion is not None):
+        total = (prompt or 0) + (completion or 0)
+
+    normalized: dict[str, int] = {}
+    if prompt is not None:
+        normalized["prompt_tokens"] = prompt
+    if completion is not None:
+        normalized["completion_tokens"] = completion
+    if total is not None:
+        normalized["total_tokens"] = total
+    return normalized or None
+
+
+__all__ = [
+    "AgentSetup",
+    "ENV_MAX_AGENT_STEPS",
+    "ENV_MEMORY_WINDOW_TURNS",
+    "ENV_TOOL_BREADTH_TIER",
+    "ENV_MAX_OUTPUT_TOKENS",
+    "ENV_ORCHESTRATION_MODE",
+    "ENV_REASONING_EFFORT",
+    "SETUP_OVERRIDE_KEY",
+    "apply_invocation_overrides",
+    "normalize_usage",
+    "resolve_agent_setup",
+]

--- a/lib/src/holiday_peak_lib/agents/base_agent.py
+++ b/lib/src/holiday_peak_lib/agents/base_agent.py
@@ -35,6 +35,14 @@ from holiday_peak_lib.mcp.server import FastAPIMCPServer
 from holiday_peak_lib.self_healing import SelfHealingKernel
 from pydantic import BaseModel, ConfigDict, Field
 
+# asb-v1 setup contract (setup-in / usage-out). Circular-import safe:
+# agent_setup imports only os + dataclasses, nothing from this package.
+from .agent_setup import (
+    SETUP_OVERRIDE_KEY,
+    apply_invocation_overrides,
+    normalize_usage,
+    resolve_agent_setup,
+)
 from .models import (
     ModelInvoker,
     ModelTarget,
@@ -600,6 +608,15 @@ class BaseRetailAgent(AgentTelemetryMixin, BaseAgent, ABC):
                 "logprobs_summary": existing_meta.get("logprobs_summary", logprob_summary),
             }
 
+            # asb-v1 cost axis: surface normalized token usage under
+            # ``_telemetry.usage`` so the optimizer's ``cost_basis='tokens'``
+            # objective can price each call. ``normalize_usage`` accepts both the
+            # Agent Framework ``UsageDetails`` shape and OpenAI-style keys; absent
+            # usage it returns ``None`` and the block is skipped (no empty key).
+            usage_payload = existing_meta.get("usage") or normalize_usage(result.get("usage"))
+            if usage_payload:
+                telemetry["usage"] = usage_payload
+
             result.setdefault("_target", target.name)
             result.setdefault("_model", target.model)
             result["_telemetry"] = telemetry
@@ -622,6 +639,18 @@ class BaseRetailAgent(AgentTelemetryMixin, BaseAgent, ABC):
         """
 
         payload_tools = kwargs.get("tools") or (self.tools if self.tools else None)
+
+        # asb-v1 setup contract: resolve the active setup (a per-request
+        # ``_setup_override`` shadows the ``HPH_*`` env defaults) and inject the
+        # model-call-honored coordinates (L=max_output_tokens, E=reasoning_effort)
+        # into the invoker kwargs. With no env and no override this is a no-op,
+        # so kwargs -- and therefore behavior -- are unchanged. The kwargs flow to
+        # both the primary and the SLM-upgrade ``__invoke_target`` legs below.
+        _setup_override = request.get(SETUP_OVERRIDE_KEY) if isinstance(request, dict) else None
+        _agent_setup = resolve_agent_setup(
+            _setup_override if isinstance(_setup_override, dict) else None
+        )
+        apply_invocation_overrides(_agent_setup, kwargs)
 
         # Smart session continuity: decide whether to continue an existing
         # Foundry thread or start fresh based on Redis summary + keyword overlap.

--- a/lib/src/holiday_peak_lib/agents/direct.py
+++ b/lib/src/holiday_peak_lib/agents/direct.py
@@ -50,6 +50,24 @@ from .provider_policy import normalize_messages as _normalize_messages
 _DEFAULT_DIRECT_INVOKE_TIMEOUT = float(os.getenv("AGENT_DIRECT_INVOKE_TIMEOUT_SECONDS", "55"))
 
 
+def _responses_store_enabled() -> bool:
+    """Whether the Responses API should persist server-side conversation state.
+
+    Native function-calling on reasoning models (gpt-5 family) requires the
+    prior response — including its reasoning items — to be retrievable on the
+    second turn (after ``function_result``) so the model can resume the tool
+    loop instead of restarting cold. ``store=True`` enables that echo. Defaults
+    to ``True``; set ``HOLIDAY_PEAK_RESPONSES_STORE=0`` to opt a deployment
+    back out (e.g. for a non-tool service that wants stateless turns).
+    """
+    return (os.getenv("HOLIDAY_PEAK_RESPONSES_STORE", "1") or "").lower() not in {
+        "0",
+        "false",
+        "no",
+        "off",
+    }
+
+
 ChatClientFactory = Callable[[FoundryAgentConfig], Any]
 
 
@@ -130,7 +148,7 @@ class DirectModelInvoker:
                 "client": self._client,
                 "instructions": self._instructions,
                 "name": self._agent_name,
-                "default_options": {"store": False},
+                "default_options": {"store": _responses_store_enabled()},
             }
             if self._static_tools:
                 agent_kwargs["tools"] = self._static_tools

--- a/lib/src/holiday_peak_lib/agents/registration_helpers.py
+++ b/lib/src/holiday_peak_lib/agents/registration_helpers.py
@@ -9,7 +9,9 @@ published/consumed via the ``holiday_peak_lib.messaging`` Observer helpers.
 
 from __future__ import annotations
 
+import re
 from collections.abc import Awaitable, Callable
+from inspect import isawaitable
 from typing import Any
 
 if __name__ != "__main__":  # pragma: no cover – TYPE_CHECKING alternative
@@ -53,3 +55,90 @@ def mcp_context_tool(
         return {result_key: context.model_dump() if context else None}
 
     return handler
+
+
+_TOOL_NAME_SANITIZE = re.compile(r"[^0-9a-zA-Z_]+")
+
+
+def _sanitize_tool_name(raw: str) -> str:
+    """Turn an MCP path/name into a valid function-tool identifier.
+
+    ``/inventory/health/context`` -> ``inventory_health_context``. The model
+    selects and calls tools by this name, so it must be a clean identifier:
+    no slashes, no leading digit, no doubled or trailing underscores.
+    """
+    cleaned = _TOOL_NAME_SANITIZE.sub("_", raw.strip().strip("/"))
+    cleaned = re.sub(r"_+", "_", cleaned).strip("_")
+    if not cleaned:
+        return "tool"
+    if cleaned[0].isdigit():
+        cleaned = f"t_{cleaned}"
+    return cleaned
+
+
+def build_named_function_tool(
+    name: str,
+    description: str,
+    handler: Callable[[dict[str, Any]], Awaitable[dict[str, Any]] | dict[str, Any]],
+) -> Callable[[dict[str, Any]], Awaitable[dict[str, Any]]]:
+    """Wrap an MCP handler as a named async callable for MAF function-calling.
+
+    The Microsoft Agent Framework derives a tool's function name, description,
+    and schema from the callable's ``__name__``, ``__doc__``, and signature.
+    MCP handlers are anonymous closures over a generic ``payload`` dict, so we
+    wrap each one in a freshly-named coroutine carrying the tool name and
+    description the model needs to choose and invoke it.
+    """
+
+    async def _tool(payload: dict[str, Any]) -> dict[str, Any]:
+        outcome = handler(payload)
+        if isawaitable(outcome):
+            outcome = await outcome
+        return outcome if isinstance(outcome, dict) else {"result": outcome}
+
+    _tool.__name__ = name
+    _tool.__qualname__ = name
+    _tool.__doc__ = description or f"Invoke the {name} operation."
+    return _tool
+
+
+def bind_mcp_tools_as_function_tools(
+    agent: "BaseRetailAgent",
+    mcp: Any,
+) -> dict[str, Callable[..., Any]]:
+    """Expose an agent's registered MCP tools to its model as function tools.
+
+    Reads the raw handlers from ``mcp.tool_handlers`` and descriptions from
+    ``mcp.tool_metadata``, builds one named coroutine per tool, and assigns the
+    resulting ``{name: callable}`` mapping to ``agent.tools``. The base agent
+    forwards ``agent.tools`` to the direct-model invoker on every call, so the
+    model emits real ``function_call``/``function_result`` turns instead of a
+    single tool-less completion. Returns the bound mapping (empty when the
+    agent registered no MCP tools).
+    """
+    handlers = getattr(mcp, "tool_handlers", {})
+    if not handlers:
+        return {}
+    metadata = getattr(mcp, "tool_metadata", {})
+    function_tools: dict[str, Callable[..., Any]] = {}
+    used: set[str] = set()
+    for path, handler in handlers.items():
+        details = metadata.get(path, {}) if isinstance(metadata, dict) else {}
+        raw_name = str(details.get("name") or path)
+        tool_name = _sanitize_tool_name(raw_name)
+        # De-duplicate identifiers that collide after sanitization so every
+        # tool keeps a distinct function name the model can target.
+        if tool_name in used:
+            suffix = 2
+            while f"{tool_name}_{suffix}" in used:
+                suffix += 1
+            tool_name = f"{tool_name}_{suffix}"
+        used.add(tool_name)
+        meta_block = details.get("metadata") if isinstance(details, dict) else None
+        description = ""
+        if isinstance(meta_block, dict):
+            description = str(meta_block.get("description") or meta_block.get("summary") or "")
+        function_tools[tool_name] = build_named_function_tool(tool_name, description, handler)
+    if function_tools:
+        agent.tools = function_tools
+    return function_tools

--- a/lib/src/holiday_peak_lib/app_factory.py
+++ b/lib/src/holiday_peak_lib/app_factory.py
@@ -14,6 +14,7 @@ from holiday_peak_lib.agents.prompt_loader import (
     load_service_prompt_instructions,
     prompt_instructions_sha256,
 )
+from holiday_peak_lib.agents.registration_helpers import bind_mcp_tools_as_function_tools
 from holiday_peak_lib.app_factory_components.endpoints import (
     EndpointContext,
     register_standard_endpoints,
@@ -52,6 +53,21 @@ _EVALUATION_CONFIG_FILE = "eval-config.yaml"
 def _env_truthy(name: str) -> bool:
     """Return whether an environment flag is explicitly enabled."""
     return (os.getenv(name) or "").lower() in {"1", "true", "yes", "on"}
+
+
+def _model_tool_calling_enabled() -> bool:
+    """Whether registered MCP tools are bound to the model as function tools.
+
+    Defaults to ``True`` — the flip is on for every model-backed agent. Set
+    ``HOLIDAY_PEAK_MODEL_TOOL_CALLING=0`` to roll a deployment back to the
+    tool-less completion path without rebuilding the image.
+    """
+    return (os.getenv("HOLIDAY_PEAK_MODEL_TOOL_CALLING", "1") or "").lower() not in {
+        "0",
+        "false",
+        "no",
+        "off",
+    }
 
 
 def _env_positive_float(name: str, *, default: float) -> float:
@@ -372,6 +388,23 @@ def build_service_app(
         agent.service_name = service_name
     if mcp_setup:
         mcp_setup(mcp, agent)
+        # Flip: expose the just-registered MCP tools to the model as native
+        # function-calling tools so the agent emits real function_call /
+        # function_result turns (tool_usage_rate 0 -> 1) instead of a single
+        # tool-less completion. One factory hook flips every model-backed
+        # service; the same handlers still serve the deterministic /mcp/*
+        # HTTP routes. Gated by HOLIDAY_PEAK_MODEL_TOOL_CALLING for rollback.
+        if _model_tool_calling_enabled():
+            bound_tools = bind_mcp_tools_as_function_tools(agent, mcp)
+            if bound_tools:
+                logger.info(
+                    "model_function_tools_bound",
+                    extra={
+                        "service": service_name,
+                        "tool_count": len(bound_tools),
+                        "tools": sorted(bound_tools),
+                    },
+                )
     default_instructions = load_service_prompt_instructions(service_name) or (
         _FALLBACK_INSTRUCTIONS_TEMPLATE.format(service_name=service_name)
     )

--- a/lib/src/holiday_peak_lib/app_factory_components/endpoints.py
+++ b/lib/src/holiday_peak_lib/app_factory_components/endpoints.py
@@ -326,6 +326,18 @@ def register_standard_endpoints(
         if not isinstance(request_payload, dict):
             request_payload = {"query": str(request_payload)}
 
+        # asb-v1 setup contract: a per-request ``_setup_override`` may arrive at
+        # the envelope top level (next to ``intent``/``payload``) or already inside
+        # the inner request. Surface it on the inner request so the agent's
+        # ``invoke_model`` resolver can shadow the ``HPH_*`` env defaults for this
+        # single call. Absent the key, ``request_payload`` is untouched. Mirrors
+        # the ``_stream`` injection used by ``/invoke/stream`` below.
+        _setup_override = payload.get("_setup_override")
+        if _setup_override is None and isinstance(request_payload, dict):
+            _setup_override = request_payload.get("_setup_override")
+        if isinstance(_setup_override, dict):
+            request_payload = {**request_payload, "_setup_override": _setup_override}
+
         try:
             invoke_foundry_enforced = require_foundry_readiness or strict_foundry_mode
             capability_payload = foundry_capabilities()

--- a/lib/src/holiday_peak_lib/mcp/server.py
+++ b/lib/src/holiday_peak_lib/mcp/server.py
@@ -39,12 +39,22 @@ class FastAPIMCPServer:
         self.app = app
         self.router = APIRouter()
         self._tool_metadata: dict[str, dict[str, Any]] = {}
+        # Raw (pre-route-wrapping) handlers, keyed by normalized path. Retained
+        # so the app factory can re-expose the same MCP tools to the model as
+        # native function-calling tools (the ``/mcp/*`` HTTP routes and the
+        # model tool surface share one handler implementation).
+        self._tool_handlers: dict[str, ToolHandler] = {}
         self._on_failure = on_failure
 
     @property
     def tool_metadata(self) -> dict[str, dict[str, Any]]:
         """Return metadata registered for each MCP tool path."""
         return dict(self._tool_metadata)
+
+    @property
+    def tool_handlers(self) -> dict[str, ToolHandler]:
+        """Return the raw tool handlers registered for each MCP tool path."""
+        return dict(self._tool_handlers)
 
     def add_tool(
         self,
@@ -58,6 +68,9 @@ class FastAPIMCPServer:
         metadata: dict[str, Any] | None = None,
     ) -> None:
         normalized_path = self._normalize_path(path)
+        # Keep the raw handler so the model tool surface can call the same
+        # implementation the HTTP route does, without the FastAPI wrapping.
+        self._tool_handlers[normalized_path] = handler
         validated_handler = self._wrap_handler(
             normalized_path,
             handler,

--- a/lib/tests/test_agent_setup.py
+++ b/lib/tests/test_agent_setup.py
@@ -1,0 +1,291 @@
+"""Tests for the asb-v1 setup contract adapter (:mod:`agent_setup`) and its seams.
+
+Covers the pure contract functions (resolve / apply / normalize) and the two
+runtime seams wired into :meth:`BaseRetailAgent.invoke_model`:
+
+* **setup-in** -- ``HPH_*`` env (and per-request ``_setup_override``) inject the
+  model-call coordinates ``L`` (``max_output_tokens``) and ``E``
+  (``reasoning_effort``) into the invoker kwargs.
+* **usage-out** -- emitted model usage is normalized to the
+  ``prompt_tokens`` / ``completion_tokens`` / ``total_tokens`` shape and surfaced
+  under ``_telemetry.usage`` for the optimizer's token cost axis.
+
+Backward compatibility (no env, no override) is asserted explicitly: kwargs are
+untouched and no ``usage`` block is emitted when the model returns none.
+"""
+
+import pytest
+from holiday_peak_lib.agents.agent_setup import (
+    AgentSetup,
+    apply_invocation_overrides,
+    normalize_usage,
+    resolve_agent_setup,
+)
+from holiday_peak_lib.agents.base_agent import (
+    AgentDependencies,
+    BaseRetailAgent,
+    ModelTarget,
+)
+
+_ALL_ENV_KEYS = (
+    "HPH_MAX_AGENT_STEPS",
+    "HPH_MEMORY_WINDOW_TURNS",
+    "HPH_TOOL_BREADTH_TIER",
+    "HPH_MAX_OUTPUT_TOKENS",
+    "HPH_ORCHESTRATION_MODE",
+    "HPH_REASONING_EFFORT",
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_hph_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep every test hermetic from ambient ``HPH_*`` configuration."""
+    for key in _ALL_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+
+# --------------------------------------------------------------------------- #
+# resolve_agent_setup
+# --------------------------------------------------------------------------- #
+class TestResolveAgentSetup:
+    """Env + override resolution for the six asb-v1 coordinates."""
+
+    def test_no_env_no_override_is_all_none(self) -> None:
+        setup = resolve_agent_setup()
+        assert setup == AgentSetup()
+        assert setup.to_metadata() == {}
+
+    def test_full_env_parses_every_coordinate(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HPH_MAX_AGENT_STEPS", "8")
+        monkeypatch.setenv("HPH_MEMORY_WINDOW_TURNS", "4")
+        monkeypatch.setenv("HPH_TOOL_BREADTH_TIER", "full")
+        monkeypatch.setenv("HPH_MAX_OUTPUT_TOKENS", "2048")
+        monkeypatch.setenv("HPH_ORCHESTRATION_MODE", "router_specialists")
+        monkeypatch.setenv("HPH_REASONING_EFFORT", "high")
+
+        setup = resolve_agent_setup()
+
+        assert setup == AgentSetup(
+            max_agent_steps=8,
+            memory_window_turns=4,
+            tool_breadth_tier="full",
+            max_output_tokens=2048,
+            orchestration_mode="router_specialists",
+            reasoning_effort="high",
+        )
+
+    def test_invalid_values_are_dropped_not_raised(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HPH_MAX_AGENT_STEPS", "not-an-int")
+        monkeypatch.setenv("HPH_MAX_OUTPUT_TOKENS", "-5")
+        monkeypatch.setenv("HPH_TOOL_BREADTH_TIER", "bogus")
+        monkeypatch.setenv("HPH_ORCHESTRATION_MODE", "swarm")
+        monkeypatch.setenv("HPH_REASONING_EFFORT", "ULTRA")
+
+        setup = resolve_agent_setup()
+
+        assert setup == AgentSetup()
+
+    def test_choice_values_are_case_insensitive(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HPH_REASONING_EFFORT", "High")
+        monkeypatch.setenv("HPH_TOOL_BREADTH_TIER", "  Minimal ")
+        setup = resolve_agent_setup()
+        assert setup.reasoning_effort == "high"
+        assert setup.tool_breadth_tier == "minimal"
+
+    def test_override_shadows_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HPH_MAX_OUTPUT_TOKENS", "512")
+        setup = resolve_agent_setup({"max_output_tokens": 4096})
+        assert setup.max_output_tokens == 4096
+
+    def test_override_none_falls_back_to_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HPH_MAX_OUTPUT_TOKENS", "512")
+        setup = resolve_agent_setup({"max_output_tokens": None})
+        assert setup.max_output_tokens == 512
+
+    def test_override_only_no_env(self) -> None:
+        setup = resolve_agent_setup({"reasoning_effort": "low", "max_output_tokens": 1024})
+        assert setup.reasoning_effort == "low"
+        assert setup.max_output_tokens == 1024
+        assert setup.tool_breadth_tier is None
+
+    def test_non_dict_override_is_ignored(self) -> None:
+        assert resolve_agent_setup("not-a-dict") == AgentSetup()  # type: ignore[arg-type]
+
+
+# --------------------------------------------------------------------------- #
+# apply_invocation_overrides
+# --------------------------------------------------------------------------- #
+class TestApplyInvocationOverrides:
+    """Injection of the model-call-honored coordinates into invoker kwargs."""
+
+    def test_injects_length_and_effort(self) -> None:
+        kwargs: dict = {}
+        apply_invocation_overrides(
+            AgentSetup(max_output_tokens=1024, reasoning_effort="medium"), kwargs
+        )
+        assert kwargs == {"max_output_tokens": 1024, "reasoning_effort": "medium"}
+
+    def test_caller_value_wins_over_setup(self) -> None:
+        kwargs: dict = {"max_output_tokens": 999}
+        apply_invocation_overrides(
+            AgentSetup(max_output_tokens=1024, reasoning_effort="low"), kwargs
+        )
+        assert kwargs["max_output_tokens"] == 999
+        assert kwargs["reasoning_effort"] == "low"
+
+    def test_empty_setup_is_noop(self) -> None:
+        kwargs: dict = {}
+        apply_invocation_overrides(AgentSetup(), kwargs)
+        assert kwargs == {}
+
+
+# --------------------------------------------------------------------------- #
+# normalize_usage
+# --------------------------------------------------------------------------- #
+class TestNormalizeUsage:
+    """Usage shape adaptation for the optimizer's token cost axis."""
+
+    def test_agent_framework_shape_is_remapped(self) -> None:
+        result = normalize_usage(
+            {
+                "input_token_count": 12,
+                "output_token_count": 8,
+                "total_token_count": 20,
+            }
+        )
+        assert result == {
+            "prompt_tokens": 12,
+            "completion_tokens": 8,
+            "total_tokens": 20,
+        }
+
+    def test_openai_shape_passes_through(self) -> None:
+        result = normalize_usage({"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8})
+        assert result == {
+            "prompt_tokens": 5,
+            "completion_tokens": 3,
+            "total_tokens": 8,
+        }
+
+    def test_total_is_derived_when_absent(self) -> None:
+        result = normalize_usage({"input_token_count": 5, "output_token_count": 7})
+        assert result == {
+            "prompt_tokens": 5,
+            "completion_tokens": 7,
+            "total_tokens": 12,
+        }
+
+    def test_partial_usage_keeps_only_present_keys(self) -> None:
+        assert normalize_usage({"input_token_count": 5}) == {
+            "prompt_tokens": 5,
+            "total_tokens": 5,
+        }
+
+    def test_zero_total_is_preserved(self) -> None:
+        assert normalize_usage({"total_tokens": 0}) == {"total_tokens": 0}
+
+    def test_booleans_are_rejected(self) -> None:
+        assert normalize_usage({"prompt_tokens": True}) is None
+
+    @pytest.mark.parametrize("raw", [None, {}, "string", [1, 2], 42])
+    def test_unusable_input_returns_none(self, raw: object) -> None:
+        assert normalize_usage(raw) is None
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end seams through BaseRetailAgent.invoke_model
+# --------------------------------------------------------------------------- #
+class _SetupProbeAgent(BaseRetailAgent):
+    """Minimal agent used to observe the invoke_model seams."""
+
+    async def handle(self, request: dict) -> dict:  # pragma: no cover - unused
+        return {"status": "ok", "request": request}
+
+
+def _make_capturing_agent(captured: dict, *, usage: dict | None) -> _SetupProbeAgent:
+    """Build an agent whose single SLM invoker records kwargs and emits ``usage``."""
+
+    async def invoker(**kwargs: object) -> dict:
+        captured.clear()
+        captured.update(kwargs)
+        response: dict = {"content": "ok", "response": "ok"}
+        if usage is not None:
+            response["usage"] = usage
+        return response
+
+    slm = ModelTarget(
+        name="probe-slm",
+        model="gpt-5-nano",
+        invoker=invoker,
+        temperature=0.2,
+        top_p=0.9,
+    )
+    return _SetupProbeAgent(config=AgentDependencies(slm=slm, llm=None))
+
+
+class TestInvokeModelSeams:
+    """Seam (a) usage threading and seam (b) L/E injection, end to end."""
+
+    @pytest.mark.asyncio
+    async def test_env_injects_length_and_effort_and_normalizes_usage(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HPH_MAX_OUTPUT_TOKENS", "1024")
+        monkeypatch.setenv("HPH_REASONING_EFFORT", "high")
+        captured: dict = {}
+        agent = _make_capturing_agent(
+            captured,
+            usage={
+                "input_token_count": 30,
+                "output_token_count": 12,
+                "total_token_count": 42,
+            },
+        )
+
+        result = await agent.invoke_model(
+            {"query": "hello"}, [{"role": "user", "content": "hello"}]
+        )
+
+        # Seam (b): swept length + effort reached the invoker.
+        assert captured["max_output_tokens"] == 1024
+        assert captured["reasoning_effort"] == "high"
+        # Seam (a): emitted usage normalized onto _telemetry.usage.
+        assert result["_telemetry"]["usage"] == {
+            "prompt_tokens": 30,
+            "completion_tokens": 12,
+            "total_tokens": 42,
+        }
+
+    @pytest.mark.asyncio
+    async def test_request_override_injects_without_env(self) -> None:
+        captured: dict = {}
+        agent = _make_capturing_agent(captured, usage=None)
+
+        await agent.invoke_model(
+            {
+                "query": "hello",
+                "_setup_override": {
+                    "max_output_tokens": 2048,
+                    "reasoning_effort": "low",
+                },
+            },
+            [{"role": "user", "content": "hello"}],
+        )
+
+        assert captured["max_output_tokens"] == 2048
+        assert captured["reasoning_effort"] == "low"
+
+    @pytest.mark.asyncio
+    async def test_no_env_no_override_is_backward_compatible(self) -> None:
+        captured: dict = {}
+        agent = _make_capturing_agent(captured, usage=None)
+
+        result = await agent.invoke_model(
+            {"query": "hello"}, [{"role": "user", "content": "hello"}]
+        )
+
+        # No swept coordinates leak into the invoker kwargs.
+        assert "max_output_tokens" not in captured
+        assert "reasoning_effort" not in captured
+        # No usage emitted by the model -> no usage block synthesized.
+        assert "usage" not in result["_telemetry"]

--- a/lib/tests/test_agents_hosted.py
+++ b/lib/tests/test_agents_hosted.py
@@ -447,13 +447,24 @@ def test_foundry_hosted_mode_auto_mounts_responses_with_fake_sdk(monkeypatch) ->
 
     app = create_standard_app("foundry-hosted-test", _FactoryAgent)
 
-    mounted = [route for route in app.routes if getattr(route, "path", "") == ""]
-    assert len(mounted) == 1
-    response_paths = {
-        getattr(route, "path", None) or getattr(route, "path_format", None)
-        for route in mounted[0].app.routes
-    }
-    assert "/responses" in response_paths
+    def _sub_app_paths(route: Any) -> set[str | None]:
+        sub_app = getattr(route, "app", None)
+        return {
+            getattr(sub, "path", None) or getattr(sub, "path_format", None)
+            for sub in getattr(sub_app, "routes", [])
+        }
+
+    # Locate the foundry responses mount by the paths it actually serves rather
+    # than by position. Some Starlette/FastAPI versions add an extra zero-length
+    # route entry (an internal _IncludedRouter) next to the mounted host server,
+    # so a bare ``len(mounted) == 1`` count is brittle across dependency versions.
+    responses_mounts = [
+        route
+        for route in app.routes
+        if getattr(route, "path", "") == "" and "/responses" in _sub_app_paths(route)
+    ]
+    assert len(responses_mounts) == 1
+    assert "/responses" in _sub_app_paths(responses_mounts[0])
 
 
 def test_serve_responses_honors_explicit_prefix_when_sdk_present() -> None:

--- a/lib/tests/test_app_factory.py
+++ b/lib/tests/test_app_factory.py
@@ -18,6 +18,26 @@ from holiday_peak_lib.utils import EventHubSubscription
 TEST_PROJECT_ENDPOINT = "https://test.services.ai.azure.com/api/projects/test-project"
 
 
+def _collect_route_paths(routes) -> set[str]:
+    """Collect registered route paths, recursing through router wrappers.
+
+    Some Starlette/FastAPI versions represent ``include_router`` calls with an
+    internal ``_IncludedRouter`` object that has no ``path`` attribute and nests
+    the real routes under ``original_router``. Walking those wrappers keeps the
+    path assertions stable across dependency versions.
+    """
+    collected: set[str] = set()
+    for route in routes:
+        path = getattr(route, "path", None)
+        if isinstance(path, str):
+            collected.add(path)
+        included = getattr(route, "original_router", None)
+        included_routes = getattr(included, "routes", None)
+        if included_routes is not None:
+            collected |= _collect_route_paths(included_routes)
+    return collected
+
+
 class SampleServiceAgent(BaseRetailAgent):
     """Test agent for app factory."""
 
@@ -376,7 +396,7 @@ class TestBuildServiceApp:
             cold_memory=mock_cold_memory,
         )
 
-        routes = {route.path for route in app.routes}
+        routes = _collect_route_paths(app.routes)
         retired_route = "/foundry/agents/" + "ensure"
         assert "/health" in routes
         assert "/ready" in routes

--- a/lib/tests/test_app_factory_endpoints.py
+++ b/lib/tests/test_app_factory_endpoints.py
@@ -223,23 +223,28 @@ def test_invoke_fails_closed_when_direct_model_required_and_unbound():
     assert "Direct-model targets are not ready" in response.json()["detail"]
 
 
-def _collect_route_paths(routes) -> set[str]:
-    """Collect registered route paths, recursing through router wrappers.
+def _collect_route_paths(routes, prefix: str = "") -> set[str]:
+    """Collect fully-qualified route paths, recursing through router wrappers.
 
-    Some Starlette/FastAPI versions represent ``include_router`` calls with an
-    internal ``_IncludedRouter`` object that has no ``path`` attribute and nests
-    the real routes under ``original_router``. Walking those wrappers keeps the
-    path assertions stable across dependency versions.
+    Newer Starlette/FastAPI versions represent ``include_router`` calls lazily
+    with an internal ``_IncludedRouter`` object that has no ``path`` attribute.
+    The real child routes live under ``original_router.routes`` with paths that
+    are relative to the prefix recorded on ``include_context``. Re-applying each
+    prefix while walking those wrappers keeps the path assertions stable across
+    dependency versions that either flatten or defer router inclusion.
     """
     collected: set[str] = set()
     for route in routes:
-        path = getattr(route, "path", None)
-        if isinstance(path, str):
-            collected.add(path)
         included = getattr(route, "original_router", None)
         included_routes = getattr(included, "routes", None)
         if included_routes is not None:
-            collected |= _collect_route_paths(included_routes)
+            context = getattr(route, "include_context", None)
+            sub_prefix = getattr(context, "prefix", "") or ""
+            collected |= _collect_route_paths(included_routes, prefix + sub_prefix)
+            continue
+        path = getattr(route, "path", None)
+        if isinstance(path, str):
+            collected.add(prefix + path)
     return collected
 
 

--- a/lib/tests/test_app_factory_endpoints.py
+++ b/lib/tests/test_app_factory_endpoints.py
@@ -223,9 +223,29 @@ def test_invoke_fails_closed_when_direct_model_required_and_unbound():
     assert "Direct-model targets are not ready" in response.json()["detail"]
 
 
+def _collect_route_paths(routes) -> set[str]:
+    """Collect registered route paths, recursing through router wrappers.
+
+    Some Starlette/FastAPI versions represent ``include_router`` calls with an
+    internal ``_IncludedRouter`` object that has no ``path`` attribute and nests
+    the real routes under ``original_router``. Walking those wrappers keeps the
+    path assertions stable across dependency versions.
+    """
+    collected: set[str] = set()
+    for route in routes:
+        path = getattr(route, "path", None)
+        if isinstance(path, str):
+            collected.add(path)
+        included = getattr(route, "original_router", None)
+        included_routes = getattr(included, "routes", None)
+        if included_routes is not None:
+            collected |= _collect_route_paths(included_routes)
+    return collected
+
+
 def test_retired_route_is_absent():
     app, _logger = _register_app()
-    route_paths = {route.path for route in app.routes}
+    route_paths = _collect_route_paths(app.routes)
     retired_route = "/foundry/agents/" + "ensure"
 
     assert retired_route not in route_paths

--- a/lib/tests/test_mcp_server.py
+++ b/lib/tests/test_mcp_server.py
@@ -134,3 +134,24 @@ async def test_mcp_validation_errors_emit_self_healing_failure_signal() -> None:
     assert incidents
     assert incidents[0].surface == SurfaceType.MCP
     assert incidents[0].status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_tool_handlers_exposes_raw_callables_for_model_binding() -> None:
+    app = FastAPI()
+    mcp = FastAPIMCPServer(app)
+
+    async def echo_tool(payload: dict[str, object]) -> dict[str, object]:
+        return {"echoed": payload["value"]}
+
+    mcp.add_tool("/echo", echo_tool, input_model=EchoInput, output_model=EchoOutput)
+
+    handlers = mcp.tool_handlers
+    # The server retains the raw (pre-wrapping) handler keyed by normalized path
+    # so the app factory can re-expose the same tools to the model.
+    assert "/echo" in handlers
+    assert handlers["/echo"] is echo_tool
+    # ``tool_handlers`` returns a defensive copy: mutating it must not corrupt
+    # the server's internal registry.
+    handlers["/echo"] = None
+    assert mcp.tool_handlers["/echo"] is echo_tool

--- a/lib/tests/test_registration_helpers.py
+++ b/lib/tests/test_registration_helpers.py
@@ -3,14 +3,18 @@
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-import pytest_asyncio
+from fastapi import FastAPI
 from holiday_peak_lib.agents.registration_helpers import (
+    _sanitize_tool_name,
+    bind_mcp_tools_as_function_tools,
+    build_named_function_tool,
     get_agent_adapters,
     mcp_context_tool,
 )
+from holiday_peak_lib.mcp.server import FastAPIMCPServer
 
 
 class TestGetAgentAdapters:
@@ -84,3 +88,96 @@ class TestMcpContextTool:
         await handler({"sku": 42})
 
         adapter_method.assert_awaited_once_with("42")
+
+
+class TestSanitizeToolName:
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("/inventory/health/context", "inventory_health_context"),
+            ("/inventory/health", "inventory_health"),
+            ("ecommerce-checkout-support", "ecommerce_checkout_support"),
+            ("//a//b//", "a_b"),
+            ("", "tool"),
+            ("/", "tool"),
+            ("123abc", "t_123abc"),
+        ],
+    )
+    def test_sanitizes_to_valid_identifier(self, raw: str, expected: str) -> None:
+        result = _sanitize_tool_name(raw)
+        assert result == expected
+        assert result.isidentifier()
+
+
+class TestBuildNamedFunctionTool:
+    @pytest.mark.asyncio
+    async def test_carries_name_and_doc_and_awaits_async_handler(self) -> None:
+        async def handler(payload: dict[str, Any]) -> dict[str, Any]:
+            return {"echo": payload.get("v")}
+
+        tool = build_named_function_tool("inventory_health", "Check health", handler)
+        assert tool.__name__ == "inventory_health"
+        assert tool.__doc__ == "Check health"
+        assert await tool({"v": 7}) == {"echo": 7}
+
+    @pytest.mark.asyncio
+    async def test_wraps_sync_handler_and_non_dict_result(self) -> None:
+        def handler(payload: dict[str, Any]) -> str:
+            return "ok"
+
+        tool = build_named_function_tool("t", "", handler)
+        assert tool.__doc__ == "Invoke the t operation."
+        assert await tool({}) == {"result": "ok"}
+
+
+class TestBindMcpToolsAsFunctionTools:
+    @pytest.mark.asyncio
+    async def test_binds_registered_mcp_tools_as_named_model_tools(self) -> None:
+        app = FastAPI()
+        mcp = FastAPIMCPServer(app)
+
+        async def get_context(payload: dict[str, Any]) -> dict[str, Any]:
+            return {"context": payload.get("sku")}
+
+        async def get_health(payload: dict[str, Any]) -> dict[str, Any]:
+            return {"healthy": True}
+
+        mcp.add_tool(
+            "/inventory/health/context", get_context, metadata={"description": "Fetch ctx"}
+        )
+        mcp.add_tool("/inventory/health", get_health)
+
+        agent = MagicMock()
+        bound = bind_mcp_tools_as_function_tools(agent, mcp)
+
+        assert set(bound) == {"inventory_health_context", "inventory_health"}
+        # The binder assigns the mapping to ``agent.tools`` (a dict of callables)
+        # which the base agent forwards to the direct-model invoker per call.
+        assert agent.tools == bound
+        assert bound["inventory_health_context"].__doc__ == "Fetch ctx"
+        # The named wrapper still calls the original handler implementation.
+        assert await bound["inventory_health_context"]({"sku": "A1"}) == {"context": "A1"}
+        assert await bound["inventory_health"]({}) == {"healthy": True}
+
+    def test_returns_empty_when_no_tools_registered(self) -> None:
+        app = FastAPI()
+        mcp = FastAPIMCPServer(app)
+        agent = MagicMock()
+        assert bind_mcp_tools_as_function_tools(agent, mcp) == {}
+
+    def test_deduplicates_colliding_sanitized_names(self) -> None:
+        app = FastAPI()
+        mcp = FastAPIMCPServer(app)
+
+        async def h(payload: dict[str, Any]) -> dict[str, Any]:
+            return {}
+
+        # ``/a/b`` and ``/a-b`` both sanitize to ``a_b`` — the binder must keep
+        # both as distinct function names so the model can target each.
+        mcp.add_tool("/a/b", h)
+        mcp.add_tool("/a-b", h)
+        agent = MagicMock()
+        bound = bind_mcp_tools_as_function_tools(agent, mcp)
+        assert len(bound) == 2
+        assert "a_b" in bound
+        assert any(name != "a_b" and name.startswith("a_b") for name in bound)


### PR DESCRIPTION
Merges the all-agents MAF tool-calling work plus the asb-v1 setup contract (setup-in/usage-out) for model invocation, and an evidence-based update to the repository-hygiene-cleanup runbook.

## Changes
- feat(agents): bind registered MCP tools as MAF native function tools for all model-backed agents
- feat(agents): asb-v1 setup contract - resolve per-request _setup_override, inject max_output_tokens/reasoning_effort, surface normalized token usage under _telemetry.usage
- docs(governance): make repository-hygiene-cleanup evidence-based and non-destructive

## Validation
- Rebased onto main; the stacked 991-ui base is already on main via #1143, so the diff is lib/** plus governance docs only (no UI files).
- lib test suite: 1403 passed locally.